### PR TITLE
Encapsulate connection lost errors

### DIFF
--- a/libmuscle/cpp/src/libmuscle/communicator.hpp
+++ b/libmuscle/cpp/src/libmuscle/communicator.hpp
@@ -198,6 +198,10 @@ class Communicator {
         std::tuple<std::string, bool> split_port_desc_(
                 std::string const & port_desc) const;
 
+        std::tuple<DataConstRef, mcp::ProfileData> try_receive_(
+                MPPClient & client, ymmsl::Reference const & receiver,
+                ymmsl::Reference const & peer);
+
         ymmsl::Reference kernel_;
         std::vector<int> index_;
         Optional<PortsDescription> declared_ports_;


### PR DESCRIPTION
With more descriptive error messages. Fixes #188.

Old C++ error message:
----------------------
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error receiving data on socket
```

New C++ error message:
----------------------
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error while receiving a message: connection with peer 'micro' was lost. Did the peer crash?
	Original error: Error receiving data on socket
```

Old Python error message:
-------------------------
```
Traceback (most recent call last):
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/communicator.py", line 319, in receive_message
    mpp_message_bytes, profile = client.receive(recv_endpoint.ref())
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mpp_client.py", line 54, in receive
    return self._transport_client.call(encoded_request)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mcp/tcp_transport_client.py", line 68, in call
    length = recv_int64(self._socket)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mcp/tcp_util.py", line 63, in recv_int64
    buf = recv_all(socket, 8)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mcp/tcp_util.py", line 29, in recv_all
    raise SocketClosed("Socket closed while receiving")
libmuscle.mcp.tcp_util.SocketClosed: Socket closed while receiving
```

New Python error message:
-------------------------
```
Traceback (most recent call last):
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/communicator.py", line 319, in receive_message
    mpp_message_bytes, profile = client.receive(recv_endpoint.ref())
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mpp_client.py", line 54, in receive
    return self._transport_client.call(encoded_request)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mcp/tcp_transport_client.py", line 68, in call
    length = recv_int64(self._socket)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mcp/tcp_util.py", line 63, in recv_int64
    buf = recv_all(socket, 8)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/mcp/tcp_util.py", line 29, in recv_all
    raise SocketClosed("Socket closed while receiving")
libmuscle.mcp.tcp_util.SocketClosed: Socket closed while receiving

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/maarten/projects/muscle3/docs/source/examples/python/diffusion.py", line 104, in <module>
    diffusion()
  File "/home/maarten/projects/muscle3/docs/source/examples/python/diffusion.py", line 63, in diffusion
    msg = instance.receive('state_in', default=cur_state_msg)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/instance.py", line 461, in receive
    return self.__receive_message(port_name, slot, default, False)
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/instance.py", line 877, in __receive_message
    msg, saved_until = self._communicator.receive_message(
  File "/home/maarten/projects/muscle3/libmuscle/python/libmuscle/communicator.py", line 321, in receive_message
    raise RuntimeError(
RuntimeError: Error while receiving a message: connection with peer 'micro' was lost. Did the peer crash?
```