### PR TITLE
Additional warning and error for checkpointing

### DIFF
--- a/docs/source/examples/python/interact_coupling.py
+++ b/docs/source/examples/python/interact_coupling.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional, Tuple, Dict
 
-from libmuscle import Instance, Message
+from libmuscle import Instance, Message, USES_CHECKPOINT_API
 from libmuscle.runner import run_simulation
 from ymmsl import (
         Component, Conduit, Configuration, Model, Operator, Ports, Settings)
@@ -275,7 +275,7 @@ def checkpointing_temporal_coupler() -> None:
     """
     instance = Instance({
         Operator.O_I: ['a_out', 'b_out'],
-        Operator.S: ['a_in', 'b_in']})
+        Operator.S: ['a_in', 'b_in']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         if instance.resuming():

--- a/integration_test/test_parameter_overlays.py
+++ b/integration_test/test_parameter_overlays.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from ymmsl import (Component, Conduit, Configuration, Model, Operator,
                    Settings)
 
-from libmuscle import Instance, Message
+from libmuscle import Instance, Message, DONT_APPLY_OVERLAY
 from libmuscle.runner import run_simulation
 
 
@@ -49,9 +49,10 @@ def explicit_relay():
     having MUSCLE handle them. This just passes all information on.
     """
     instance = Instance({
-            Operator.F_INIT: ['in[]'], Operator.O_F: ['out[]']})
+            Operator.F_INIT: ['in[]'], Operator.O_F: ['out[]']},
+            DONT_APPLY_OVERLAY)
 
-    while instance.reuse_instance(False):
+    while instance.reuse_instance():
         # f_init
         assert instance.get_setting('test2', 'float') == 13.3
         assert instance.get_port_length('in') == instance.get_port_length(

--- a/integration_test/test_snapshot_complex_coupling.py
+++ b/integration_test/test_snapshot_complex_coupling.py
@@ -2,9 +2,10 @@ import random
 import time
 
 import pytest
-from ymmsl import KeepsStateForNextUse, Operator, load, dump
+from ymmsl import Operator, load, dump
 
-from libmuscle import Instance, Message
+from libmuscle import (
+        Instance, Message, HAS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -18,7 +19,7 @@ def cache_component(max_channels=2):
              Operator.O_I: [f'sub_out{i+1}' for i in range(max_channels)],
              Operator.S: [f'sub_in{i+1}' for i in range(max_channels)],
              Operator.O_F: [f'out{i+1}' for i in range(max_channels)]}
-    instance = Instance(ports)
+    instance = Instance(ports, USES_CHECKPOINT_API)
 
     cache_t = float('-inf')
     cache_data = []
@@ -57,7 +58,7 @@ def cache_component(max_channels=2):
 def echo_component(max_channels=2):
     ports = {Operator.F_INIT: [f'in{i+1}' for i in range(max_channels)],
              Operator.O_F: [f'out{i+1}' for i in range(max_channels)]}
-    instance = Instance(ports, keeps_state_for_next_use=KeepsStateForNextUse.NO)
+    instance = Instance(ports, HAS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         for p_in, p_out in zip(ports[Operator.F_INIT], ports[Operator.O_F]):
@@ -69,7 +70,7 @@ def main_component():
     instance = Instance({
             Operator.O_I: ['state_out'],
             Operator.S: ['Ai', 'Bi', 'Ci', 'Di'],
-            Operator.O_F: ['o_f']})
+            Operator.O_F: ['o_f']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')

--- a/integration_test/test_snapshot_complex_coupling.py
+++ b/integration_test/test_snapshot_complex_coupling.py
@@ -5,7 +5,7 @@ import pytest
 from ymmsl import Operator, load, dump
 
 from libmuscle import (
-        Instance, Message, HAS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
+        Instance, Message, KEEPS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -58,7 +58,7 @@ def cache_component(max_channels=2):
 def echo_component(max_channels=2):
     ports = {Operator.F_INIT: [f'in{i+1}' for i in range(max_channels)],
              Operator.O_F: [f'out{i+1}' for i in range(max_channels)]}
-    instance = Instance(ports, HAS_NO_STATE_FOR_NEXT_USE)
+    instance = Instance(ports, KEEPS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         for p_in, p_out in zip(ports[Operator.F_INIT], ports[Operator.O_F]):

--- a/integration_test/test_snapshot_dispatch.py
+++ b/integration_test/test_snapshot_dispatch.py
@@ -2,7 +2,7 @@ import pytest
 from ymmsl import Operator, load, dump
 
 from libmuscle import (
-        Instance, Message, HAS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
+        Instance, Message, KEEPS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -48,7 +48,7 @@ def stateless_component():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
             Operator.O_F: ['o_f']},
-            HAS_NO_STATE_FOR_NEXT_USE)
+            KEEPS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')

--- a/integration_test/test_snapshot_dispatch.py
+++ b/integration_test/test_snapshot_dispatch.py
@@ -1,7 +1,8 @@
 import pytest
-from ymmsl import KeepsStateForNextUse, Operator, load, dump
+from ymmsl import Operator, load, dump
 
-from libmuscle import Instance, Message
+from libmuscle import (
+        Instance, Message, HAS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -13,7 +14,7 @@ _LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
 def component():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
-            Operator.O_F: ['o_f']})
+            Operator.O_F: ['o_f']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')
@@ -47,7 +48,7 @@ def stateless_component():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
             Operator.O_F: ['o_f']},
-            stateful=KeepsStateForNextUse.NO)
+            HAS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')

