### PR TITLE
Ensure correct timestamp type in Message

### DIFF
--- a/libmuscle/python/libmuscle/communicator.py
+++ b/libmuscle/python/libmuscle/communicator.py
@@ -49,6 +49,11 @@ class Message:
             data: An object to send or that was received.
             settings: Overlay settings to send or that were received.
         """
+        # make sure timestamp and next_timestamp are floats
+        timestamp = float(timestamp)
+        if next_timestamp is not None:
+            next_timestamp = float(next_timestamp)
+
         self.timestamp = timestamp
         self.next_timestamp = next_timestamp
         self.data = data

--- a/libmuscle/python/libmuscle/mpp_message.py
+++ b/libmuscle/python/libmuscle/mpp_message.py
@@ -171,6 +171,11 @@ class MPPMessage:
             settings_overlay: The serialised overlay settings.
             data: The serialised contents of the message.
         """
+        # make sure timestamp and next_timestamp are floats
+        timestamp = float(timestamp)
+        if next_timestamp is not None:
+            next_timestamp = float(next_timestamp)
+
         self.sender = sender
         self.receiver = receiver
         self.port_length = port_length


### PR DESCRIPTION
Fixes #118 

When an incorrect type is provided by the user for Message.timestamp or Message.next_timestamp, MsgPack will serialize an invalid MMPMessage on the wire. This leads to errors in statically typed peer actors.

Issue is fixed by explicitly converting to float in Message.__init__ and checking again in MMPMessage.__init__ (as the user may have assigned another value between creation of the Message and Instance.send).