### PR TITLE
Draft: Graphical plot of yMMSL configuration

### DIFF
--- a/muscle3/model_graph_pydot.py
+++ b/muscle3/model_graph_pydot.py
@@ -8,11 +8,11 @@ import pydot
 
 # https://www.graphviz.org/docs/attr-types/arrowType/
 OPERATOR_SHAPES = {
-    Operator.NONE: 'normal',
-    Operator.F_INIT: 'odiamond',
-    Operator.O_I: 'dot',
-    Operator.S: 'odot',
-    Operator.O_F: 'diamond'
+    Operator.NONE: "normal",
+    Operator.F_INIT: "odiamond",
+    Operator.O_I: "dot",
+    Operator.S: "odot",
+    Operator.O_F: "diamond",
 }
 
 
@@ -24,48 +24,97 @@ def endpoint_to_key(endpoint: Reference):
 
     Not sure how to handle vector ports yet.
     """
-    return str(endpoint).replace('.', ':')
+    return str(endpoint).replace(".", ":")
 
 
 def port_shape(port: Reference, component: Union[Component, None]):
     """Given a port reference, find the component referred to
     and look up the shape corresponding to the port type."""
-    print(component.ports.operator(port))
-    return OPERATOR_SHAPES[component.ports.operator(port)] if component else 'normal'
+    return OPERATOR_SHAPES[component.ports.operator(port)] if component else "normal"
 
 
 def find_component(name: Reference, components: List[Component]):
     """Find a component by reference"""
-    return next((component for component in components if component.name == str(name)), None)
+    return next(
+        (component for component in components if component.name == str(name)), None
+    )
 
 
 def plot_model_graph(config: PartialConfiguration) -> None:
-    """Convert a PartialConfiguration into DOT format.
-
-    """
-    graph = pydot.Dot(config.model.name, graph_type='digraph')
+    """Convert a PartialConfiguration into DOT format."""
+    graph = pydot.Dot(
+        config.model.name,
+        graph_type="digraph",
+        layout="sfdp",
+        pad=1,
+        splines="ortho",
+        nodesep=0.6,
+        ranksep=0.75,
+        fontname="Sans-Serif",
+    )
 
     for component in config.model.components:
-        graph.add_node(pydot.Node(str(component.name), shape='box'))
+        graph.add_node(
+            pydot.Node(
+                str(component.name),
+                shape="box",
+                style="rounded",
+                fixedsize="false",
+                width=2,
+                height=1,
+                labelloc="c",
+            )
+        )
 
     for conduit in config.model.conduits:
         # The ':' acts as a port, on a node, so we ensure that edges
         # coming from the same name get mapped to the same port
+        sender = find_component(conduit.sending_component(), config.model.components)
+        receiver = find_component(
+            conduit.receiving_component(), config.model.components
+        )
 
-        receiver = next((component for component in config.model.components
-                        if component.name == str(conduit.receiving_component)), None)
-        receiving_operator = OPERATOR_SHAPES[receiver.ports.operator(conduit.receiving_port)] if receiver else 'normal'
+        # Could save space in generated dot graph by setting default values
+        # (see https://graphviz.org/docs/edges/ edge [name0=val0])
+        edge = pydot.Edge(
+            endpoint_to_key(conduit.sender),
+            endpoint_to_key(conduit.receiver),
+            arrowtail=port_shape(
+                conduit.sending_port(),
+                sender,
+            ),
+            arrowhead=port_shape(
+                conduit.receiving_port(),
+                receiver,
+            ),
+            dir="both",
+            labelfontsize=8,
+            fontsize=8,
+            len=2,
+        )
 
-        graph.add_edge(pydot.Edge(endpoint_to_key(conduit.sender),
-                                  endpoint_to_key(conduit.receiver),
-                                  arrowtail=port_shape(conduit.sending_port(),
-                                                       find_component(conduit.sending_component(),
-                                                                      config.model.components)),
-                                  arrowhead=port_shape(conduit.receiving_port(),
-                                                       find_component(conduit.receiving_component(),
-                                                                      config.model.components)),
-                                  dir='both',
-                      ))
+        # if port names match exactly (optionally when removing an _in or _out suffix)
+        # we show the name on the conduit instead of on the port
+        sending_port = str(conduit.sending_port())
+        receiving_port = str(conduit.receiving_port())
+
+        # special casing for ports having names matching almost exactly
+        sending_port = (
+            sending_port[:-4] if sending_port.endswith("_out") else sending_port
+        )
+        receiving_port = (
+            receiving_port[:-3] if receiving_port.endswith("_in") else receiving_port
+        )
+
+        if sending_port == receiving_port:
+            edge.set_label(sending_port)
+        else:
+            edge.set_taillabel(str(conduit.sending_port()))
+            edge.set_headlabel(str(conduit.receiving_port()))
+
+        # we could consider setting a minlen based on the text length and font size
+
+        graph.add_edge(edge)
 
     print(graph)
     return graph

--- a/muscle3/model_graph_pydot.py
+++ b/muscle3/model_graph_pydot.py
@@ -112,16 +112,10 @@ def legend_html_label():
     return f"""<<TABLE CELLSPACING="0" CELLBORDER="0" >
   <TR>
     <TD BGCOLOR='{COLORS[Operator.F_INIT]}'>F_INIT</TD>
