### PR TITLE
Prototype to fix #182

### DIFF
--- a/libmuscle/cpp/src/libmuscle/instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/instance.cpp
@@ -919,6 +919,11 @@ Instance::Instance(
                 , communicator, root
 #endif
                 ))
+#ifdef MUSCLE_ENABLE_MPI
+    , has_mpi_(true)
+#else
+    , has_mpi_(false)
+#endif
 {}
 
 Instance::~Instance() = default;
@@ -1045,10 +1050,24 @@ Message Instance::receive_with_settings(
 }
 
 Instance::Impl const * Instance::impl_() const {
+# ifdef MUSCLE_ENABLE_MPI
+    if (! has_mpi_)
+        throw std::runtime_error("Object constructed without MPI");
+# else
+    if (has_mpi_)
+        throw std::runtime_error("Object constructed with MPI");
+# endif
     return pimpl_.get();
 }
 
 Instance::Impl * Instance::impl_() {
+# ifdef MUSCLE_ENABLE_MPI
+    if (! has_mpi_)
+        throw std::runtime_error("Object constructed without MPI");
+# else
+    if (has_mpi_)
+        throw std::runtime_error("Object constructed with MPI");
+# endif
     return pimpl_.get();
 }
 

--- a/libmuscle/cpp/src/libmuscle/instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/instance.cpp
@@ -903,6 +903,11 @@ Instance::Instance(
                 , communicator, root
 #endif
                 ))
+#ifdef MUSCLE_ENABLE_MPI
+    , has_mpi_(true)
+#else
+    , has_mpi_(false)
+#endif
 {}
 
 Instance::Instance(

--- a/libmuscle/cpp/src/libmuscle/instance.hpp
+++ b/libmuscle/cpp/src/libmuscle/instance.hpp
@@ -523,6 +523,7 @@ class Instance {
     private:
         class Impl;
         std::unique_ptr<Impl> pimpl_;
+        bool has_mpi_;
 
         Impl const * impl_() const;
         Impl * impl_();


### PR DESCRIPTION
@LourensVeen I couldn't mimick the MPI constructor in the non-MPI version of libmuscle without importing `mpi.h`, so I tried a different approach.

Please check if you agree, then I'll finish the PR by adding proper error messages.