### PR TITLE
Feature/cpp instance flags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,29 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
+0.7.0
+*****
+
+Backwards Incompatible changes
+------------------------------
+
+* `Instance.reuse_instance` no longer accepts `apply_overlay` argument. Use
+  `InstanceFlags.DONT_APPLY_OVERLAY` when creating the instance instead.
+* `LIBMUSCLE_Instance_create` signature has changed, this might lead to errors like:
+
+  .. code-block:: text
+
+       30 |     instance = LIBMUSCLE_Instance_create(ports, MPI_COMM_WORLD, root_rank)
+          |               1
+    Error: Type mismatch in argument ‘flags’ at (1); passed INTEGER(4) to TYPE(libmuscle_instanceflags)
+
+  You may provide an explicit `InstanceFlags()` argument, or use named arguments:
+
+  .. code-block:: fortran
+
+    instance = LIBMUSCLE_Instance_create(ports, LIBMUSCLE_InstanceFlags(), MPI_COMM_WORLD, root_rank)
+    instance = LIBMUSCLE_Instance_create(ports, communicator=MPI_COMM_WORLD, root=root_rank)
+
 0.6.0
 *****
 

--- a/docs/source/cpp_api.rst
+++ b/docs/source/cpp_api.rst
@@ -14,6 +14,7 @@ Namespace libmuscle
 .. doxygenclass:: libmuscle::impl::Data
 .. doxygenclass:: libmuscle::impl::DataConstRef
 .. doxygenclass:: libmuscle::impl::Instance
+.. doxygenenum:: libmuscle::impl::InstanceFlags
 .. doxygenclass:: libmuscle::impl::Message
 .. doxygentypedef:: libmuscle::impl::PortsDescription
 

--- a/docs/source/examples/cpp/load_balancer.cpp
+++ b/docs/source/examples/cpp/load_balancer.cpp
@@ -8,6 +8,7 @@
 
 using libmuscle::Data;
 using libmuscle::Instance;
+using libmuscle::InstanceFlags;
 using libmuscle::Message;
 using ymmsl::Operator;
 using ymmsl::Settings;
@@ -27,9 +28,10 @@ void load_balancer(int argc, char * argv[]) {
             {Operator::F_INIT, {"front_in[]"}},
             {Operator::O_I, {"back_out[]"}},
             {Operator::S, {"back_in[]"}},
-            {Operator::O_F, {"front_out[]"}}});
+            {Operator::O_F, {"front_out[]"}}},
+            InstanceFlags::DONT_APPLY_OVERLAY);
 
-    while (instance.reuse_instance(false)) {
+    while (instance.reuse_instance()) {
         // F_INIT
         int started = 0;
         int done = 0;

--- a/docs/source/examples/fortran/load_balancer.f90
+++ b/docs/source/examples/fortran/load_balancer.f90
@@ -26,10 +26,10 @@ program load_balancer
     call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_O_I, 'back_out[]')
     call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_S, 'back_in[]')
     call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_O_F, 'front_out[]')
-    instance = LIBMUSCLE_Instance_create(ports)
+    instance = LIBMUSCLE_Instance_create(ports, LIBMUSCLE_InstanceFlags(DONT_APPLY_OVERLAY=.true.))
     call LIBMUSCLE_PortsDescription_free(ports)
 
-    do while (LIBMUSCLE_Instance_reuse_instance(instance, .false.))
+    do while (LIBMUSCLE_Instance_reuse_instance(instance))
         ! F_INIT
         started = 0
         done = 0

--- a/docs/source/examples/fortran/reaction_mpi.f90
+++ b/docs/source/examples/fortran/reaction_mpi.f90
@@ -27,7 +27,7 @@ program reaction_mpi
     ports = LIBMUSCLE_PortsDescription_create()
     call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_F_INIT, 'initial_state')
     call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_O_F, 'final_state')
-    instance = LIBMUSCLE_Instance_create(ports, MPI_COMM_WORLD, root_rank)
+    instance = LIBMUSCLE_Instance_create(ports, communicator=MPI_COMM_WORLD, root=root_rank)
     call LIBMUSCLE_PortsDescription_free(ports)
 
     do while (LIBMUSCLE_Instance_reuse_instance(instance))

--- a/docs/source/examples/python/reaction_diffusion_qmc.py
+++ b/docs/source/examples/python/reaction_diffusion_qmc.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import sobol_seq
 
-from libmuscle import Grid, Instance, Message
+from libmuscle import Grid, Instance, Message, DONT_APPLY_OVERLAY
 from libmuscle.runner import run_simulation
 from ymmsl import (
         Component, Conduit, Configuration, Model, Operator, Ports, Settings)
@@ -130,9 +130,10 @@ def load_balancer() -> None:
             Operator.F_INIT: ['front_in[]'],
             Operator.O_I: ['back_out[]'],
             Operator.S: ['back_in[]'],
-            Operator.O_F: ['front_out[]']})
+            Operator.O_F: ['front_out[]']},
+            DONT_APPLY_OVERLAY)
 
-    while instance.reuse_instance(False):
+    while instance.reuse_instance():
         # F_INIT
         started = 0     # number started and index of next to start
         done = 0        # number done and index of next to return

--- a/docs/source/fortran_api.rst
+++ b/docs/source/fortran_api.rst
@@ -2150,23 +2150,23 @@ LIBMUSCLE_InstanceFlags
             You may not use any checkpointing API calls when this flag is not supplied.
 
     :f logical KEEPS_NO_STATE_FOR_NEXT_USE: Indicate this instance does not carry state
-            between iterations of the reuse loop.
+            between iterations of the reuse loop. Specifying this flag is equivalent to
+            :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
 
-            This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
-
-            If neither ``KEEPS_NO_STATE_FOR_NEXT_USE`` and
-            ``STATE_NOT_REQUIRED_FOR_NEXT_USE`` are supplied, this corresponds to
-            :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`.
+            By default, (if neither ``KEEPS_NO_STATE_FOR_NEXT_USE`` nor
+            ``STATE_NOT_REQUIRED_FOR_NEXT_USE`` are provided), the instance is assumed
+            to keep state between reuses, and to require that state (equivalent to
+            :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`).
 
     :f logical STATE_NOT_REQUIRED_FOR_NEXT_USE: Indicate this instance carries state
             between iterations of the reuse loop, however this state is not required
-            for restarting.
+            for restarting. Specifying this flag is equivalent to
+            :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
 
-            This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
-
-            If neither ``KEEPS_NO_STATE_FOR_NEXT_USE`` and
-            ``STATE_NOT_REQUIRED_FOR_NEXT_USE`` are supplied, this corresponds to
-            :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`.
+            By default, (if neither ``KEEPS_NO_STATE_FOR_NEXT_USE`` nor
+            ``STATE_NOT_REQUIRED_FOR_NEXT_USE`` are provided), the instance is assumed
+            to keep state between reuses, and to require that state (equivalent to
+            :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`).
 
 
 Namespace YMMSL

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -180,7 +180,7 @@ Creating an Instance
             ports = LIBMUSCLE_PortsDescription_create()
             call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_F_INIT, 'initial_state')
             call LIBMUSCLE_PortsDescription_add(ports, YMMSL_Operator_O_F, 'final_state')
-            instance = LIBMUSCLE_Instance_create(ports, MPI_COMM_WORLD, root_rank)
+            instance = LIBMUSCLE_Instance_create(ports, communicator=MPI_COMM_WORLD, root=root_rank)
             call LIBMUSCLE_PortsDescription_free(ports)
 
 

--- a/docs/source/uncertainty_quantification.rst
+++ b/docs/source/uncertainty_quantification.rst
@@ -252,7 +252,14 @@ limited number of macro model instances. It has a front side, which connects to
 
 .. code-block:: python
 
-  while instance.reuse_instance(False):
+  instance = Instance({
+          Operator.F_INIT: ['front_in[]'],
+          Operator.O_I: ['back_out[]'],
+          Operator.S: ['back_in[]'],
+          Operator.O_F: ['front_out[]']},
+          DONT_APPLY_OVERLAY)
+
+  while instance.reuse_instance():
       # F_INIT
       started = 0     # number started and index of next to start
       done = 0        # number done and index of next to return
@@ -287,10 +294,12 @@ receiving a result, they'll be queued up and processed in order.)
 We use :meth:`libmuscle.Instance.receive_with_settings` everywhere, in order to
 correctly pass on any settings overlays. Since we are using
 :meth:`libmuscle.Instance.receive_with_settings` on an F_INIT port, we passed