--- a/integration_test/test_snapshot_interact.py
+++ b/integration_test/test_snapshot_interact.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from ymmsl import Operator, load, dump
 
-from libmuscle import Instance, Message
+from libmuscle import Instance, Message, USES_CHECKPOINT_API
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -21,7 +21,7 @@ _LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
 def component():
     instance = Instance({
             Operator.O_I: ['o_i'],
-            Operator.S: ['s']})
+            Operator.S: ['s']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         t0 = instance.get_setting('t0', 'float')

--- a/integration_test/test_snapshot_macro_micro.py
+++ b/integration_test/test_snapshot_macro_micro.py
@@ -1,7 +1,8 @@
 import pytest
-from ymmsl import KeepsStateForNextUse, Operator, load, dump
+from ymmsl import Operator, load, dump
 
-from libmuscle import Instance, Message
+from libmuscle import (
+        Instance, Message, HAS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -13,7 +14,7 @@ _LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
 def macro():
     instance = Instance({
             Operator.O_I: ['o_i'],
-            Operator.S: ['s']})
+            Operator.S: ['s']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')
@@ -52,7 +53,7 @@ def macro():
 def macro_vector():
     instance = Instance({
             Operator.O_I: ['o_i[]'],
-            Operator.S: ['s[]']})
+            Operator.S: ['s[]']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')
@@ -93,7 +94,7 @@ def macro_vector():
 def micro():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
-            Operator.O_F: ['o_f']})
+            Operator.O_F: ['o_f']}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')
@@ -127,7 +128,7 @@ def stateless_micro():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
             Operator.O_F: ['o_f']},
-            keeps_state_for_next_use=KeepsStateForNextUse.NO)
+            HAS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')
@@ -149,7 +150,7 @@ def data_transformer():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
             Operator.O_F: ['o_f']},
-            keeps_state_for_next_use=KeepsStateForNextUse.NO)
+            HAS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         msg = instance.receive('f_i')

--- a/integration_test/test_snapshot_macro_micro.py
+++ b/integration_test/test_snapshot_macro_micro.py
@@ -2,7 +2,7 @@ import pytest
 from ymmsl import Operator, load, dump
 
 from libmuscle import (
-        Instance, Message, HAS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
+        Instance, Message, KEEPS_NO_STATE_FOR_NEXT_USE, USES_CHECKPOINT_API)
 from libmuscle.manager.run_dir import RunDir
 
 from .conftest import run_manager_with_actors, ls_snapshots
@@ -128,7 +128,7 @@ def stateless_micro():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
             Operator.O_F: ['o_f']},
-            HAS_NO_STATE_FOR_NEXT_USE)
+            KEEPS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         dt = instance.get_setting('dt', 'float')
@@ -150,7 +150,7 @@ def data_transformer():
     instance = Instance({
             Operator.F_INIT: ['f_i'],
             Operator.O_F: ['o_f']},
-            HAS_NO_STATE_FOR_NEXT_USE)
+            KEEPS_NO_STATE_FOR_NEXT_USE)
 
     while instance.reuse_instance():
         msg = instance.receive('f_i')