-    <TD></TD>
-    <TD BGCOLOR='{COLORS[Operator.O_F]}'>O_F</TD>
-  </TR>
-  <TR>
-    <TD COLSPAN="3"><B>legend</B></TD>
-  </TR>
-  <TR>
     <TD BGCOLOR='{COLORS[Operator.O_I]}'>O_I</TD>
-    <TD></TD>
+    <TD><B>legend</B></TD>
     <TD BGCOLOR='{COLORS[Operator.S]}'>S</TD>
+    <TD BGCOLOR='{COLORS[Operator.O_F]}'>O_F</TD>
   </TR>
 </TABLE>>"""
     pass
@@ -129,57 +123,30 @@ def legend_html_label():
 
 def component_html_label(component: Component):
     """Construct a HTML-like label (https://graphviz.org/doc/info/shapes.html#html)"""
-    # TODO: make a helper function or clean this up
 
-    # To layout the (single) table allowed, while getting evenly divided input and
-    # output ports, we can use colspan
+    label = "<<TABLE CELLSPACING='0' CELLBORDER='0' >\n  <TR>\n"
 
-    # remap variables here to enable experimenting with layout
-    # very ugly, should refactor
-    top_left = component.ports.f_init
-    top_left_color = COLORS[Operator.F_INIT]
-    top_right = component.ports.o_f
-    top_right_color = COLORS[Operator.O_F]
-    bottom_left = component.ports.o_i
-    bottom_left_color = COLORS[Operator.O_I]
-    bottom_right = component.ports.s
-    bottom_right_color = COLORS[Operator.S]
-    c_top = max(len(bottom_left), 1) + max(len(bottom_right), 1) + 1
-    c_bottom = max(len(top_left), 1) + max(len(top_right), 1) + 1
+    for port in component.ports.f_init:
+        label += f"    <TD PORT='{port}' BGCOLOR='{COLORS[Operator.F_INIT]}'>{port_shortname(port)}</TD>\n"
+    if len(component.ports.f_init) == 0:
+        label += f"    <TD BGCOLOR='{COLORS[Operator.F_INIT]}'></TD>\n"
+    for port in component.ports.o_i:
+        label += f"    <TD PORT='{port}' BGCOLOR='{COLORS[Operator.O_I]}'>{port_shortname(port)}</TD>\n"
+    if len(component.ports.o_i) == 0:
+        label += f"    <TD BGCOLOR='{COLORS[Operator.O_I]}'></TD>\n"
 
-    label = "<<TABLE CELLSPACING='0' CELLBORDER='0' >\n"
+    label += f"    <TD><B>{component.name}</B></TD>\n"
 
-    top_ports = ""
-    for port in top_left:
-        top_ports += f"    <TD PORT='{port}' COLSPAN='{c_top}' BGCOLOR='{top_left_color}'>{port_shortname(port)}</TD>\n"
-    if len(top_left) == 0:
-        top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
-    top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
-    if len(top_right) == 0:
-        top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
-    for port in top_right:
-        top_ports += f"    <TD PORT='{port}' COLSPAN='{c_top}' BGCOLOR='{top_right_color}'>{port_shortname(port)}</TD>\n"
+    for port in component.ports.s:
+        label += f"    <TD PORT='{port}' BGCOLOR='{COLORS[Operator.S]}'>{port_shortname(port)}</TD>\n"
+    if len(component.ports.s) == 0:
+        label += f"    <TD BGCOLOR='{COLORS[Operator.S]}'></TD>\n"
+    for port in component.ports.o_f:
+        label += f"    <TD PORT='{port}' BGCOLOR='{COLORS[Operator.O_F]}'>{port_shortname(port)}</TD>\n"
+    if len(component.ports.o_f) == 0:
+        label += f"    <TD BGCOLOR='{COLORS[Operator.O_F]}'></TD>\n"
 
-    if top_ports != "":
-        label += f"  <TR>\n{top_ports}  </TR>\n"
-
-    label += f"  <TR>\n    <TD COLSPAN='{c_top*c_bottom}'><B>{component.name}</B></TD>\n  </TR>\n"
-
-    bottom_ports = ""
-    for port in bottom_left:
-        bottom_ports += f"    <TD PORT='{port}' COLSPAN='{c_bottom}' BGCOLOR='{bottom_left_color}'>{port_shortname(port)}</TD>\n"
-    if len(bottom_left) == 0:
-        bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
-    bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
-    if len(bottom_right) == 0:
-        bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
-    for port in bottom_right:
-        bottom_ports += f"    <TD PORT='{port}' COLSPAN='{c_bottom}' BGCOLOR='{bottom_right_color}'>{port_shortname(port)}</TD>\n"
-
-    if bottom_ports != "":
-        label += f"  <TR>\n{bottom_ports}  </TR>\n"
-
-    return label.replace("'", '"') + "</TABLE>>"
+    return label.replace("'", '"') + "</TR></TABLE>>"
 
 
 def plot_model_graph(config: PartialConfiguration, simplify_edge_labels: bool) -> None:

--- a/muscle3/model_graph_pydot.py
+++ b/muscle3/model_graph_pydot.py
@@ -1,0 +1,71 @@
+from typing import List, Union
+
+from ymmsl.configuration import PartialConfiguration
+from ymmsl.identity import Reference
+from ymmsl.component import Operator, Component
+
+import pydot
+
+# https://www.graphviz.org/docs/attr-types/arrowType/
+OPERATOR_SHAPES = {
+    Operator.NONE: 'normal',
+    Operator.F_INIT: 'odiamond',
+    Operator.O_I: 'dot',
+    Operator.S: 'odot',
+    Operator.O_F: 'diamond'
+}
+
+
+def endpoint_to_key(endpoint: Reference):
+    """Replace an endpoint name like component.port with
+    a graphviz node:port display.
+
+    See https://graphviz.readthedocs.io/en/stable/manual.html#node-ports-compass
+
+    Not sure how to handle vector ports yet.
+    """
+    return str(endpoint).replace('.', ':')
+
+
+def port_shape(port: Reference, component: Union[Component, None]):
+    """Given a port reference, find the component referred to
+    and look up the shape corresponding to the port type."""
+    print(component.ports.operator(port))
+    return OPERATOR_SHAPES[component.ports.operator(port)] if component else 'normal'
+
+
+def find_component(name: Reference, components: List[Component]):
+    """Find a component by reference"""
+    return next((component for component in components if component.name == str(name)), None)
+
+
+def plot_model_graph(config: PartialConfiguration) -> None:
+    """Convert a PartialConfiguration into DOT format.
+
+    """
+    graph = pydot.Dot(config.model.name, graph_type='digraph')
+
+    for component in config.model.components:
+        graph.add_node(pydot.Node(str(component.name), shape='box'))
+
+    for conduit in config.model.conduits:
+        # The ':' acts as a port, on a node, so we ensure that edges
+        # coming from the same name get mapped to the same port
+
+        receiver = next((component for component in config.model.components
+                        if component.name == str(conduit.receiving_component)), None)
+        receiving_operator = OPERATOR_SHAPES[receiver.ports.operator(conduit.receiving_port)] if receiver else 'normal'
+
+        graph.add_edge(pydot.Edge(endpoint_to_key(conduit.sender),
+                                  endpoint_to_key(conduit.receiver),
+                                  arrowtail=port_shape(conduit.sending_port(),
+                                                       find_component(conduit.sending_component(),
+                                                                      config.model.components)),
+                                  arrowhead=port_shape(conduit.receiving_port(),
+                                                       find_component(conduit.receiving_component(),
+                                                                      config.model.components)),
+                                  dir='both',
+                      ))
+
+    print(graph)
+    return graph

--- a/muscle3/model_graph_pydot.py
+++ b/muscle3/model_graph_pydot.py
@@ -112,14 +112,16 @@ def legend_html_label():
     return f"""<<TABLE CELLSPACING="0" CELLBORDER="0" >
   <TR>
     <TD BGCOLOR='{COLORS[Operator.F_INIT]}'>F_INIT</TD>
-    <TD BGCOLOR='{COLORS[Operator.S]}'>S</TD>
-  </TR>
-  <TR>
-    <TD COLSPAN="2"><B>legend</B></TD>
-  </TR>
-  <TR>
+    <TD></TD>
     <TD BGCOLOR='{COLORS[Operator.O_F]}'>O_F</TD>
+  </TR>
+  <TR>
+    <TD COLSPAN="3"><B>legend</B></TD>
+  </TR>
+  <TR>
     <TD BGCOLOR='{COLORS[Operator.O_I]}'>O_I</TD>
+    <TD></TD>
+    <TD BGCOLOR='{COLORS[Operator.S]}'>S</TD>
   </TR>
 </TABLE>>"""
     pass
@@ -136,22 +138,25 @@ def component_html_label(component: Component):
     # very ugly, should refactor
     top_left = component.ports.f_init
     top_left_color = COLORS[Operator.F_INIT]
-    top_right = component.ports.s
-    top_right_color = COLORS[Operator.S]
-    bottom_left = component.ports.o_f
-    bottom_left_color = COLORS[Operator.O_F]
-    bottom_right = component.ports.o_i
-    bottom_right_color = COLORS[Operator.O_I]
-    c_top = len(bottom_left) + len(bottom_right)
-    c_bottom = len(top_left) + len(top_right)
+    top_right = component.ports.o_f
+    top_right_color = COLORS[Operator.O_F]
+    bottom_left = component.ports.o_i
+    bottom_left_color = COLORS[Operator.O_I]
+    bottom_right = component.ports.s
+    bottom_right_color = COLORS[Operator.S]
+    c_top = max(len(bottom_left), 1) + max(len(bottom_right), 1) + 1
+    c_bottom = max(len(top_left), 1) + max(len(top_right), 1) + 1
 
     label = "<<TABLE CELLSPACING='0' CELLBORDER='0' >\n"
 
     top_ports = ""
     for port in top_left:
         top_ports += f"    <TD PORT='{port}' COLSPAN='{c_top}' BGCOLOR='{top_left_color}'>{port_shortname(port)}</TD>\n"
-    # spacer port
-    # top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
+    if len(top_left) == 0:
+        top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
+    top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
+    if len(top_right) == 0:
+        top_ports += f"    <TD COLSPAN='{c_top}'></TD>\n"
     for port in top_right:
         top_ports += f"    <TD PORT='{port}' COLSPAN='{c_top}' BGCOLOR='{top_right_color}'>{port_shortname(port)}</TD>\n"
 
@@ -163,8 +168,11 @@ def component_html_label(component: Component):
     bottom_ports = ""
     for port in bottom_left:
         bottom_ports += f"    <TD PORT='{port}' COLSPAN='{c_bottom}' BGCOLOR='{bottom_left_color}'>{port_shortname(port)}</TD>\n"
-    # spacer port
-    # bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
+    if len(bottom_left) == 0:
+        bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
+    bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
+    if len(bottom_right) == 0:
+        bottom_ports += f"    <TD COLSPAN='{c_bottom}'></TD>\n"
     for port in bottom_right:
         bottom_ports += f"    <TD PORT='{port}' COLSPAN='{c_bottom}' BGCOLOR='{bottom_right_color}'>{port_shortname(port)}</TD>\n"
 

--- a/muscle3/muscle3.py
+++ b/muscle3/muscle3.py
@@ -8,8 +8,7 @@ import ymmsl
 from ymmsl import PartialConfiguration
 
 
-from libmuscle.planner.planner import (
-        Planner, Resources, InsufficientResourcesAvailable)
+from libmuscle.planner.planner import Planner, Resources, InsufficientResourcesAvailable
 from libmuscle.snapshot_manager import SnapshotManager
 
 from .model_graph_pydot import plot_model_graph
@@ -34,20 +33,30 @@ def muscle3() -> None:
     pass
 
 
-@muscle3.command(short_help='Calculate resources needed for a simulation')
+@muscle3.command(short_help="Calculate resources needed for a simulation")
 @click.argument(
-        'ymmsl_files', nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True))
+    "ymmsl_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+    ),
+)
 @click.option(
-        '-c', '--cores-per-node', nargs=1, type=int, required=True,
-        help='Set number of cores per cluster node.')
-@click.option(
-        '-v', '--verbose', is_flag=True, help='Show instance allocations.')
-def resources(
-        ymmsl_files: Sequence[str],
-        cores_per_node: int, verbose: bool
-        ) -> None:
+    "-c",
+    "--cores-per-node",
+    nargs=1,
+    type=int,
+    required=True,
+    help="Set number of cores per cluster node.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Show instance allocations.")
+def resources(ymmsl_files: Sequence[str], cores_per_node: int, verbose: bool) -> None:
     """Calculate the number of nodes needed to run the simulation.
 
     In order to run a MUSCLE3 simulation on a cluster, a batch job has
@@ -83,7 +92,7 @@ def resources(
         click.echo(_RESOURCES_INCOMPLETE_MODEL, err=True)
         sys.exit(1)
 
-    resources = Resources({'node000001': set(range(cores_per_node))})
+    resources = Resources({"node000001": set(range(cores_per_node))})
     planner = Planner(resources)
     try:
         allocations = planner.allocate_all(config, True)
@@ -96,33 +105,42 @@ def resources(
     if verbose:
         click.echo()
         if num_nodes == 1:
-            click.echo('A total of 1 node will be needed, as follows:')
+            click.echo("A total of 1 node will be needed, as follows:")
         else:
-            click.echo(
-                    f'A total of {num_nodes} nodes will be needed,'
-                    ' as follows:')
+            click.echo(f"A total of {num_nodes} nodes will be needed," " as follows:")
 
         click.echo()
         for instance in sorted(allocations):
-            click.echo(f'{instance}: {str(allocations[instance])}')
+            click.echo(f"{instance}: {str(allocations[instance])}")
     else:
-        click.echo(f'{num_nodes}', nl=False)
+        click.echo(f"{num_nodes}", nl=False)
 
     sys.exit(0)
 
 
-@muscle3.command(short_help='Display details of a stored snapshot')
+@muscle3.command(short_help="Display details of a stored snapshot")
 @click.argument(
-        'snapshot_files', nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True, path_type=Path))
+    "snapshot_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+        path_type=Path,
+    ),
+)
 @click.option(
-        '-d', '--data', is_flag=True,
-        help='Display stored data. Note this may result in a lot of output!')
-@click.option(
-        '-v', '--verbose', is_flag=True, help='Display more metadata.')
-def snapshot(
-        snapshot_files: Sequence[Path], data: bool, verbose: bool) -> None:
+    "-d",
+    "--data",
+    is_flag=True,
+    help="Display stored data. Note this may result in a lot of output!",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Display more metadata.")
+def snapshot(snapshot_files: Sequence[Path], data: bool, verbose: bool) -> None:
     """Display information about stored snapshots.
 
     Per provided snapshot, display metadata. Stored data can also be output by
