### PR TITLE
Reduce delays

### DIFF
--- a/libmuscle/python/libmuscle/manager/instance_manager.py
+++ b/libmuscle/python/libmuscle/manager/instance_manager.py
@@ -41,7 +41,7 @@ class LogHandlingThread(Thread):
         """The thread's entry point."""
         while True:
             try:
-                record = self._queue.get(True, 1.0)
+                record = self._queue.get(True, 0.1)
                 logger = logging.getLogger(record.name)
                 logger.handle(record)
             except queue.Empty:

--- a/libmuscle/python/libmuscle/mcp/tcp_transport_server.py
+++ b/libmuscle/python/libmuscle/mcp/tcp_transport_server.py
@@ -71,7 +71,7 @@ class TcpTransportServer(TransportServer):
 
         self._server = TcpTransportServerImpl(('', port), TcpHandler, self)
         self._server_thread = threading.Thread(
-                target=self._server.serve_forever, daemon=True)
+                target=self._server.serve_forever, args=(0.1,), daemon=True)
         self._server_thread.start()
 
     def get_location(self) -> str:


### PR DESCRIPTION
- instance_manager.py:
  - Increase polling frequency of LogHandlingThread. Reduces the shutdown delay (in InstanceManager.shutdown), saves 0-900 ms.
- qcgpj_instantiator.py
  - Add a 10ms delay at the start of QCGPJInstantiator._main to allow the main process some time for submitting InstantiationRequests. Saves 90ms in startup duration.
  - Do not sleep in QCGPJInstantiator._main when a shutdown request is received. If all instances exited successfully we can immediately be done and save a 100ms wait.
- tcp_transport_server.py
  - Set poll_interval of SocketServer.serve_forever to 100ms. Saves 0-400 ms in shutdown duration (in instances and muscle_manager).

Combined, these changes save 190ms to ~2 seconds for a run started with `muscle_manager	--start-all`. This is most notable for short runs, like the ones in the unit tests.

`make test` duration, averaged over 5 runs (no compilation):
- Before this commit: 50.51 seconds
- After this commit: 29.51 seconds