--- a/libmuscle/python/libmuscle/__init__.py
+++ b/libmuscle/python/libmuscle/__init__.py
@@ -1,6 +1,6 @@
 from libmuscle.communicator import Message
 from libmuscle.grid import Grid
-from libmuscle.instance import Instance
+from libmuscle.instance import Instance, InstanceFlags
 from libmuscle.version import __version__
 from libmuscle import runner
 
@@ -8,4 +8,11 @@ from libmuscle import runner
 # Note that libmuscle.version above is created by the build system; it's okay
 # that it's not present.
 
-__all__ = ['__version__', 'Grid', 'Instance', 'Message', 'runner']
+__all__ = [
+        '__version__', 'Grid', 'Instance', 'InstanceFlags', 'Message', 'runner']
+
+
+# export InstanceFlag members to the module namespace
+# adapted from https://github.com/python/cpython/blob/3.10/Lib/re.py#L179
+globals().update(InstanceFlags.__members__)
+__all__.extend(InstanceFlags.__members__)

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -1,13 +1,15 @@
 from copy import copy
+from enum import Flag, auto
 import logging
 import os
 import sys
 from typing import cast, Dict, List, Optional, Tuple, overload
 # TODO: import from typing module when dropping support for python 3.7
 from typing_extensions import Literal
+import warnings
 
 from ymmsl import (Identifier, Operator, SettingValue, Port, Reference,
-                   Settings, KeepsStateForNextUse)
+                   Settings)
 
 from libmuscle.api_guard import APIGuard
 from libmuscle.checkpoint_triggers import TriggerManager
@@ -29,6 +31,62 @@ _logger = logging.getLogger(__name__)
 _FInitCacheType = Dict[Tuple[str, Optional[int]], Message]
 
 
+class InstanceFlags(Flag):
+    """Enumeration of properties that an instance may have.
+
+    You may combine multiple flags using the bitwise OR operator `|`. For
+    example:
+
+    .. code-block:: python
+
+        from libmuscle import (
+                Instance, USES_CHECKPOINT_API, KEEPS_STATE_FOR_NEXT_USE)
+
+        ports = ...
+        flags = USES_CHECKPOINT_API | KEEPS_STATE_FOR_NEXT_USE
+        instance = Instance(ports, flags)
+    """
+
+    DONT_APPLY_OVERLAY = auto()
+    """Do not apply the received settings overlay during prereceive of F_INIT
+    messages. If you're going to use :meth:`Instance.receive_with_settings` on
+    your F_INIT ports, you need to set this flag when creating an
+    :class:`Instance`.
+
+    If you don't know what that means, do not specify this flag and everything
+    will be fine. If it turns out that you did need to specify the flag, MUSCLE3
+    will tell you about it in an error message and you can add it still.
+    """
+
+    USES_CHECKPOINT_API = auto()
+    """Indicate that this instance supports checkpointing.
+
+    You may not use any checkpointing API calls when this flag is not supplied.
+    """
+
+    HAS_NO_STATE_FOR_NEXT_USE = auto()
+    """Indicate this instance does not carry state between iterations of the
+    reuse loop.
+
+    This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
+
+    If neither :attr:`HAS_NO_STATE_FOR_NEXT_USE` and
+    :attr:`STATE_FOR_NEXT_USE_NOT_REQUIRED` are supplied, this corresponds to
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+    """
+
+    STATE_FOR_NEXT_USE_NOT_REQUIRED = auto()
+    """Indicate this instance carries state between iterations of the
+    reuse loop, however this state is not required for restarting.
+
+    This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
+
+    If neither :attr:`HAS_NO_STATE_FOR_NEXT_USE` and
+    :attr:`STATE_FOR_NEXT_USE_NOT_REQUIRED` are supplied, this corresponds to
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+    """
+
+
 class Instance:
     """Represents a component instance in a MUSCLE3 simulation.
 
@@ -37,21 +95,19 @@ class Instance:
     """
     def __init__(
             self, ports: Optional[Dict[Operator, List[str]]] = None,
-            keeps_state_for_next_use: KeepsStateForNextUse
-            = KeepsStateForNextUse.NECESSARY) -> None:
+            flags: InstanceFlags = InstanceFlags(0)) -> None:
         """Create an Instance.
 
         Args:
             ports: A list of port names for each
                 :external:py:class:`~ymmsl.Operator` of this component.
-            keeps_state_for_next_use: Indicate whether this instance carries
-                state between iterations of the reuse loop. See
-                :external:py:class:`ymmsl.KeepsStateForNextUse` for a
-                description of the options.
+            flags: Indicate properties for this instance. See
+                :py:class:`InstanceFlags` for a detailed description of possible
+                flags.
         """
         self.__is_shut_down = False
 
