### PR TITLE
`make test` issues

### DIFF
--- a/integration_test/test_mpi_macro_micro.py
+++ b/integration_test/test_mpi_macro_micro.py
@@ -11,8 +11,9 @@ from ymmsl import Operator
 from .conftest import skip_if_python_only
 
 
-def run_macro(instance_id: str):
+def run_macro(instance_id: str, muscle_manager: str):
     sys.argv.append('--muscle-instance={}'.format(instance_id))
+    sys.argv.append('--muscle-manager={}'.format(muscle_manager))
     macro()
 
 
@@ -61,7 +62,8 @@ def test_mpi_macro_micro(tmpdir, mmp_server_process_simple):
              str(mpi_test_micro), '--muscle-instance=micro'], env=env)
 
     # run macro model
-    macro_process = mp.Process(target=run_macro, args=('macro',))
+    macro_process = mp.Process(target=run_macro,
+                               args=('macro', mmp_server_process_simple))
     macro_process.start()
 
     # check results

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -440,7 +440,7 @@ class Instance:
         if port.operator == Operator.F_INIT:
             if (port_name, slot) in self._f_init_cache:
                 msg = self._f_init_cache[(port_name, slot)]
-                del(self._f_init_cache[(port_name, slot)])
+                del self._f_init_cache[(port_name, slot)]
                 if with_settings and msg.settings is None:
                     err_msg = ('If you use receive_with_settings()'
                                ' on an F_INIT port, then you have to'


### PR DESCRIPTION
This PR fixes two issues:
- Flake8 check (which was probably added in the 5.0.x release of flake8 from end of July) failed with `libmuscle/python/libmuscle/instance.py:443:20: E275 missing whitespace after keyword`
- `integration_test/test_mpi_macro_micro.py` did not explicitly provide connection details to the `macro` instance. This works as long as `muscle_manager` is able to bind to the default port 9000, but failed when another program has claimed that port.