-``False`` to :meth:`libmuscle.Instance.reuse_instance`. It is a technical
-requirement of MUSCLE3 to do this, and MUSCLE will give an error message if
-you call :meth:`libmuscle.Instance.receive_with_settings` without having passed
-``False`` to :meth:`libmuscle.Instance.reuse_instance`. (There's just no other
+:attr:`libmuscle.InstanceFlags.DONT_APPLY_OVERLAY` as flag when creating the
+:class:`libmuscle.Instance`. It is a technical requirement of MUSCLE3 to do
+this, and MUSCLE will give an error message if you call
+:meth:`libmuscle.Instance.receive_with_settings` without having set the
+:attr:`libmuscle.InstanceFlags.DONT_APPLY_OVERLAY` flag when creating the
+:class:`libmuscle.Instance.reuse_instance`. (There's just no other
 way to implement this, or rather, all other options can lead to potentially
 difficult-to-debug situations, while this can be checked and a clear error
 message shown if it goes wrong. So we chose this as the preferable option.)

--- a/libmuscle/cpp/build/libmuscle/libmuscle.version
+++ b/libmuscle/cpp/build/libmuscle/libmuscle.version
@@ -355,6 +355,7 @@
         LIBMUSCLE_Instance_receive_with_settings_pd_;
         LIBMUSCLE_Instance_receive_with_settings_ps_;
         LIBMUSCLE_Instance_receive_with_settings_psd_;
+        LIBMUSCLE_InstanceFlags_to_int_;
         LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_;
         LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_;
         LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_;

--- a/libmuscle/cpp/build/libmuscle/libmuscle.version
+++ b/libmuscle/cpp/build/libmuscle/libmuscle.version
@@ -324,8 +324,7 @@
         LIBMUSCLE_Message_unset_settings_;
         LIBMUSCLE_Instance_create_;
         LIBMUSCLE_Instance_free_;
-        LIBMUSCLE_Instance_reuse_instance_default_;
-        LIBMUSCLE_Instance_reuse_instance_apply_;
+        LIBMUSCLE_Instance_reuse_instance_;
         LIBMUSCLE_Instance_error_shutdown_;
         LIBMUSCLE_Instance_is_setting_a_character_;
         LIBMUSCLE_Instance_is_setting_a_int8_;

--- a/libmuscle/cpp/build/libmuscle/libmuscle.version
+++ b/libmuscle/cpp/build/libmuscle/libmuscle.version
@@ -322,8 +322,7 @@
         LIBMUSCLE_Message_get_settings_;
         LIBMUSCLE_Message_set_settings_;
         LIBMUSCLE_Message_unset_settings_;
-        LIBMUSCLE_Instance_create_autoports_;
-        LIBMUSCLE_Instance_create_with_ports_;
+        LIBMUSCLE_Instance_create_;
         LIBMUSCLE_Instance_free_;
         LIBMUSCLE_Instance_reuse_instance_default_;
         LIBMUSCLE_Instance_reuse_instance_apply_;

--- a/libmuscle/cpp/build/libmuscle/libmuscle_mpi.version
+++ b/libmuscle/cpp/build/libmuscle/libmuscle_mpi.version
@@ -355,6 +355,7 @@
         LIBMUSCLE_Instance_receive_with_settings_pd_;
         LIBMUSCLE_Instance_receive_with_settings_ps_;
         LIBMUSCLE_Instance_receive_with_settings_psd_;
+        LIBMUSCLE_InstanceFlags_to_int_;
         LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_;
         LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_;
         LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_;

--- a/libmuscle/cpp/build/libmuscle/libmuscle_mpi.version
+++ b/libmuscle/cpp/build/libmuscle/libmuscle_mpi.version
@@ -322,8 +322,7 @@
         LIBMUSCLE_Message_get_settings_;
         LIBMUSCLE_Message_set_settings_;
         LIBMUSCLE_Message_unset_settings_;
-        LIBMUSCLE_Instance_create_autoports_cr_;
-        LIBMUSCLE_Instance_create_with_ports_cr_;
+        LIBMUSCLE_Instance_create_;
         LIBMUSCLE_Instance_free_;
         LIBMUSCLE_Instance_reuse_instance_default_;
         LIBMUSCLE_Instance_reuse_instance_apply_;

--- a/libmuscle/cpp/build/libmuscle/libmuscle_mpi.version
+++ b/libmuscle/cpp/build/libmuscle/libmuscle_mpi.version
@@ -324,8 +324,7 @@
         LIBMUSCLE_Message_unset_settings_;
         LIBMUSCLE_Instance_create_;
         LIBMUSCLE_Instance_free_;
-        LIBMUSCLE_Instance_reuse_instance_default_;
-        LIBMUSCLE_Instance_reuse_instance_apply_;
+        LIBMUSCLE_Instance_reuse_instance_;
         LIBMUSCLE_Instance_error_shutdown_;
         LIBMUSCLE_Instance_is_setting_a_character_;
         LIBMUSCLE_Instance_is_setting_a_int8_;

--- a/libmuscle/cpp/src/libmuscle/bindings/libmuscle_fortran_c.cpp
+++ b/libmuscle/cpp/src/libmuscle/bindings/libmuscle_fortran_c.cpp
@@ -14,6 +14,7 @@ using libmuscle::Data;
 using libmuscle::PortsDescription;
 using libmuscle::Message;
 using libmuscle::Instance;
+using libmuscle::InstanceFlags;
 using libmuscle::impl::bindings::CmdLineArgs;
 using ymmsl::Operator;
 using ymmsl::Settings;
@@ -3669,15 +3670,17 @@ void LIBMUSCLE_Message_unset_settings_(std::intptr_t self) {
 
 std::intptr_t LIBMUSCLE_Instance_create_(
         std::intptr_t cla,
-        std::intptr_t ports
+        std::intptr_t ports,
+        int flags
 ) {
     CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);
+    InstanceFlags flags_o = static_cast<InstanceFlags>(flags);
     Instance * result;
     if (ports == 0) {
-        result = new Instance(cla_p->argc(), cla_p->argv());
+        result = new Instance(cla_p->argc(), cla_p->argv(), flags_o);
     } else {
         PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(ports);
-        result = new Instance(cla_p->argc(), cla_p->argv(), *ports_p);
+        result = new Instance(cla_p->argc(), cla_p->argv(), *ports_p, flags_o);
     }
     return reinterpret_cast<std::intptr_t>(result);
 }

--- a/libmuscle/cpp/src/libmuscle/bindings/libmuscle_fortran_c.cpp
+++ b/libmuscle/cpp/src/libmuscle/bindings/libmuscle_fortran_c.cpp
@@ -3691,15 +3691,9 @@ void LIBMUSCLE_Instance_free_(std::intptr_t self) {
     return;
 }
 
-bool LIBMUSCLE_Instance_reuse_instance_default_(std::intptr_t self) {
+bool LIBMUSCLE_Instance_reuse_instance_(std::intptr_t self) {
     Instance * self_p = reinterpret_cast<Instance *>(self);
     bool result = self_p->reuse_instance();
-    return result;
-}
-
-bool LIBMUSCLE_Instance_reuse_instance_apply_(std::intptr_t self, bool apply_overlay) {
-    Instance * self_p = reinterpret_cast<Instance *>(self);
-    bool result = self_p->reuse_instance(apply_overlay);
     return result;
 }
 

--- a/libmuscle/cpp/src/libmuscle/bindings/libmuscle_fortran_c.cpp
+++ b/libmuscle/cpp/src/libmuscle/bindings/libmuscle_fortran_c.cpp
@@ -3667,21 +3667,18 @@ void LIBMUSCLE_Message_unset_settings_(std::intptr_t self) {
     return;
 }
 
-std::intptr_t LIBMUSCLE_Instance_create_autoports_(std::intptr_t cla) {
-    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);
-    Instance * result = new Instance(cla_p->argc(), cla_p->argv());
-    return reinterpret_cast<std::intptr_t>(result);
-}
-
-std::intptr_t LIBMUSCLE_Instance_create_with_ports_(
+std::intptr_t LIBMUSCLE_Instance_create_(
         std::intptr_t cla,
         std::intptr_t ports
 ) {
     CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);
-    PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(
-            ports);
-    Instance * result = new Instance(
-        cla_p->argc(), cla_p->argv(), *ports_p);
+    Instance * result;
+    if (ports == 0) {
+        result = new Instance(cla_p->argc(), cla_p->argv());
+    } else {
+        PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(ports);
+        result = new Instance(cla_p->argc(), cla_p->argv(), *ports_p);
+    }
     return reinterpret_cast<std::intptr_t>(result);
 }
 

--- a/libmuscle/cpp/src/libmuscle/bindings/libmuscle_mpi_fortran_c.cpp
+++ b/libmuscle/cpp/src/libmuscle/bindings/libmuscle_mpi_fortran_c.cpp
@@ -3667,28 +3667,22 @@ void LIBMUSCLE_Message_unset_settings_(std::intptr_t self) {
     return;
 }
 
-std::intptr_t LIBMUSCLE_Instance_create_autoports_cr_(
-        std::intptr_t cla,
-        int communicator,
-        int root
-) {
-    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);
-    MPI_Comm communicator_m = MPI_Comm_f2c(communicator);
-    Instance * result = new Instance(cla_p->argc(), cla_p->argv(), communicator_m, root);
-    return reinterpret_cast<std::intptr_t>(result);
-}
-
-std::intptr_t LIBMUSCLE_Instance_create_with_ports_cr_(
+std::intptr_t LIBMUSCLE_Instance_create_(
         std::intptr_t cla,
         std::intptr_t ports,
         int communicator, int root
 ) {
     CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);
-    PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(
-            ports);
     MPI_Comm communicator_m = MPI_Comm_f2c(communicator);
-    Instance * result = new Instance(
-        cla_p->argc(), cla_p->argv(), *ports_p, communicator_m, root);
+    Instance * result;
+    if (ports == 0) {
+        result = new Instance(
+            cla_p->argc(), cla_p->argv(), communicator_m, root);
+    } else {
+        PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(ports);
+        result = new Instance(
+            cla_p->argc(), cla_p->argv(), *ports_p, communicator_m, root);
+    }
     return reinterpret_cast<std::intptr_t>(result);
 }
 

--- a/libmuscle/cpp/src/libmuscle/bindings/libmuscle_mpi_fortran_c.cpp
+++ b/libmuscle/cpp/src/libmuscle/bindings/libmuscle_mpi_fortran_c.cpp
@@ -14,6 +14,7 @@ using libmuscle::Data;
 using libmuscle::PortsDescription;
 using libmuscle::Message;
 using libmuscle::Instance;
+using libmuscle::InstanceFlags;
 using libmuscle::impl::bindings::CmdLineArgs;
 using ymmsl::Operator;
 using ymmsl::Settings;
@@ -3670,18 +3671,20 @@ void LIBMUSCLE_Message_unset_settings_(std::intptr_t self) {
 std::intptr_t LIBMUSCLE_Instance_create_(
         std::intptr_t cla,
         std::intptr_t ports,
+        int flags,
         int communicator, int root
 ) {
     CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);
+    InstanceFlags flags_o = static_cast<InstanceFlags>(flags);
     MPI_Comm communicator_m = MPI_Comm_f2c(communicator);
     Instance * result;
     if (ports == 0) {
         result = new Instance(
-            cla_p->argc(), cla_p->argv(), communicator_m, root);
+            cla_p->argc(), cla_p->argv(), flags_o, communicator_m, root);
     } else {
         PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(ports);
         result = new Instance(
-            cla_p->argc(), cla_p->argv(), *ports_p, communicator_m, root);
+            cla_p->argc(), cla_p->argv(), *ports_p, flags_o, communicator_m, root);
     }
     return reinterpret_cast<std::intptr_t>(result);
 }

--- a/libmuscle/cpp/src/libmuscle/bindings/libmuscle_mpi_fortran_c.cpp
+++ b/libmuscle/cpp/src/libmuscle/bindings/libmuscle_mpi_fortran_c.cpp
@@ -3695,15 +3695,9 @@ void LIBMUSCLE_Instance_free_(std::intptr_t self) {
     return;
 }
 