-        self._keeps_state = KeepsStateForNextUse(keeps_state_for_next_use)
+        self._flags = InstanceFlags(flags)
 
         # Note that these are accessed by Muscle3, but otherwise private.
         self._name, self._index = self.__make_full_name()
@@ -63,7 +119,8 @@ class Instance:
 
         self.__set_up_logging()
 
-        self._api_guard = APIGuard()
+        self._api_guard = APIGuard(
+                InstanceFlags.USES_CHECKPOINT_API in self._flags)
         """Checks that the user uses the API correctly."""
 
         self._profiler = Profiler(self._instance_name(), self.__manager)
@@ -126,7 +183,7 @@ class Instance:
         self._set_local_log_level()
         self._set_remote_log_level()
 
-    def reuse_instance(self, apply_overlay: bool = True) -> bool:
+    def reuse_instance(self, apply_overlay: Optional[bool] = None) -> bool:
         """Decide whether to run this instance again.
 
         In a multiscale simulation, instances get reused all the time.
@@ -148,16 +205,6 @@ class Instance:
         This method must be called at the beginning of the reuse loop,
         i.e. before the F_INIT operator, and its return value should
         decide whether to enter that loop again.
-
-        Args:
-            apply_overlay: Whether to apply the received settings
-                overlay or to save it. If you're going to use
-                :meth:`receive_with_settings` on your F_INIT ports,
-                set this to False. If you don't know what that means,
-                just call :meth:`reuse_instance()` without specifying this
-                and everything will be fine. If it turns out that you
-                did need to specify False, MUSCLE3 will tell you about
-                it in an error message and you can add it still.
 
         Raises:
             RuntimeError:
@@ -183,8 +230,9 @@ class Instance:
 
         do_implicit_checkpoint = (
                 not self._first_run and
-                not self._api_guard.uses_checkpointing() and
-                self._keeps_state is not KeepsStateForNextUse.NECESSARY)
+                InstanceFlags.USES_CHECKPOINT_API not in self._flags and
+                (InstanceFlags.STATE_FOR_NEXT_USE_NOT_REQUIRED in self._flags or
+                 InstanceFlags.HAS_NO_STATE_FOR_NEXT_USE in self._flags))
 
         if do_implicit_checkpoint:
             if self._trigger_manager.should_save_final_snapshot(
@@ -567,7 +615,7 @@ class Instance:
         self._save_snapshot(message, False)
         self._api_guard.save_snapshot_done()
 
-    def should_save_final_snapshot(self, *, apply_overlay: bool = True) -> bool:
+    def should_save_final_snapshot(self) -> bool:
         """Check if a snapshot should be saved at the end of the reuse loop.
 
         This method checks if a snapshot should be saved now.
@@ -601,7 +649,7 @@ class Instance:
         """
         self._api_guard.verify_should_save_final_snapshot()
 
-        self._do_reuse = self._decide_reuse_instance(apply_overlay)
+        self._do_reuse = self._decide_reuse_instance()
         result = self._trigger_manager.should_save_final_snapshot(
                 self._do_reuse, self.__f_init_max_timestamp)
 
@@ -718,7 +766,8 @@ class Instance:
                                                      self.__manager)
             logging.getLogger().addHandler(self._mmp_handler)
 
-    def _decide_reuse_instance(self, apply_overlay: bool) -> bool:
+    def _decide_reuse_instance(
+            self, apply_overlay: Optional[bool] = None) -> bool:
         """Decide whether and how to reuse the instance.
 
         This sets self._first_run, self._do_resume and self._do_init, and