@@ -131,37 +149,56 @@ def snapshot(
     """
     for file in snapshot_files:
         snapshot = SnapshotManager.load_snapshot_from_file(file)
-        click.echo(f'Snapshot at {file}:')
-        typ = 'Final' if snapshot.is_final_snapshot else 'Intermediate'
-        properties = OrderedDict([
-            ('Snapshot type', typ),
-            ('Snapshot timestamp',
-             snapshot.message.timestamp if snapshot.message else float('-inf')),
-            ('Snapshot wallclock time', snapshot.wallclock_time),
-            ('Snapshot triggers', snapshot.triggers),
-        ])
+        click.echo(f"Snapshot at {file}:")
+        typ = "Final" if snapshot.is_final_snapshot else "Intermediate"
+        properties = OrderedDict(
+            [
+                ("Snapshot type", typ),
+                (
+                    "Snapshot timestamp",
+                    snapshot.message.timestamp if snapshot.message else float("-inf"),
+                ),
+                ("Snapshot wallclock time", snapshot.wallclock_time),
+                ("Snapshot triggers", snapshot.triggers),
+            ]
+        )
         if verbose:
-            properties.update([
-                ('Internal: Port message counts', snapshot.port_message_counts),
-            ])
+            properties.update(
+                [
+                    ("Internal: Port message counts", snapshot.port_message_counts),
+                ]
+            )
         for prop_name, prop_value in properties.items():
-            click.secho(f'{prop_name}: ', nl=False, bold=True)
+            click.secho(f"{prop_name}: ", nl=False, bold=True)
             click.echo(prop_value)
         if data:
-            click.secho('Snapshot data:', bold=True)
+            click.secho("Snapshot data:", bold=True)
             if snapshot.message is not None:
                 click.echo(snapshot.message.data)
             else:
                 click.secho("No data available", italic=True)
         click.echo()
 
-@muscle3.command(short_help='Print a graphical representation of this workflow')
+
+@muscle3.command(short_help="Print a graphical representation of this workflow")
 @click.argument(
-        'ymmsl_files', nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True))
+    "ymmsl_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+    ),
+)
+@click.option(
+    "-v", "--verbose", is_flag=True, help="Include more information in the graph."
+)
 # TODO: Add output format argument (png, wxpython, sixel?)
-def graph(ymmsl_files: Sequence[str]) -> None:
+def graph(ymmsl_files: Sequence[str], verbose: bool) -> None:
     """Plot a graphical representation of the passed yMMSL files.
 
     To help develop or understand about a coupled simulation it may
@@ -183,21 +220,19 @@ def graph(ymmsl_files: Sequence[str]) -> None:
     """
     partial_config = _load_ymmsl_files(ymmsl_files)
 
-    graph = plot_model_graph(partial_config)
+    graph = plot_model_graph(partial_config, simplify_edge_labels=not verbose)
 
-    graph.write_png('output.png')
-
-
+    graph.write_png("output.png")
 
 
 def _load_ymmsl_files(ymmsl_files: Sequence[str]) -> PartialConfiguration:
     """Loads and merges yMMSL files."""
     configuration = PartialConfiguration()
     for path in ymmsl_files:
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             configuration.update(ymmsl.load(f))
     return configuration
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     muscle3()

--- a/muscle3/muscle3.py
+++ b/muscle3/muscle3.py
@@ -12,6 +12,8 @@ from libmuscle.planner.planner import (
         Planner, Resources, InsufficientResourcesAvailable)
 from libmuscle.snapshot_manager import SnapshotManager
 
+from .model_graph_pydot import plot_model_graph
+
 
 _RESOURCES_INCOMPLETE_MODEL = """
 A model, implementations and resources must be given to be able to calculate
@@ -152,6 +154,40 @@ def snapshot(
             else:
                 click.secho("No data available", italic=True)
         click.echo()
+
+@muscle3.command(short_help='Print a graphical representation of this workflow')
+@click.argument(
+        'ymmsl_files', nargs=-1, required=True, type=click.Path(
+            exists=True, file_okay=True, dir_okay=False, readable=True,
+            allow_dash=True, resolve_path=True))
+# TODO: Add output format argument (png, wxpython, sixel?)
+def graph(ymmsl_files: Sequence[str]) -> None:
+    """Plot a graphical representation of the passed yMMSL files.
+
+    To help develop or understand about a coupled simulation it may
+    be useful to view a graphical representation.
+
+    If multiple yMMSL files are given, then they will be combined left
+    to right, i.e. if there are conflicting declarations, the one from
+    the file last given is used.
+
+    Result:
+
+      A graph is displayed or saved to disk, containing all the defined
+      components and the connections between them.
+
+    Examples:
+
+      muscle3 graph simulation.ymmsl
+
+    """
+    partial_config = _load_ymmsl_files(ymmsl_files)
+
+    graph = plot_model_graph(partial_config)
+
+    graph.write_png('output.png')
+
+
 
 
 def _load_ymmsl_files(ymmsl_files: Sequence[str]) -> PartialConfiguration:

--- a/muscle3/muscle3.py
+++ b/muscle3/muscle3.py
@@ -227,13 +227,21 @@ def snapshot(snapshot_files: Sequence[Path], data: bool, verbose: bool) -> None:
     type=str,
     help="Open with specified viewer (try xdg-open)",
 )
-@click.option("-v", "--verbose", is_flag=True, help="Include more information.")
+@click.option("-v", "--verbose", is_flag=True, help="Show more info (prints the generated dot syntax)")
+@click.option("-p", "--ports", is_flag=True, help="Explicitly draw component ports.")
+@click.option("-l", "--legend", is_flag=True, help="Show a legend (only with --ports).")
+@click.option("-s", "--simple-edges", is_flag=True, help="Only indicate conduit direction, not port types.")
+@click.option("--portlabels", is_flag=True, help="Never simplify matching port labels along an edge.")
 def graph(
     ymmsl_files: Sequence[str],
     out: Union[Path, None],
     fmt: str,
     viewer: str,
     verbose: bool,
+    ports: bool,
+    legend: bool,
+    simple_edges: bool,
+    portlabels: bool
 ) -> None:
     """Plot a graphical representation of the passed yMMSL files.
 
@@ -256,7 +264,7 @@ def graph(
     """
     partial_config = _load_ymmsl_files(ymmsl_files)
 
-    graph = plot_model_graph(partial_config, simplify_edge_labels=not verbose)
+    graph = plot_model_graph(partial_config, simplify_edge_labels=not portlabels, draw_ports=ports, simple_edges=simple_edges, show_legend=legend)
 
     if fmt is None:
         fmt = "svg"
@@ -268,6 +276,9 @@ def graph(
     elif out == '-':
         print(graph.create(format=fmt))
     else:
+        if verbose:
+            print(graph)
+
         graph.write(out, format=fmt)
 
     if viewer is not None and out != '-':

--- a/muscle3/muscle3.py
+++ b/muscle3/muscle3.py
@@ -263,10 +263,14 @@ def graph(
     if out is None:
         out = "output." + fmt
 
-    # should we handle '-' separately here?
-    graph.write(out, format=fmt)
+    if out == '-' and fmt == 'dot':
+        print(graph)
+    elif out == '-':
+        print(graph.create(format=fmt))
+    else:
+        graph.write(out, format=fmt)
 
-    if viewer is not None:
+    if viewer is not None and out != '-':
         subprocess.run([viewer, out])
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
             'sphinx_rtd_theme',
             'sphinx-fortran',
             'tox'
-        ]
+        ],
+        'ui': [
+            'pydot'
+        ],
     },
 )


### PR DESCRIPTION
The idea is to have a nice method to visualize the workflow you are developing.
For this a new command is defined
```bash
muscle3 graph file.ymmsl
```

See `--help` for an up-to-date description of the options.

### Things to do still

- [ ] Provide documentation
- [ ] See if we can make the arrows 'feel' more in the direction of data flow
- [ ] More distinct styling (thick lines, like MMSL docs? different colors for stateful / stateless actors?)
- [ ] Show implementation name
- [ ] Investigate hovering for more details (should work in svg)
- [ ] Compare a few layout engines (needs example cases)
- [ ] Plot unconnected ports (optional)
- [ ] Investigate options for live-updating (show running, waiting models, message counts)