-bool LIBMUSCLE_Instance_reuse_instance_default_(std::intptr_t self) {
+bool LIBMUSCLE_Instance_reuse_instance_(std::intptr_t self) {
     Instance * self_p = reinterpret_cast<Instance *>(self);
     bool result = self_p->reuse_instance();
-    return result;
-}
-
-bool LIBMUSCLE_Instance_reuse_instance_apply_(std::intptr_t self, bool apply_overlay) {
-    Instance * self_p = reinterpret_cast<Instance *>(self);
-    bool result = self_p->reuse_instance(apply_overlay);
     return result;
 }
 

--- a/libmuscle/cpp/src/libmuscle/instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/instance.cpp
@@ -67,7 +67,8 @@ class Instance::Impl {
     public:
         Impl(
                 int argc, char const * const argv[],
-                PortsDescription const & ports
+                PortsDescription const & ports,
+                InstanceFlags flags
 #ifdef MUSCLE_ENABLE_MPI
                 , MPI_Comm const & communicator
                 , int root
@@ -112,6 +113,7 @@ class Instance::Impl {
         bool first_run_;
         std::unordered_map<::ymmsl::Reference, Message> f_init_cache_;
         bool is_shut_down_;
+        InstanceFlags flags_;
 
         void register_();
         void connect_();
@@ -146,7 +148,8 @@ class Instance::Impl {
 
 Instance::Impl::Impl(
         int argc, char const * const argv[],
-        PortsDescription const & ports
+        PortsDescription const & ports,
+        InstanceFlags flags
 #ifdef MUSCLE_ENABLE_MPI
         , MPI_Comm const & communicator
         , int root
@@ -162,6 +165,7 @@ Instance::Impl::Impl(
     , first_run_(true)
     , f_init_cache_()
     , is_shut_down_(false)
+    , flags_(flags)
 {
 #ifdef MUSCLE_ENABLE_MPI
     MPI_Comm_dup(communicator, &mpi_comm_);
@@ -907,7 +911,7 @@ Instance::Instance(
 #endif
         )
     : pimpl_(new Impl(
-                argc, argv, {{}}
+                argc, argv, {{}}, InstanceFlags::NONE
 #ifdef MUSCLE_ENABLE_MPI
                 , communicator, root
 #endif
@@ -923,7 +927,40 @@ Instance::Instance(
 #endif
         )
     : pimpl_(new Impl(
-                argc, argv, ports
+                argc, argv, ports, InstanceFlags::NONE
+#ifdef MUSCLE_ENABLE_MPI
+                , communicator, root
+#endif
+                ))
+{}
+
+Instance::Instance(
+        int argc, char const * const argv[],
+        InstanceFlags flags
+#ifdef MUSCLE_ENABLE_MPI
+        , MPI_Comm const & communicator
+        , int root
+#endif
+        )
+    : pimpl_(new Impl(
+                argc, argv, {{}}, flags
+#ifdef MUSCLE_ENABLE_MPI
+                , communicator, root
+#endif
+                ))
+{}
+
+Instance::Instance(
+        int argc, char const * const argv[],
+        PortsDescription const & ports,
+        InstanceFlags flags
+#ifdef MUSCLE_ENABLE_MPI
+        , MPI_Comm const & communicator
+        , int root
+#endif
+        )
+    : pimpl_(new Impl(
+                argc, argv, ports, flags
 #ifdef MUSCLE_ENABLE_MPI
                 , communicator, root
 #endif

--- a/libmuscle/cpp/src/libmuscle/instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/instance.cpp
@@ -902,68 +902,40 @@ void Instance::Impl::shutdown_() {
  * These just forward to the hidden implementations above.
  */
 
+#ifdef MUSCLE_ENABLE_MPI
+#define MPI_ARGS_DECL , MPI_Comm const & communicator, int root
+#define MPI_ARGS_CALL , communicator, root
+#else
+#define MPI_ARGS_DECL
+#define MPI_ARGS_CALL
+#endif
+
 Instance::Instance(
         int argc, char const * const argv[]
-#ifdef MUSCLE_ENABLE_MPI
-        , MPI_Comm const & communicator
-        , int root
-#endif
-        )
-    : pimpl_(new Impl(
-                argc, argv, {{}}, InstanceFlags::NONE
-#ifdef MUSCLE_ENABLE_MPI
-                , communicator, root
-#endif
-                ))
+        MPI_ARGS_DECL)
+    : pimpl_(new Impl(argc, argv, {}, InstanceFlags::NONE MPI_ARGS_CALL))
 {}
 
 Instance::Instance(
         int argc, char const * const argv[],
         PortsDescription const & ports
-#ifdef MUSCLE_ENABLE_MPI
-        , MPI_Comm const & communicator
-        , int root
-#endif
-        )
-    : pimpl_(new Impl(
-                argc, argv, ports, InstanceFlags::NONE
-#ifdef MUSCLE_ENABLE_MPI
-                , communicator, root
-#endif
-                ))
+        MPI_ARGS_DECL)
+    : pimpl_(new Impl(argc, argv, ports, InstanceFlags::NONE MPI_ARGS_CALL))
 {}
 
 Instance::Instance(
         int argc, char const * const argv[],
         InstanceFlags flags
-#ifdef MUSCLE_ENABLE_MPI
-        , MPI_Comm const & communicator
-        , int root
-#endif
-        )
-    : pimpl_(new Impl(
-                argc, argv, {{}}, flags
-#ifdef MUSCLE_ENABLE_MPI
-                , communicator, root
-#endif
-                ))
+        MPI_ARGS_DECL)
+    : pimpl_(new Impl(argc, argv, {}, flags MPI_ARGS_CALL))
 {}
 
 Instance::Instance(
         int argc, char const * const argv[],
         PortsDescription const & ports,
         InstanceFlags flags
-#ifdef MUSCLE_ENABLE_MPI
-        , MPI_Comm const & communicator
-        , int root
-#endif
-        )
-    : pimpl_(new Impl(
-                argc, argv, ports, flags
-#ifdef MUSCLE_ENABLE_MPI
-                , communicator, root
-#endif
-                ))
+        MPI_ARGS_DECL)
+    : pimpl_(new Impl(argc, argv, ports, flags MPI_ARGS_CALL))
 {}
 
 Instance::~Instance() = default;

--- a/libmuscle/cpp/src/libmuscle/instance.hpp
+++ b/libmuscle/cpp/src/libmuscle/instance.hpp
@@ -45,24 +45,24 @@ enum class InstanceFlags : int {
     USES_CHECKPOINT_API = 2,
 
     /** Indicate this instance does not carry state between iterations of the
-     *      reuse loop.
+     * reuse loop. Specifying this flag is equivalent to
+     * `ymmsl.KeepsStateForNextUse.NO`.
      *
-     * This corresponds to `ymmsl.KeepsStateForNextUse.NO`.
-     *
-     * If neither KEEPS_NO_STATE_FOR_NEXT_USE and STATE_NOT_REQUIRED_FOR_NEXT_USE
-     * are supplied, this corresponds to
-     * `ymmsl.KeepsStateForNextUse.NECESSARY`.
+     * By default, (if neither KEEPS_NO_STATE_FOR_NEXT_USE nor
+     * STATE_NOT_REQUIRED_FOR_NEXT_USE are provided), the instance is assumed
+     * to keep state between reuses, and to require that state (equivalent to
+     * `ymmsl.KeepsStateForNextUse.NECESSARY`).
      */
     KEEPS_NO_STATE_FOR_NEXT_USE = 4,
 
     /** Indicate this instance carries state between iterations of the
-     *      reuse loop, however this state is not required for restarting.
+     * reuse loop, however this state is not required for restarting.
+     * Specifying this flag is equivalent to `ymmsl.KeepsStateForNextUse.HELPFUL`.
      *
-     * This corresponds to `ymmsl.KeepsStateForNextUse.HELPFUL`.
-     *
-     * If neither KEEPS_NO_STATE_FOR_NEXT_USE and STATE_NOT_REQUIRED_FOR_NEXT_USE
-     * are supplied, this corresponds to
-     * `ymmsl.KeepsStateForNextUse.NECESSARY`.
+     * By default, (if neither KEEPS_NO_STATE_FOR_NEXT_USE nor
+     * STATE_NOT_REQUIRED_FOR_NEXT_USE are provided), the instance is assumed
+     * to keep state between reuses, and to require that state (equivalent to
+     * `ymmsl.KeepsStateForNextUse.NECESSARY`).
      */
     STATE_NOT_REQUIRED_FOR_NEXT_USE = 8,
 };

--- a/libmuscle/cpp/src/libmuscle/instance.hpp
+++ b/libmuscle/cpp/src/libmuscle/instance.hpp
@@ -16,8 +16,12 @@ namespace libmuscle { namespace impl {
 
 /** Enumeration of properties that an instance may have.
  *
- * You may combine multiple flags using the bitwise OR operator `|`. For
- * example:
+ * You may combine multiple flags using the bitwise OR operator `|`. For example:
+ *
+ * \code{cpp}
+ *      auto flags = InstanceFlags::DONT_APPLY_OVERLAY | InstanceFlags::USES_CHECKPOINT_API;
+ *      Instance instance(argc, argv, flags);
+ * \endcode
  */
 enum class InstanceFlags : int {
     NONE = 0,
@@ -43,22 +47,22 @@ enum class InstanceFlags : int {
     /** Indicate this instance does not carry state between iterations of the
      *      reuse loop.
      *
-     * This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
+     * This corresponds to `ymmsl.KeepsStateForNextUse.NO`.
      *
      * If neither KEEPS_NO_STATE_FOR_NEXT_USE and STATE_NOT_REQUIRED_FOR_NEXT_USE
      * are supplied, this corresponds to
-     * :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+     * `ymmsl.KeepsStateForNextUse.NECESSARY`.
      */
     KEEPS_NO_STATE_FOR_NEXT_USE = 4,
 
     /** Indicate this instance carries state between iterations of the
      *      reuse loop, however this state is not required for restarting.
      *
-     * This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
+     * This corresponds to `ymmsl.KeepsStateForNextUse.HELPFUL`.
      *
      * If neither KEEPS_NO_STATE_FOR_NEXT_USE and STATE_NOT_REQUIRED_FOR_NEXT_USE
      * are supplied, this corresponds to
-     * :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+     * `ymmsl.KeepsStateForNextUse.NECESSARY`.
      */
     STATE_NOT_REQUIRED_FOR_NEXT_USE = 8,
 };

--- a/libmuscle/cpp/src/libmuscle/instance.hpp
+++ b/libmuscle/cpp/src/libmuscle/instance.hpp
@@ -14,6 +14,67 @@
 
 namespace libmuscle { namespace impl {
 
+/** Enumeration of properties that an instance may have.
+ *
+ * You may combine multiple flags using the bitwise OR operator `|`. For
+ * example:
+ */
+enum class InstanceFlags : int {
+    NONE = 0,
+
+    /**
+     * Do not apply the received settings overlay during prereceive of F_INIT
+     * messages. If you're going to use Instance.receive_with_settings on
+     * your F_INIT ports, you need to set this flag when creating an
+     * Instance.
+     *
+     * If you don't know what that means, do not specify this flag and everything
+     * will be fine. If it turns out that you did need to specify the flag, MUSCLE3
+     * will tell you about it in an error message and you can add it still.
+     */
+    DONT_APPLY_OVERLAY = 1,
+
+    /** Indicate that this instance supports checkpointing.
+     *
+     * You may not use any checkpointing API calls when this flag is not supplied.
+     */
+    USES_CHECKPOINT_API = 2,
+
+    /** Indicate this instance does not carry state between iterations of the
+     *      reuse loop.
+     *
+     * This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
+     *
+     * If neither KEEPS_NO_STATE_FOR_NEXT_USE and STATE_NOT_REQUIRED_FOR_NEXT_USE
+     * are supplied, this corresponds to
+     * :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+     */
+    KEEPS_NO_STATE_FOR_NEXT_USE = 4,
+
+    /** Indicate this instance carries state between iterations of the
+     *      reuse loop, however this state is not required for restarting.
+     *
+     * This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
+     *
+     * If neither KEEPS_NO_STATE_FOR_NEXT_USE and STATE_NOT_REQUIRED_FOR_NEXT_USE
+     * are supplied, this corresponds to
+     * :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+     */
+    STATE_NOT_REQUIRED_FOR_NEXT_USE = 8,
+};
+
+inline InstanceFlags operator|(InstanceFlags a, InstanceFlags b) {
+    return static_cast<InstanceFlags>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+inline InstanceFlags operator&(InstanceFlags a, InstanceFlags b) {
+    return static_cast<InstanceFlags>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+inline bool operator!(InstanceFlags a) {
+    return a == InstanceFlags::NONE;
+}
+
 /** Represents a component instance in a MUSCLE3 simulation.
  *
  * This class provides a low-level send/receive API for the instance to use.
@@ -63,6 +124,59 @@ class Instance {
         Instance(
                 int argc, char const * const argv[],
                 PortsDescription const & ports
+#ifdef MUSCLE_ENABLE_MPI
+                , MPI_Comm const & communicator = MPI_COMM_WORLD
+                , int root = 0
+#endif
+                );
+
+        /** Create an Instance.
+         *
+         * For MPI-based components, creating an Instance is a
+         * collective operation, so it must be done in all processes
+         * simultaneously, with the same communicator and the same root.
+         *
+         * @param argc The number of command-line arguments.
+         * @param argv Command line arguments.
+         * @param flags InstanceFlags for this instance.
+         * @param communicator MPI communicator containing all processes in
+         *      this instance (MPI only).
+         * @param root The designated root process (MPI only).
+         */
+        Instance(
+                int argc, char const * const argv[],
+                InstanceFlags flags
+#ifdef MUSCLE_ENABLE_MPI
+                , MPI_Comm const & communicator = MPI_COMM_WORLD
+                , int root = 0
+#endif
+                );
+
+        /** Create an instance.
+         *
+         * A PortsDescription can be written like this:
+         *
+         * PortsDescription ports({
+         *     {Operator::F_INIT, {"port1", "port2"}},
+         *     {Operator::O_F, {"port3[]"}}
+         *     });
+         *
+         * For MPI-based components, creating an Instance is a
+         * collective operation, so it must be done in all processes
+         * simultaneously, with the same communicator and the same root.
+         *
+         * @param argc The number of command-line arguments.
+         * @param argv Command line arguments.
+         * @param ports A description of the ports that this instance has.
+         * @param flags InstanceFlags for this instance.
+         * @param communicator MPI communicator containing all processes in
+         *      this instance (MPI only).
+         * @param root The designated root process (MPI only).
+         */
+        Instance(
+                int argc, char const * const argv[],
+                PortsDescription const & ports,
+                InstanceFlags flags
 #ifdef MUSCLE_ENABLE_MPI
                 , MPI_Comm const & communicator = MPI_COMM_WORLD
                 , int root = 0

--- a/libmuscle/cpp/src/libmuscle/instance.hpp
+++ b/libmuscle/cpp/src/libmuscle/instance.hpp
@@ -214,17 +214,8 @@ class Instance {
          * MPI-based components must execute the reuse loop in each
          * process in parallel, and call this function at the top of the
          * reuse loop in each process.
-         *
-         * @param apply_overlay Whether to apply the received settings
-         *        overlay or to save it. If you're going to use
-         *        receive_with_settings() on your F_INIT ports,
-         *        set this to false. If you don't know what that means,
-         *        just call reuse_instance() without specifying this
-         *        and everything will be fine. If it turns out that you
-         *        did need to specify false, MUSCLE3 will tell you about
-         *        it in an error message and you can add it.
          */
-        bool reuse_instance(bool apply_overlay = true);
+        bool reuse_instance();
 
         /** Logs an error and shuts down the Instance.
          *

--- a/libmuscle/cpp/src/libmuscle/libmuscle.hpp
+++ b/libmuscle/cpp/src/libmuscle/libmuscle.hpp
@@ -9,6 +9,8 @@ namespace libmuscle {
     using impl::Data;
     using impl::DataConstRef;
     using impl::Instance;
+    // Note: C++20 allows using enum, which introduces all enum members in this scope
+    using impl::InstanceFlags;
     using impl::Message;
     using impl::PortsDescription;
     using impl::StorageOrder;

--- a/libmuscle/cpp/src/libmuscle/tests/test_instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_instance.cpp
@@ -36,6 +36,7 @@
 
 using libmuscle::impl::ClosePort;
 using libmuscle::impl::Instance;
+using libmuscle::impl::InstanceFlags;
 using libmuscle::impl::Message;
 using libmuscle::impl::MockCommunicator;
 using libmuscle::impl::MockMMPClient;
@@ -289,7 +290,8 @@ TEST(libmuscle_instance, receive_with_settings) {
     Instance instance(argv.size(), argv.data(),
             PortsDescription({
                 {Operator::F_INIT, {"in"}}
-                }));
+                }),
+            InstanceFlags::DONT_APPLY_OVERLAY);
 
     MockCommunicator::list_ports_return_value = PortsDescription({
                 {Operator::F_INIT, {"in"}}
@@ -302,7 +304,7 @@ TEST(libmuscle_instance, receive_with_settings) {
     MockCommunicator::next_received_message["in"] =
         std::make_unique<Message>(1.0, "Testing with settings", recv_settings);
 
-    ASSERT_TRUE(instance.reuse_instance(false));
+    ASSERT_TRUE(instance.reuse_instance());
     Message msg(instance.receive_with_settings("in"));
 
     ASSERT_EQ(msg.timestamp(), 1.0);
@@ -349,7 +351,8 @@ TEST(libmuscle_instance, receive_with_settings_default) {
     Instance instance(argv.size(), argv.data(),
             PortsDescription({
                 {Operator::F_INIT, {"not_connected"}}
-                }));
+                }),
+            InstanceFlags::DONT_APPLY_OVERLAY);
 
     MockCommunicator::list_ports_return_value = PortsDescription({
                 {Operator::F_INIT, {"not_connected"}}
@@ -361,7 +364,7 @@ TEST(libmuscle_instance, receive_with_settings_default) {
     default_settings["test1"] = 12;
     Message default_msg(1.0, "Testing with settings", default_settings);
 
-    ASSERT_TRUE(instance.reuse_instance(false));
+    ASSERT_TRUE(instance.reuse_instance());
     Message msg(instance.receive_with_settings("not_connected", default_msg));
 
     ASSERT_EQ(msg.timestamp(), 1.0);

--- a/libmuscle/fortran/src/libmuscle/libmuscle.f90
+++ b/libmuscle/fortran/src/libmuscle/libmuscle.f90
@@ -467,7 +467,8 @@ module libmuscle
     public :: LIBMUSCLE_Instance_receive_with_settings_ps
     public :: LIBMUSCLE_Instance_receive_with_settings_psd
     public :: LIBMUSCLE_Instance_receive_with_settings_on_slot
-    type :: LIBMUSCLE_InstanceFlags
+    public :: LIBMUSCLE_InstanceFlags
+    type LIBMUSCLE_InstanceFlags
         logical :: DONT_APPLY_OVERLAY = .false.
         logical :: USES_CHECKPOINT_API = .false.
         logical :: KEEPS_NO_STATE_FOR_NEXT_USE = .false.

--- a/libmuscle/fortran/src/libmuscle/libmuscle.f90
+++ b/libmuscle/fortran/src/libmuscle/libmuscle.f90
@@ -428,8 +428,6 @@ module libmuscle
     end type LIBMUSCLE_Instance
     public :: LIBMUSCLE_Instance
 
-    public :: LIBMUSCLE_Instance_create_autoports
-    public :: LIBMUSCLE_Instance_create_with_ports
     public :: LIBMUSCLE_Instance_create
     public :: LIBMUSCLE_Instance_free
     public :: LIBMUSCLE_Instance_reuse_instance_default
@@ -2953,22 +2951,15 @@ module libmuscle
             integer (c_intptr_t), value, intent(in) :: self
         end subroutine LIBMUSCLE_Message_unset_settings_
 
-        integer (c_intptr_t) function LIBMUSCLE_Instance_create_autoports_(cla) &
-                bind(C, name="LIBMUSCLE_Instance_create_autoports_")
-
-            use iso_c_binding
-            integer (c_intptr_t), value, intent(in) :: cla
-        end function LIBMUSCLE_Instance_create_autoports_
-
-        integer (c_intptr_t) function LIBMUSCLE_Instance_create_with_ports_( &
+        integer (c_intptr_t) function LIBMUSCLE_Instance_create_( &
                 cla, &
                 ports) &
-                bind(C, name="LIBMUSCLE_Instance_create_with_ports_")
+                bind(C, name="LIBMUSCLE_Instance_create_")
 
             use iso_c_binding
             integer (c_intptr_t), value, intent(in) :: cla
             integer (c_intptr_t), value, intent(in) :: ports
-        end function LIBMUSCLE_Instance_create_with_ports_
+        end function LIBMUSCLE_Instance_create_
 
         subroutine LIBMUSCLE_Instance_free_(self) &
                 bind(C, name="LIBMUSCLE_Instance_free_")
@@ -3817,12 +3808,6 @@ module libmuscle
         module procedure &
             LIBMUSCLE_Message_set_data_d, &
             LIBMUSCLE_Message_set_data_dcr
-    end interface
-
-    interface LIBMUSCLE_Instance_create
-        module procedure &
-            LIBMUSCLE_Instance_create_autoports, &
-            LIBMUSCLE_Instance_create_with_ports
     end interface
 
     interface LIBMUSCLE_Instance_reuse_instance
@@ -16505,11 +16490,12 @@ contains
             self%ptr)
     end subroutine LIBMUSCLE_Message_unset_settings
 
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports()
+    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create(ports)
         implicit none
 
+        type(LIBMUSCLE_PortsDescription), intent(in), optional :: ports
         integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
+        integer (c_intptr_t) :: cla, ports_ptr
         character (kind=c_char, len=:), allocatable :: cur_arg
 
         num_args = command_argument_count()
@@ -16523,33 +16509,14 @@ contains
                    cla, i, cur_arg, int(len(cur_arg), c_size_t))
             deallocate(cur_arg)
         end do
-        LIBMUSCLE_Instance_create_autoports%ptr = &
-            LIBMUSCLE_Instance_create_autoports_(cla)
+        if (present(ports)) then
+            ports_ptr = ports%ptr
+        else
+            ports_ptr = 0
+        end if
+        LIBMUSCLE_Instance_create%ptr = LIBMUSCLE_Instance_create_(cla, ports_ptr)
         call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_autoports
-
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports(ports)
-        implicit none
-
-        type(LIBMUSCLE_PortsDescription) :: ports
-        integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
-        character (kind=c_char, len=:), allocatable :: cur_arg
-
-        num_args = command_argument_count()
-        cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)
-        do i = 0, num_args
-            call get_command_argument(i, length=arg_len)
-            allocate (character(arg_len+1) :: cur_arg)
-            call get_command_argument(i, value=cur_arg)
-            cur_arg(arg_len+1:arg_len+1) = c_null_char
-            call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &
-                   cla, i, cur_arg, int(len(cur_arg), c_size_t))
-            deallocate(cur_arg)
-        end do
-        LIBMUSCLE_Instance_create_with_ports%ptr = LIBMUSCLE_Instance_create_with_ports_(cla, ports%ptr)
-        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_with_ports
+    end function LIBMUSCLE_Instance_create
 
     subroutine LIBMUSCLE_Instance_free( &
             self)

--- a/libmuscle/fortran/src/libmuscle/libmuscle.f90
+++ b/libmuscle/fortran/src/libmuscle/libmuscle.f90
@@ -430,8 +430,6 @@ module libmuscle
 
     public :: LIBMUSCLE_Instance_create
     public :: LIBMUSCLE_Instance_free
-    public :: LIBMUSCLE_Instance_reuse_instance_default
-    public :: LIBMUSCLE_Instance_reuse_instance_apply
     public :: LIBMUSCLE_Instance_reuse_instance
     public :: LIBMUSCLE_Instance_error_shutdown
     public :: LIBMUSCLE_Instance_is_setting_a_character
@@ -2980,22 +2978,12 @@ module libmuscle
             integer (c_intptr_t), value, intent(in) :: self
         end subroutine LIBMUSCLE_Instance_free_
 
-        logical (c_bool) function LIBMUSCLE_Instance_reuse_instance_default_(self) &
-                bind(C, name="LIBMUSCLE_Instance_reuse_instance_default_")
+        logical (c_bool) function LIBMUSCLE_Instance_reuse_instance_(self) &
+                bind(C, name="LIBMUSCLE_Instance_reuse_instance_")
 
             use iso_c_binding
             integer (c_intptr_t), value, intent(in) :: self
-        end function LIBMUSCLE_Instance_reuse_instance_default_
-
-        logical (c_bool) function LIBMUSCLE_Instance_reuse_instance_apply_( &
-                self, &
-                apply_overlay) &
-                bind(C, name="LIBMUSCLE_Instance_reuse_instance_apply_")
-
-            use iso_c_binding
-            integer (c_intptr_t), value, intent(in) :: self
-            logical (c_bool), value, intent(in) :: apply_overlay
-        end function LIBMUSCLE_Instance_reuse_instance_apply_
+        end function LIBMUSCLE_Instance_reuse_instance_
 
         subroutine LIBMUSCLE_Instance_error_shutdown_( &
                 self, &
@@ -3820,12 +3808,6 @@ module libmuscle
         module procedure &
             LIBMUSCLE_Message_set_data_d, &
             LIBMUSCLE_Message_set_data_dcr
-    end interface
-
-    interface LIBMUSCLE_Instance_reuse_instance
-        module procedure &
-            LIBMUSCLE_Instance_reuse_instance_default, &
-            LIBMUSCLE_Instance_reuse_instance_apply
     end interface
 
     interface LIBMUSCLE_Instance_send
@@ -16540,36 +16522,19 @@ contains
             self%ptr)
     end subroutine LIBMUSCLE_Instance_free
 
-    function LIBMUSCLE_Instance_reuse_instance_default( &
+    function LIBMUSCLE_Instance_reuse_instance( &
             self)
         implicit none
         type(LIBMUSCLE_Instance), intent(in) :: self
-        logical :: LIBMUSCLE_Instance_reuse_instance_default
+        logical :: LIBMUSCLE_Instance_reuse_instance
 
         logical (c_bool) :: ret_val
 
-        ret_val = LIBMUSCLE_Instance_reuse_instance_default_( &
+        ret_val = LIBMUSCLE_Instance_reuse_instance_( &
             self%ptr)
 
-        LIBMUSCLE_Instance_reuse_instance_default = ret_val
-    end function LIBMUSCLE_Instance_reuse_instance_default
-
-    function LIBMUSCLE_Instance_reuse_instance_apply( &
-            self, &
-            apply_overlay)
-        implicit none
-        type(LIBMUSCLE_Instance), intent(in) :: self
-        logical, intent(in) :: apply_overlay
-        logical :: LIBMUSCLE_Instance_reuse_instance_apply
-
-        logical (c_bool) :: ret_val
-
-        ret_val = LIBMUSCLE_Instance_reuse_instance_apply_( &
-            self%ptr, &
-            logical(apply_overlay, c_bool))
-
-        LIBMUSCLE_Instance_reuse_instance_apply = ret_val
-    end function LIBMUSCLE_Instance_reuse_instance_apply
+        LIBMUSCLE_Instance_reuse_instance = ret_val
+    end function LIBMUSCLE_Instance_reuse_instance
 
     subroutine LIBMUSCLE_Instance_error_shutdown( &
             self, &

--- a/libmuscle/fortran/src/libmuscle/libmuscle_mpi.f90
+++ b/libmuscle/fortran/src/libmuscle/libmuscle_mpi.f90
@@ -468,7 +468,8 @@ module libmuscle_mpi
     public :: LIBMUSCLE_Instance_receive_with_settings_ps
     public :: LIBMUSCLE_Instance_receive_with_settings_psd
     public :: LIBMUSCLE_Instance_receive_with_settings_on_slot
-    type :: LIBMUSCLE_InstanceFlags
+    public :: LIBMUSCLE_InstanceFlags
+    type LIBMUSCLE_InstanceFlags
         logical :: DONT_APPLY_OVERLAY = .false.
         logical :: USES_CHECKPOINT_API = .false.
         logical :: KEEPS_NO_STATE_FOR_NEXT_USE = .false.

--- a/libmuscle/fortran/src/libmuscle/libmuscle_mpi.f90
+++ b/libmuscle/fortran/src/libmuscle/libmuscle_mpi.f90
@@ -431,8 +431,6 @@ module libmuscle_mpi
 
     public :: LIBMUSCLE_Instance_create
     public :: LIBMUSCLE_Instance_free
-    public :: LIBMUSCLE_Instance_reuse_instance_default
-    public :: LIBMUSCLE_Instance_reuse_instance_apply
     public :: LIBMUSCLE_Instance_reuse_instance
     public :: LIBMUSCLE_Instance_error_shutdown
     public :: LIBMUSCLE_Instance_is_setting_a_character
@@ -2985,22 +2983,12 @@ module libmuscle_mpi
             integer (c_intptr_t), value, intent(in) :: self
         end subroutine LIBMUSCLE_Instance_free_
 
-        logical (c_bool) function LIBMUSCLE_Instance_reuse_instance_default_(self) &
-                bind(C, name="LIBMUSCLE_Instance_reuse_instance_default_")
+        logical (c_bool) function LIBMUSCLE_Instance_reuse_instance_(self) &
+                bind(C, name="LIBMUSCLE_Instance_reuse_instance_")
 
             use iso_c_binding
             integer (c_intptr_t), value, intent(in) :: self
-        end function LIBMUSCLE_Instance_reuse_instance_default_
-
-        logical (c_bool) function LIBMUSCLE_Instance_reuse_instance_apply_( &
-                self, &
-                apply_overlay) &
-                bind(C, name="LIBMUSCLE_Instance_reuse_instance_apply_")
-
-            use iso_c_binding
-            integer (c_intptr_t), value, intent(in) :: self
-            logical (c_bool), value, intent(in) :: apply_overlay
-        end function LIBMUSCLE_Instance_reuse_instance_apply_
+        end function LIBMUSCLE_Instance_reuse_instance_
 
         subroutine LIBMUSCLE_Instance_error_shutdown_( &
                 self, &
@@ -3825,12 +3813,6 @@ module libmuscle_mpi
         module procedure &
             LIBMUSCLE_Message_set_data_d, &
             LIBMUSCLE_Message_set_data_dcr
-    end interface
-
-    interface LIBMUSCLE_Instance_reuse_instance
-        module procedure &
-            LIBMUSCLE_Instance_reuse_instance_default, &
-            LIBMUSCLE_Instance_reuse_instance_apply
     end interface
 
     interface LIBMUSCLE_Instance_send
@@ -16552,36 +16534,19 @@ contains
             self%ptr)
     end subroutine LIBMUSCLE_Instance_free
 
-    function LIBMUSCLE_Instance_reuse_instance_default( &
+    function LIBMUSCLE_Instance_reuse_instance( &
             self)
         implicit none
         type(LIBMUSCLE_Instance), intent(in) :: self
-        logical :: LIBMUSCLE_Instance_reuse_instance_default
+        logical :: LIBMUSCLE_Instance_reuse_instance
 
         logical (c_bool) :: ret_val
 
-        ret_val = LIBMUSCLE_Instance_reuse_instance_default_( &
+        ret_val = LIBMUSCLE_Instance_reuse_instance_( &
             self%ptr)
 
-        LIBMUSCLE_Instance_reuse_instance_default = ret_val
-    end function LIBMUSCLE_Instance_reuse_instance_default
-
-    function LIBMUSCLE_Instance_reuse_instance_apply( &
-            self, &
-            apply_overlay)
-        implicit none
-        type(LIBMUSCLE_Instance), intent(in) :: self
-        logical, intent(in) :: apply_overlay
-        logical :: LIBMUSCLE_Instance_reuse_instance_apply
-
-        logical (c_bool) :: ret_val
-
-        ret_val = LIBMUSCLE_Instance_reuse_instance_apply_( &
-            self%ptr, &
-            logical(apply_overlay, c_bool))
-
-        LIBMUSCLE_Instance_reuse_instance_apply = ret_val
-    end function LIBMUSCLE_Instance_reuse_instance_apply
+        LIBMUSCLE_Instance_reuse_instance = ret_val
+    end function LIBMUSCLE_Instance_reuse_instance
 
     subroutine LIBMUSCLE_Instance_error_shutdown( &
             self, &

--- a/libmuscle/fortran/src/libmuscle/libmuscle_mpi.f90
+++ b/libmuscle/fortran/src/libmuscle/libmuscle_mpi.f90
@@ -429,12 +429,6 @@ module libmuscle_mpi
     end type LIBMUSCLE_Instance
     public :: LIBMUSCLE_Instance
 
-    public :: LIBMUSCLE_Instance_create_autoports_cr
-    public :: LIBMUSCLE_Instance_create_autoports_c
-    public :: LIBMUSCLE_Instance_create_autoports
-    public :: LIBMUSCLE_Instance_create_with_ports_cr
-    public :: LIBMUSCLE_Instance_create_with_ports_c
-    public :: LIBMUSCLE_Instance_create_with_ports
     public :: LIBMUSCLE_Instance_create
     public :: LIBMUSCLE_Instance_free
     public :: LIBMUSCLE_Instance_reuse_instance_default
@@ -2958,31 +2952,19 @@ module libmuscle_mpi
             integer (c_intptr_t), value, intent(in) :: self
         end subroutine LIBMUSCLE_Message_unset_settings_
 
-        integer (c_intptr_t) function LIBMUSCLE_Instance_create_autoports_cr_( &
-                cla, &
-                communicator, &
-                root) &
-                bind(C, name="LIBMUSCLE_Instance_create_autoports_cr_")
-
-            use iso_c_binding
-            integer (c_intptr_t), value, intent(in) :: cla
-            integer (c_int), value, intent(in) :: communicator
-            integer (c_int), value, intent(in) :: root
-        end function LIBMUSCLE_Instance_create_autoports_cr_
-
-        integer (c_intptr_t) function LIBMUSCLE_Instance_create_with_ports_cr_( &
+        integer (c_intptr_t) function LIBMUSCLE_Instance_create_( &
                 cla, &
                 ports, &
                 communicator, &
                 root) &
-                bind(C, name="LIBMUSCLE_Instance_create_with_ports_cr_")
+                bind(C, name="LIBMUSCLE_Instance_create_")
 
             use iso_c_binding
             integer (c_intptr_t), value, intent(in) :: cla
             integer (c_intptr_t), value, intent(in) :: ports
             integer (c_int), value, intent(in) :: communicator
             integer (c_int), value, intent(in) :: root
-        end function LIBMUSCLE_Instance_create_with_ports_cr_
+        end function LIBMUSCLE_Instance_create_
 
         subroutine LIBMUSCLE_Instance_free_(self) &
                 bind(C, name="LIBMUSCLE_Instance_free_")
@@ -3831,16 +3813,6 @@ module libmuscle_mpi
         module procedure &
             LIBMUSCLE_Message_set_data_d, &
             LIBMUSCLE_Message_set_data_dcr
-    end interface
-
-    interface LIBMUSCLE_Instance_create
-        module procedure &
-            LIBMUSCLE_Instance_create_autoports_cr, &
-            LIBMUSCLE_Instance_create_autoports_c, &
-            LIBMUSCLE_Instance_create_autoports, &
-            LIBMUSCLE_Instance_create_with_ports_cr, &
-            LIBMUSCLE_Instance_create_with_ports_c, &
-            LIBMUSCLE_Instance_create_with_ports
     end interface
 
     interface LIBMUSCLE_Instance_reuse_instance
@@ -16523,87 +16495,15 @@ contains
             self%ptr)
     end subroutine LIBMUSCLE_Message_unset_settings
 
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports_cr( &
-           communicator, root)
-        implicit none
-        integer :: communicator, root
-
-        integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
-        character (kind=c_char, len=:), allocatable :: cur_arg
-
-        num_args = command_argument_count()
-        cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)
-        do i = 0, num_args
-            call get_command_argument(i, length=arg_len)
-            allocate (character(arg_len+1) :: cur_arg)
-            call get_command_argument(i, value=cur_arg)
-            cur_arg(arg_len+1:arg_len+1) = c_null_char
-            call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &
-                   cla, i, cur_arg, int(len(cur_arg), c_size_t))
-            deallocate(cur_arg)
-        end do
-        LIBMUSCLE_Instance_create_autoports_cr%ptr = &
-            LIBMUSCLE_Instance_create_autoports_cr_(cla, communicator, root)
-        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_autoports_cr
-
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports_c( &
-           communicator)
-        implicit none
-        integer :: communicator
-
-        integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
-        character (kind=c_char, len=:), allocatable :: cur_arg
-
-        num_args = command_argument_count()
-        cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)
-        do i = 0, num_args
-            call get_command_argument(i, length=arg_len)
-            allocate (character(arg_len+1) :: cur_arg)
-            call get_command_argument(i, value=cur_arg)
-            cur_arg(arg_len+1:arg_len+1) = c_null_char
-            call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &
-                   cla, i, cur_arg, int(len(cur_arg), c_size_t))
-            deallocate(cur_arg)
-        end do
-        LIBMUSCLE_Instance_create_autoports_c%ptr = &
-            LIBMUSCLE_Instance_create_autoports_cr_(cla, communicator, 0)
-        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_autoports_c
-
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports()
-        implicit none
-
-        integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
-        character (kind=c_char, len=:), allocatable :: cur_arg
-
-        num_args = command_argument_count()
-        cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)
-        do i = 0, num_args
-            call get_command_argument(i, length=arg_len)
-            allocate (character(arg_len+1) :: cur_arg)
-            call get_command_argument(i, value=cur_arg)
-            cur_arg(arg_len+1:arg_len+1) = c_null_char
-            call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &
-                   cla, i, cur_arg, int(len(cur_arg), c_size_t))
-            deallocate(cur_arg)
-        end do
-        LIBMUSCLE_Instance_create_autoports%ptr = &
-            LIBMUSCLE_Instance_create_autoports_cr_(cla, MPI_COMM_WORLD, 0)
-        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_autoports
-
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports_cr( &
+    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create( &
             ports, communicator, root)
         implicit none
 
-        type(LIBMUSCLE_PortsDescription) :: ports
-        integer :: communicator, root
+        type(LIBMUSCLE_PortsDescription), intent(in), optional :: ports
+        integer, intent(in), optional :: communicator, root
+        integer :: acommunicator, aroot
         integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
+        integer (c_intptr_t) :: cla, ports_ptr
         character (kind=c_char, len=:), allocatable :: cur_arg
 
         num_args = command_argument_count()
@@ -16617,64 +16517,25 @@ contains
                    cla, i, cur_arg, int(len(cur_arg), c_size_t))
             deallocate(cur_arg)
         end do
-        LIBMUSCLE_Instance_create_with_ports_cr%ptr = &
-            LIBMUSCLE_Instance_create_with_ports_cr_( &
-                cla, ports%ptr, communicator, root)
+        if (present(ports)) then
+            ports_ptr = ports%ptr
+        else
+            ports_ptr = 0
+        end if
+        if (present(communicator)) then
+            acommunicator = communicator
+        else
+            acommunicator = MPI_COMM_WORLD
+        end if
+        if (present(root)) then
+            aroot = root
+        else
+            aroot = 0
+        end if
+        LIBMUSCLE_Instance_create%ptr = &
+            LIBMUSCLE_Instance_create_(cla, ports_ptr, acommunicator, aroot)
         call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_with_ports_cr
-
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports_c( &
-            ports, communicator)
-        implicit none
-
-        type(LIBMUSCLE_PortsDescription) :: ports
-        integer :: communicator
-        integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
-        character (kind=c_char, len=:), allocatable :: cur_arg
-
-        num_args = command_argument_count()
-        cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)
-        do i = 0, num_args
-            call get_command_argument(i, length=arg_len)
-            allocate (character(arg_len+1) :: cur_arg)
-            call get_command_argument(i, value=cur_arg)
-            cur_arg(arg_len+1:arg_len+1) = c_null_char
-            call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &
-                   cla, i, cur_arg, int(len(cur_arg), c_size_t))
-            deallocate(cur_arg)
-        end do
-        LIBMUSCLE_Instance_create_with_ports_c%ptr = &
-            LIBMUSCLE_Instance_create_with_ports_cr_( &
-                cla, ports%ptr, communicator, 0)
-        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_with_ports_c
-
-    type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports( &
-            ports)
-        implicit none
-
-        type(LIBMUSCLE_PortsDescription) :: ports
-        integer :: num_args, i, arg_len
-        integer (c_intptr_t) :: cla
-        character (kind=c_char, len=:), allocatable :: cur_arg
-
-        num_args = command_argument_count()
-        cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)
-        do i = 0, num_args
-            call get_command_argument(i, length=arg_len)
-            allocate (character(arg_len+1) :: cur_arg)
-            call get_command_argument(i, value=cur_arg)
-            cur_arg(arg_len+1:arg_len+1) = c_null_char
-            call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &
-                   cla, i, cur_arg, int(len(cur_arg), c_size_t))
-            deallocate(cur_arg)
-        end do
-        LIBMUSCLE_Instance_create_with_ports%ptr = &
-            LIBMUSCLE_Instance_create_with_ports_cr_( &
-                cla, ports%ptr, MPI_COMM_WORLD, 0)
-        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)
-    end function LIBMUSCLE_Instance_create_with_ports
+    end function LIBMUSCLE_Instance_create
 
     subroutine LIBMUSCLE_Instance_free( &
             self)

--- a/libmuscle/fortran/src/libmuscle/tests/assert.f90
+++ b/libmuscle/fortran/src/libmuscle/tests/assert.f90
@@ -7,7 +7,7 @@ contains
 
         if (.not. x) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_true
 
@@ -17,7 +17,7 @@ contains
 
         if (x) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_false
 
@@ -28,7 +28,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_integer
 
@@ -39,7 +39,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_int1
 
@@ -50,7 +50,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_int2
 
@@ -61,7 +61,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_int4
 
@@ -72,7 +72,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_int8
 
@@ -83,7 +83,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_size
 
@@ -93,7 +93,7 @@ contains
 
         if (x .neqv. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_logical
 
@@ -103,7 +103,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_character
 
@@ -114,7 +114,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_real4
 
@@ -125,7 +125,7 @@ contains
 
         if (x .ne. y) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_real8
 
@@ -137,7 +137,7 @@ contains
 
         if (.not. all(x .eq. y)) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_real8array
 
@@ -149,7 +149,7 @@ contains
 
         if (.not. all(x .eq. y)) then
             print *, 'Assertion failed'
-            stop
+            stop 1
         end if
     end subroutine assert_eq_real8array2
 end module assert

--- a/libmuscle/fortran/src/libmuscle/tests/test_instance_flags.f90
+++ b/libmuscle/fortran/src/libmuscle/tests/test_instance_flags.f90
@@ -1,0 +1,129 @@
+module instanceflags_tests
+    use assert
+    implicit none
+contains
+    subroutine test_instanceflags_default_create
+        use libmuscle
+
+        type(LIBMUSCLE_InstanceFlags) :: flags
+        integer :: i
+
+        print *, '[  RUN     ] instanceflags.default_create'
+        flags = LIBMUSCLE_InstanceFlags()
+        call assert_false(flags%DONT_APPLY_OVERLAY)
+        call assert_false(flags%USES_CHECKPOINT_API)
+        call assert_false(flags%KEEPS_NO_STATE_FOR_NEXT_USE)
+        call assert_false(flags%STATE_NOT_REQUIRED_FOR_NEXT_USE)
+        i = flags%to_int()
+        call assert_eq_integer(i, 0)
+        print *, '[       OK ] instanceflags.default_create'
+    end subroutine test_instanceflags_default_create
+
+    subroutine test_instanceflags_create_1
+        use libmuscle
+
+        type(LIBMUSCLE_InstanceFlags) :: flags
+        integer :: i
+
+        print *, '[  RUN     ] instanceflags.create_1'
+        flags = LIBMUSCLE_InstanceFlags(DONT_APPLY_OVERLAY=.true.)
+        call assert_true(flags%DONT_APPLY_OVERLAY)
+        call assert_false(flags%USES_CHECKPOINT_API)
+        call assert_false(flags%KEEPS_NO_STATE_FOR_NEXT_USE)
+        call assert_false(flags%STATE_NOT_REQUIRED_FOR_NEXT_USE)
+        i = flags%to_int()
+        call assert_eq_integer(i, 1)
+        print *, '[       OK ] instanceflags.create_1'
+    end subroutine test_instanceflags_create_1
+
+    subroutine test_instanceflags_create_2
+        use libmuscle
+
+        type(LIBMUSCLE_InstanceFlags) :: flags
+        integer :: i
+
+        print *, '[  RUN     ] instanceflags.create_2'
+        flags = LIBMUSCLE_InstanceFlags(USES_CHECKPOINT_API=.true.)
+        call assert_false(flags%DONT_APPLY_OVERLAY)
+        call assert_true(flags%USES_CHECKPOINT_API)
+        call assert_false(flags%KEEPS_NO_STATE_FOR_NEXT_USE)
+        call assert_false(flags%STATE_NOT_REQUIRED_FOR_NEXT_USE)
+        i = flags%to_int()
+        call assert_eq_integer(i, 2)
+        print *, '[       OK ] instanceflags.create_2'
+    end subroutine test_instanceflags_create_2
+
+    subroutine test_instanceflags_create_3
+        use libmuscle
+
+        type(LIBMUSCLE_InstanceFlags) :: flags
+        integer :: i
+
+        print *, '[  RUN     ] instanceflags.create_3'
+        flags = LIBMUSCLE_InstanceFlags(KEEPS_NO_STATE_FOR_NEXT_USE=.true.)
+        call assert_false(flags%DONT_APPLY_OVERLAY)
+        call assert_false(flags%USES_CHECKPOINT_API)
+        call assert_true(flags%KEEPS_NO_STATE_FOR_NEXT_USE)
+        call assert_false(flags%STATE_NOT_REQUIRED_FOR_NEXT_USE)
+        i = flags%to_int()
+        call assert_eq_integer(i, 4)
+        print *, '[       OK ] instanceflags.create_3'
+    end subroutine test_instanceflags_create_3
+
+    subroutine test_instanceflags_create_4
+        use libmuscle
+
+        type(LIBMUSCLE_InstanceFlags) :: flags
+        integer :: i
+
+        print *, '[  RUN     ] instanceflags.create_4'
+        flags = LIBMUSCLE_InstanceFlags(STATE_NOT_REQUIRED_FOR_NEXT_USE=.true.)
+        call assert_false(flags%DONT_APPLY_OVERLAY)
+        call assert_false(flags%USES_CHECKPOINT_API)
+        call assert_false(flags%KEEPS_NO_STATE_FOR_NEXT_USE)
+        call assert_true(flags%STATE_NOT_REQUIRED_FOR_NEXT_USE)
+        i = flags%to_int()
+        call assert_eq_integer(i, 8)
+        print *, '[       OK ] instanceflags.create_4'
+    end subroutine test_instanceflags_create_4
+
+    subroutine test_instanceflags_create_all
+        use libmuscle
+
+        type(LIBMUSCLE_InstanceFlags) :: flags
+        integer :: i
+
+        print *, '[  RUN     ] instanceflags.create_all'
+        flags = LIBMUSCLE_InstanceFlags( &
+            DONT_APPLY_OVERLAY=.true., &
+            USES_CHECKPOINT_API=.true., &
+            KEEPS_NO_STATE_FOR_NEXT_USE=.true., &
+            STATE_NOT_REQUIRED_FOR_NEXT_USE=.true.)
+        call assert_true(flags%DONT_APPLY_OVERLAY)
+        call assert_true(flags%USES_CHECKPOINT_API)
+        call assert_true(flags%KEEPS_NO_STATE_FOR_NEXT_USE)
+        call assert_true(flags%STATE_NOT_REQUIRED_FOR_NEXT_USE)
+        i = flags%to_int()
+        call assert_eq_integer(i, 15)
+        print *, '[       OK ] instanceflags.create_all'
+    end subroutine test_instanceflags_create_all
+end module instanceflags_tests
+
+program test_instanceflags
+    use instanceflags_tests
+    implicit none
+
+    print *, ''
+    print *, '[==========] Fortran API InstanceFlags'
+
+    call test_instanceflags_default_create
+    call test_instanceflags_create_1
+    call test_instanceflags_create_2
+    call test_instanceflags_create_3
+    call test_instanceflags_create_4
+    call test_instanceflags_create_all
+
+    print *, '[==========] Fortran API InstanceFlags'
+    print *, '[  PASSED  ] Fortran API InstanceFlags'
+    print *, ''
+end program test_instanceflags

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -73,7 +73,7 @@ class InstanceFlags(Flag):
 
     If neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` and
     :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are supplied, this corresponds to
-    :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`.
     """
 
     STATE_NOT_REQUIRED_FOR_NEXT_USE = auto()
@@ -84,7 +84,7 @@ class InstanceFlags(Flag):
 
     If neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` and
     :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are supplied, this corresponds to
-    :external:py:attr:`ymmsl.KeepsStateForNextUse.REQUIRED`.
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`.
     """
 
 
@@ -643,18 +643,7 @@ class Instance:
         .. note::
             This method will block until it can determine whether a final
             snapshot should be taken. This means it must also determine if this
-            instance is reused. The optional keyword-only argument
-            `apply_overlay` has the same meaning as for :meth:`reuse_instance`.
-
-        Args:
-            apply_overlay: Whether to apply the received settings
-                overlay or to save it. If you're going to use
-                :meth:`receive_with_settings` on your F_INIT ports, set this to
-                False. If you don't know what that means, just call
-                :meth:`should_save_final_snapshot()` without specifying this and
-                everything will be fine. If it turns out that you did need to
-                specify False, MUSCLE3 will tell you about it in an error
-                message and you can add it still.
+            instance is reused.
 
         Returns:
             True iff a final snapshot should be taken by the submodel according

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -67,24 +67,25 @@ class InstanceFlags(Flag):
 
     KEEPS_NO_STATE_FOR_NEXT_USE = auto()
     """Indicate this instance does not carry state between iterations of the
-    reuse loop.
+    reuse loop. Specifying this flag is equivalent to
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
 
-    This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.NO`.
-
-    If neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` and
-    :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are supplied, this corresponds to
-    :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`.
+    By default, (if neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` nor
+    :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are provided), the instance is assumed
+    to keep state between reuses, and to require that state (equivalent to
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`).
     """
 
     STATE_NOT_REQUIRED_FOR_NEXT_USE = auto()
     """Indicate this instance carries state between iterations of the
     reuse loop, however this state is not required for restarting.
+    Specifying this flag is equivalent to
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
 
-    This corresponds to :external:py:attr:`ymmsl.KeepsStateForNextUse.HELPFUL`.
-
-    If neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` and
-    :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are supplied, this corresponds to
-    :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`.
+    By default, (if neither :attr:`KEEPS_NO_STATE_FOR_NEXT_USE` nor
+    :attr:`STATE_NOT_REQUIRED_FOR_NEXT_USE` are provided), the instance is assumed
+    to keep state between reuses, and to require that state (equivalent to
+    :external:py:attr:`ymmsl.KeepsStateForNextUse.NECESSARY`).
     """
 
 

--- a/scripts/api_generator.py
+++ b/scripts/api_generator.py
@@ -2324,11 +2324,10 @@ class Flags:
         """Create a Fortran type definition for this enum.
         """
         result = ''
-        public = ''
         if self.public:
-            public = ', public'
+            result += f'public :: {self.ns_prefix}_{self.name}\n'
 
-        result += f'type :: {self.ns_prefix}_{self.name}\n'
+        result += f'type {self.ns_prefix}_{self.name}\n'
         for value in self.values:
             result += f'    logical :: {value} = .false.\n'
         result += '\n'

--- a/scripts/api_generator.py
+++ b/scripts/api_generator.py
@@ -2286,6 +2286,101 @@ class Enum:
         return textwrap.indent(result, 4*' ')
 
 
+class Flags:
+    def __init__(self, name: str, values: List[str]):
+        """Create a Flags description.
+
+        Flags are an enum class in C++, but a custom derived type with boolean
+        attributes in Fortran.
+
+        Args:
+            name: name of the flags
+            values: list of option names
+        """
+        self.ns_prefix = None       # type: Optional[str]
+        self.public = None          # type: Optional[bool]
+        self.name = name
+        self.values = values
+
+    def set_ns_prefix(self, ns_for_name: Dict[str, str]) -> None:
+        """Sets the namespace prefix correctly for all members.
+
+        Args:
+            ns_for_name: A map from type names to namespace names.
+        """
+        self.ns_prefix = ns_for_name[self.name]
+
+    def set_public(self, public: bool) -> None:
+        """Sets whether this enum should be public.
+
+        Public objects are usable by the Fortran program.
+
+        Args:
+            public: True iff this is public.
+        """
+        self.public = public
+
+    def fortran_type_definition(self) -> str:
+        """Create a Fortran type definition for this enum.
+        """
+        result = ''
+        public = ''
+        if self.public:
+            public = ', public'
+
+        result += f'type :: {self.ns_prefix}_{self.name}\n'
+        for value in self.values:
+            result += f'    logical :: {value} = .false.\n'
+        result += '\n'
+        result += 'contains\n'
+        result += f'    procedure :: to_int => {self.ns_prefix}_{self.name}_to_int_\n'
+        result += 'end type\n'
+        return textwrap.indent(result, 4*' ')
+
+    def fortran_exports(self) -> List[str]:
+        """Generates a list of linker exports for the Fortran symbols.
+        """
+        fun_name = f'{self.ns_prefix}_{self.name}_to_int_;'
+        return [fun_name]
+
+    def fortran_c_wrapper(self) -> str:
+        """Create C functions for the members.
+        """
+        return ''
+
+    def fortran_interface(self) -> str:
+        """Create a Fortran interface definition for the C ABI.
+        """
+        return ''
+
+    def fortran_public_declarations(self) -> str:
+        """Creates Fortran declarations making functions public.
+        """
+        return ''
+
+    def fortran_overloads(self) -> str:
+        """Create Fortran overload declarations for any OverloadSets.
+        """
+        return ''
+
+    def fortran_functions(self) -> str:
+        """Create Fortran function definitions for this class.
+        """
+        fun_name = f'{self.ns_prefix}_{self.name}_to_int_'
+        result = f'integer function {fun_name}(flags)\n'
+        result += '    implicit none\n'
+        result += '\n'
+        result += f'    class({self.ns_prefix}_{self.name}), intent(in) :: flags\n'
+        result += '    integer :: ret_val\n'
+        result += '\n'
+        result += '    ret_val = 0\n'
+        for i, value in enumerate(self.values):
+            result += f"    if (flags%{value}) ret_val = ret_val + {1 << i}\n"
+        result += f'    {fun_name} = ret_val\n'
+        result += f'end function {fun_name}\n'
+        return textwrap.indent(result, 4*' ')
+
+
 class Namespace:
     def __init__(self, name: str, public: Optional[bool], prefix: str,
                  enums: List[Enum], classes: List[Class]) -> None:

--- a/scripts/make_libmuscle_api.py
+++ b/scripts/make_libmuscle_api.py
@@ -814,296 +814,120 @@ portsdescription_desc = Class('PortsDescription', None, [
     ])
 
 
-instance_constructors = [
-    Constructor([Obj('CmdLineArgs', 'cla')], 'create_autoports', fc_override=(
-        'std::intptr_t LIBMUSCLE_Instance_create_autoports_(std::intptr_t cla) {\n'
+instance_constructor = Constructor(
+    [Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports')],
+    fc_override=(
+        'std::intptr_t LIBMUSCLE_Instance_create_(\n'
+        '        std::intptr_t cla,\n'
+        '        std::intptr_t ports\n'
+        ') {\n'
         '    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);\n'
-        '    Instance * result = new Instance(cla_p->argc(), cla_p->argv());\n'
+        '    Instance * result;\n'
+        '    if (ports == 0) {\n'
+        '        result = new Instance(cla_p->argc(), cla_p->argv());\n'
+        '    } else {\n'
+        '        PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(ports);\n'
+        '        result = new Instance(cla_p->argc(), cla_p->argv(), *ports_p);\n'
+        '    }\n'
         '    return reinterpret_cast<std::intptr_t>(result);\n'
         '}\n\n'),
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports()\n'
-            '    implicit none\n'
-            '\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_autoports%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_autoports_(cla)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_autoports\n'
-            '\n')),
-    Constructor(
-        [Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports')],
-        'create_with_ports',
-        fc_override=(
-            'std::intptr_t LIBMUSCLE_Instance_create_with_ports_(\n'
-            '        std::intptr_t cla,\n'
-            '        std::intptr_t ports\n'
-            ') {\n'
-            '    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);\n'
-            '    PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(\n'
-            '            ports);\n'
-            '    Instance * result = new Instance(\n'
-            '        cla_p->argc(), cla_p->argv(), *ports_p);\n'
-            '    return reinterpret_cast<std::intptr_t>(result);\n'
-            '}\n\n'),
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports(ports)\n'
-            '    implicit none\n'
-            '\n'
-            '    type(LIBMUSCLE_PortsDescription) :: ports\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_with_ports%ptr = LIBMUSCLE_Instance_create_with_ports_(cla, ports%ptr)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_with_ports\n'
-            '\n')),
-    OverloadSet('create', ['create_autoports', 'create_with_ports']),
-    ]
+    f_override=(
+        'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create(ports)\n'
+        '    implicit none\n'
+        '\n'
+        '    type(LIBMUSCLE_PortsDescription), intent(in), optional :: ports\n'
+        '    integer :: num_args, i, arg_len\n'
+        '    integer (c_intptr_t) :: cla, ports_ptr\n'
+        '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
+        '\n'
+        '    num_args = command_argument_count()\n'
+        '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
+        '    do i = 0, num_args\n'
+        '        call get_command_argument(i, length=arg_len)\n'
+        '        allocate (character(arg_len+1) :: cur_arg)\n'
+        '        call get_command_argument(i, value=cur_arg)\n'
+        '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
+        '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
+        '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
+        '        deallocate(cur_arg)\n'
+        '    end do\n'
+        '    if (present(ports)) then\n'
+        '        ports_ptr = ports%ptr\n'
+        '    else\n'
+        '        ports_ptr = 0\n'
+        '    end if\n'
+        '    LIBMUSCLE_Instance_create%ptr = LIBMUSCLE_Instance_create_(cla, ports_ptr)\n'
+        '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
+        'end function LIBMUSCLE_Instance_create\n'
+        '\n'))
 
-
-instance_mpi_constructors = [
-    Constructor(
-        [Obj('CmdLineArgs', 'cla'), Int('communicator'), Int('root')],
-        'create_autoports_cr',
-        fc_override=(
-            'std::intptr_t LIBMUSCLE_Instance_create_autoports_cr_(\n'
-            '        std::intptr_t cla,\n'
-            '        int communicator,\n'
-            '        int root\n'
-            ') {\n'
-            '    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);\n'
-            '    MPI_Comm communicator_m = MPI_Comm_f2c(communicator);\n'
-            '    Instance * result = new Instance(cla_p->argc(), cla_p->argv(), communicator_m, root);\n'
-            '    return reinterpret_cast<std::intptr_t>(result);\n'
-            '}\n\n'),
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports_cr( &\n'
-            '       communicator, root)\n'
-            '    implicit none\n'
-            '    integer :: communicator, root\n'
-            '\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_autoports_cr%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_autoports_cr_(cla, communicator, root)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_autoports_cr\n'
-            '\n')),
-    Constructor(
-        [Obj('CmdLineArgs', 'cla'), Int('communicator')],
-        'create_autoports_c',
-        fc_override='',
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports_c( &\n'
-            '       communicator)\n'
-            '    implicit none\n'
-            '    integer :: communicator\n'
-            '\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_autoports_c%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_autoports_cr_(cla, communicator, 0)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_autoports_c\n'
-            '\n')),
-    Constructor(
-        [Obj('CmdLineArgs', 'cla')],
-        'create_autoports',
-        fc_override='',
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_autoports()\n'
-            '    implicit none\n'
-            '\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_autoports%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_autoports_cr_(cla, MPI_COMM_WORLD, 0)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_autoports\n'
-            '\n')),
-    Constructor(
-        [
-            Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports'),
-            Int('communicator'), Int('root')],
-        'create_with_ports_cr',
-        fc_override=(
-            'std::intptr_t LIBMUSCLE_Instance_create_with_ports_cr_(\n'
-            '        std::intptr_t cla,\n'
-            '        std::intptr_t ports,\n'
-            '        int communicator, int root\n'
-            ') {\n'
-            '    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);\n'
-            '    PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(\n'
-            '            ports);\n'
-            '    MPI_Comm communicator_m = MPI_Comm_f2c(communicator);\n'
-            '    Instance * result = new Instance(\n'
-            '        cla_p->argc(), cla_p->argv(), *ports_p, communicator_m, root);\n'
-            '    return reinterpret_cast<std::intptr_t>(result);\n'
-            '}\n\n'),
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports_cr( &\n'
-            '        ports, communicator, root)\n'
-            '    implicit none\n'
-            '\n'
-            '    type(LIBMUSCLE_PortsDescription) :: ports\n'
-            '    integer :: communicator, root\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_with_ports_cr%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_with_ports_cr_( &\n'
-            '            cla, ports%ptr, communicator, root)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_with_ports_cr\n'
-            '\n')),
-    Constructor(
-        [
-            Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports'),
-            Int('communicator')],
-        'create_with_ports_c',
-        fc_override='',
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports_c( &\n'
-            '        ports, communicator)\n'
-            '    implicit none\n'
-            '\n'
-            '    type(LIBMUSCLE_PortsDescription) :: ports\n'
-            '    integer :: communicator\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_with_ports_c%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_with_ports_cr_( &\n'
-            '            cla, ports%ptr, communicator, 0)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_with_ports_c\n'
-            '\n')),
-    Constructor(
-        [
-            Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports')],
-        'create_with_ports',
-        fc_override='',
-        f_override=(
-            'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create_with_ports( &\n'
-            '        ports)\n'
-            '    implicit none\n'
-            '\n'
-            '    type(LIBMUSCLE_PortsDescription) :: ports\n'
-            '    integer :: num_args, i, arg_len\n'
-            '    integer (c_intptr_t) :: cla\n'
-            '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-            '\n'
-            '    num_args = command_argument_count()\n'
-            '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
-            '    do i = 0, num_args\n'
-            '        call get_command_argument(i, length=arg_len)\n'
-            '        allocate (character(arg_len+1) :: cur_arg)\n'
-            '        call get_command_argument(i, value=cur_arg)\n'
-            '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-            '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
-            '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
-            '        deallocate(cur_arg)\n'
-            '    end do\n'
-            '    LIBMUSCLE_Instance_create_with_ports%ptr = &\n'
-            '        LIBMUSCLE_Instance_create_with_ports_cr_( &\n'
-            '            cla, ports%ptr, MPI_COMM_WORLD, 0)\n'
-            '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
-            'end function LIBMUSCLE_Instance_create_with_ports\n'
-            '\n')),
-    OverloadSet('create', [
-        'create_autoports_cr', 'create_autoports_c', 'create_autoports',
-        'create_with_ports_cr', 'create_with_ports_c', 'create_with_ports']),
-    ]
+instance_mpi_constructor = Constructor(
+    [
+        Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports'),
+        Int('communicator'), Int('root')],
+    fc_override=(
+        'std::intptr_t LIBMUSCLE_Instance_create_(\n'
+        '        std::intptr_t cla,\n'
+        '        std::intptr_t ports,\n'
+        '        int communicator, int root\n'
+        ') {\n'
+        '    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(cla);\n'
+        '    MPI_Comm communicator_m = MPI_Comm_f2c(communicator);\n'
+        '    Instance * result;\n'
+        '    if (ports == 0) {\n'
+        '        result = new Instance(\n'
+        '            cla_p->argc(), cla_p->argv(), communicator_m, root);\n'
+        '    } else {\n'
+        '        PortsDescription * ports_p = reinterpret_cast<PortsDescription *>(ports);\n'
+        '        result = new Instance(\n'
+        '            cla_p->argc(), cla_p->argv(), *ports_p, communicator_m, root);\n'
+        '    }\n'
+        '    return reinterpret_cast<std::intptr_t>(result);\n'
+        '}\n\n'),
+    f_override=(
+        'type(LIBMUSCLE_Instance) function LIBMUSCLE_Instance_create( &\n'
+        '        ports, communicator, root)\n'
+        '    implicit none\n'
+        '\n'
+        '    type(LIBMUSCLE_PortsDescription), intent(in), optional :: ports\n'
+        '    integer, intent(in), optional :: communicator, root\n'
+        '    integer :: acommunicator, aroot\n'
+        '    integer :: num_args, i, arg_len\n'
+        '    integer (c_intptr_t) :: cla, ports_ptr\n'
+        '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
+        '\n'
+        '    num_args = command_argument_count()\n'
+        '    cla = LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_create_(num_args + 1)\n'
+        '    do i = 0, num_args\n'
+        '        call get_command_argument(i, length=arg_len)\n'
+        '        allocate (character(arg_len+1) :: cur_arg)\n'
+        '        call get_command_argument(i, value=cur_arg)\n'
+        '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
+        '        call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_set_arg_( &\n'
+        '               cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'
+        '        deallocate(cur_arg)\n'
+        '    end do\n'
+        '    if (present(ports)) then\n'
+        '        ports_ptr = ports%ptr\n'
+        '    else\n'
+        '        ports_ptr = 0\n'
+        '    end if\n'
+        '    if (present(communicator)) then\n'
+        '        acommunicator = communicator\n'
+        '    else\n'
+        '        acommunicator = MPI_COMM_WORLD\n'
+        '    end if\n'
+        '    if (present(root)) then\n'
+        '        aroot = root\n'
+        '    else\n'
+        '        aroot = 0\n'
+        '    end if\n'
+        '    LIBMUSCLE_Instance_create%ptr = &\n'
+        '        LIBMUSCLE_Instance_create_(cla, ports_ptr, acommunicator, aroot)\n'
+        '    call LIBMUSCLE_IMPL_BINDINGS_CmdLineArgs_free_(cla)\n'
+        'end function LIBMUSCLE_Instance_create\n'
+        '\n')
+    )
 
 
 instance_members = [
@@ -1199,12 +1023,12 @@ instance_members = [
 
 
 instance_desc = Class(
-        'Instance', None, instance_constructors + [
+        'Instance', None, [instance_constructor] + [
             copy(mem) for mem in instance_members])
 
 
 instance_mpi_desc = Class(
-        'Instance', None, instance_mpi_constructors + [
+        'Instance', None, [instance_mpi_constructor] + [
             copy(mem) for mem in instance_members])
 
 

--- a/scripts/make_libmuscle_api.py
+++ b/scripts/make_libmuscle_api.py
@@ -932,17 +932,7 @@ instance_mpi_constructor = Constructor(
 
 instance_members = [
     Destructor(),
-    MemFun(
-            Bool(), 'reuse_instance_default',
-            cpp_chain_call=lambda **kwargs: 'self_p->reuse_instance()'),
-    MemFun(
-            Bool(), 'reuse_instance_apply', [Bool('apply_overlay')],
-            cpp_chain_call=lambda **kwargs: (
-                'self_p->reuse_instance({})'.format(kwargs['cpp_args']))
-            ),
-    OverloadSet(
-            'reuse_instance',
-            ['reuse_instance_default', 'reuse_instance_apply']),
+    MemFun(Bool(), 'reuse_instance'),
     MemFun(Void(), 'error_shutdown', [String('message')]),
     MemFunTmpl(
         [String(), Int64t(), Double(), Bool(), VecDbl('value'),


### PR DESCRIPTION
Adds instance flags to C++ and Fortran APIs

- C++ `Instance()` constructors get two additional call signatures to allow backwards compatibility with v0.6.0.
  - `InstanceFlags` argument is added before MPI_COMM such that the non-MPI and MPI call signatures remain compatible.
  - Now there are 4 call signatures for the constructors, which is still manageable but a bit convoluted with the `#ifdef`s for MPI
- Fortran constructors are reworked to reduce repeated codes. The additional `InstanceFlags` **break backwards compatibility** for MPI models, but with a clear compiler error (at least on `gfortran`). See `changelog.rst`.
- C++/Fortran lose the `apply_overlay` argument to `reuse_instance()` (backwards incompatible, see `changelog.rst`).
- Python also loses the `apply_overlay` argument to `reuse_instance()` (was already deprecated in 0.6.0). Definitely closes #181.