@@ -801,10 +850,11 @@ class Instance:
                 if with_settings and msg.settings is None:
                     err_msg = ('If you use receive_with_settings()'
                                ' on an F_INIT port, then you have to'
-                               ' pass apply_overlay=False to reuse_instance() '
-                               ' and should_save_final_snapshot(),'
-                               ' if applicable, otherwise the settings will'
-                               ' already have been applied by MUSCLE.')
+                               ' set the flag'
+                               ' :attr:`InstanceFlag.DONT_APPLY_OVERLAY` when'
+                               ' creating the :class:`Instance`, otherwise the'
+                               ' settings will already have been applied by'
+                               ' MUSCLE.')
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
             else:
@@ -922,7 +972,7 @@ class Instance:
                  for port in ports.get(Operator.F_INIT, [])])
         return f_init_connected or self._communicator.settings_in_connected()
 
-    def _pre_receive(self, apply_overlay: bool) -> bool:
+    def _pre_receive(self, apply_overlay: Optional[bool]) -> bool:
         """Pre-receives on all ports.
 
         This includes muscle_settings_in and all user-defined ports.
@@ -965,12 +1015,20 @@ class Instance:
         self._trigger_manager.harmonise_wall_time(saved_until)
         return True
 
-    def __pre_receive_f_init(self, apply_overlay: bool) -> None:
+    def __pre_receive_f_init(self, apply_overlay: Optional[bool]) -> None:
         """Receives on all ports connected to F_INIT.
 
         This receives all incoming messages on F_INIT and stores them
         in self._f_init_cache.
         """
+        if apply_overlay is not None:
+            warnings.warn(
+                    'Explicitly providing apply_overlay in reuse_instance is'
+                    ' deprecated. Use InstanceFlags.DONT_APPLY_OVERLAY when'
+                    ' creating the instance instead.', DeprecationWarning)
+        else:
+            apply_overlay = InstanceFlags.DONT_APPLY_OVERLAY not in self._flags
+
         def pre_receive(port_name: str, slot: Optional[int]) -> None:
             msg, saved_until = self._communicator.receive_message(
                     port_name, slot)

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -64,25 +64,25 @@ class InstanceFlags(Flag):
     You may not use any checkpointing API calls when this flag is not supplied.
     """
 
-    HAS_NO_STATE_FOR_NEXT_USE = auto()
+    KEEPS_NO_STATE_FOR_NEXT_USE = auto()
     """Indicate this instance does not carry state between iterations of the
     reuse loop.
 
     This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
 
-    If neither :attr:`HAS_NO_STATE_FOR_NEXT_USE` and
-    :attr:`STATE_FOR_NEXT_USE_NOT_REQUIRED` are supplied, this corresponds to
+    If neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` and
+    :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are supplied, this corresponds to
     :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
     """
 
-    STATE_FOR_NEXT_USE_NOT_REQUIRED = auto()
+    STATE_NOT_REQUIRED_FOR_NEXT_USE = auto()
     """Indicate this instance carries state between iterations of the
     reuse loop, however this state is not required for restarting.
 
     This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
 
-    If neither :attr:`HAS_NO_STATE_FOR_NEXT_USE` and
-    :attr:`STATE_FOR_NEXT_USE_NOT_REQUIRED` are supplied, this corresponds to
+    If neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` and
+    :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are supplied, this corresponds to
     :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
     """
 
@@ -231,8 +231,8 @@ class Instance:
         do_implicit_checkpoint = (
                 not self._first_run and
                 InstanceFlags.USES_CHECKPOINT_API not in self._flags and
-                (InstanceFlags.STATE_FOR_NEXT_USE_NOT_REQUIRED in self._flags or
-                 InstanceFlags.HAS_NO_STATE_FOR_NEXT_USE in self._flags))
+                (InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE in self._flags or
+                 InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE in self._flags))
 
         if do_implicit_checkpoint:
             if self._trigger_manager.should_save_final_snapshot(

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -87,6 +87,12 @@ class InstanceFlags(Flag):
     """
 
 
+_CHECKPOINT_SUPPORT_MASK = (
+        InstanceFlags.USES_CHECKPOINT_API |
+        InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE |
+        InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE)
+
+
 class Instance:
     """Represents a component instance in a MUSCLE3 simulation.
 
@@ -177,6 +183,13 @@ class Instance:
 
         elapsed_time, checkpoints = checkpoint_info[0:2]
         self._trigger_manager.set_checkpoint_info(elapsed_time, checkpoints)
+
+        if checkpoints and not (self._flags & _CHECKPOINT_SUPPORT_MASK):
+            raise RuntimeError(
+                    'The workflow has requested checkpoints, but this instance'
+                    ' does not support checkpointing. Please consult the'
+                    ' MUSCLE3 checkpointing documentation how to add'
+                    ' checkpointing support.')
 
         resume_snapshot, snapshot_dir = checkpoint_info[2:4]
         saved_at = self._snapshot_manager.prepare_resume(

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -40,10 +40,10 @@ class InstanceFlags(Flag):
     .. code-block:: python
 
         from libmuscle import (
-                Instance, USES_CHECKPOINT_API, KEEPS_STATE_FOR_NEXT_USE)
+                Instance, USES_CHECKPOINT_API, DONT_APPLY_OVERLAY)
 
         ports = ...
-        flags = USES_CHECKPOINT_API | KEEPS_STATE_FOR_NEXT_USE
+        flags = USES_CHECKPOINT_API | DONT_APPLY_OVERLAY
         instance = Instance(ports, flags)
     """
 

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -108,6 +108,11 @@ class Instance:
         self.__is_shut_down = False
 
         self._flags = InstanceFlags(flags)
+        if InstanceFlags.USES_CHECKPOINT_API in self._flags:
+            warnings.warn(
+                    'Checkpointing in MUSCLE3 version 0.6.0 is still in'
+                    ' development: the API may change in a future MUSCLE3'
+                    ' release.')
 
         # Note that these are accessed by Muscle3, but otherwise private.
         self._name, self._index = self.__make_full_name()

--- a/libmuscle/python/libmuscle/test/conftest.py
+++ b/libmuscle/python/libmuscle/test/conftest.py
@@ -26,4 +26,4 @@ def message2() -> Message:
 
 @pytest.fixture
 def guard() -> APIGuard:
-    return APIGuard()
+    return APIGuard(True)

--- a/libmuscle/python/libmuscle/test/test_api_guard.py
+++ b/libmuscle/python/libmuscle/test/test_api_guard.py
@@ -5,20 +5,17 @@ import pytest
 from libmuscle.api_guard import APIGuard
 
 
-def test_no_checkpointing_support(guard):
+def test_no_checkpointing_support():
+    guard = APIGuard(False)
     for _ in range(3):
         guard.verify_reuse_instance()
         guard.reuse_instance_done(True)
 
-    assert not guard.uses_checkpointing()
-
     guard.verify_reuse_instance()
     guard.reuse_instance_done(False)
 
-    assert not guard.uses_checkpointing()
 
-
-def test_final_snapshot_only(guard):
+def test_final_snapshot_only(guard: APIGuard):
     for i in range(4):
         guard.verify_reuse_instance()
         guard.reuse_instance_done(True)
@@ -48,7 +45,7 @@ def test_final_snapshot_only(guard):
     guard.reuse_instance_done(False)
 
 
-def test_full_checkpointing(guard):
+def test_full_checkpointing(guard: APIGuard):
     for i in range(4):
         guard.verify_reuse_instance()
         guard.reuse_instance_done(True)
@@ -133,20 +130,19 @@ def test_missing_step(guard, fun):
     check_all_raise_except(guard, {fun})
 
 
-def test_missing_resuming(guard):
+def test_missing_resuming(guard: APIGuard):
     run_until_before(guard, APIGuard.verify_resuming)
-    check_all_raise_except(guard, {
-        APIGuard.verify_resuming, APIGuard.verify_reuse_instance})
+    check_all_raise_except(guard, {APIGuard.verify_resuming})
 
 
-def test_missing_should_save_final(guard):
+def test_missing_should_save_final(guard: APIGuard):
     run_until_before(guard, APIGuard.verify_should_save_final_snapshot)
     check_all_raise_except(guard, {
         APIGuard.verify_should_save_snapshot,
         APIGuard.verify_should_save_final_snapshot})
 
 
-def test_double_should_save(guard):
+def test_double_should_save(guard: APIGuard):
     run_until_before(guard, APIGuard.verify_should_save_snapshot)
     guard.verify_should_save_snapshot()
     guard.should_save_snapshot_done(True)


### PR DESCRIPTION
Note: this PR builds on top of #152 

- Add a UserWarning for preliminary checkpoint API support
- Validate that an instance implements checkpointing (possibly implicit) when the workflow requests checkpoints (raise RuntimeError otherwise)