### PR TITLE
Output final lines of log files on error for easier debugging

### DIFF
--- a/libmuscle/python/libmuscle/manager/instance_manager.py
+++ b/libmuscle/python/libmuscle/manager/instance_manager.py
@@ -1,4 +1,5 @@
 import logging
+from textwrap import indent
 from threading import Thread
 from typing import Union
 from multiprocessing import Queue
@@ -9,6 +10,7 @@ from ymmsl import Configuration
 from libmuscle.manager.instantiator import (
         CancelAllRequest, CrashedResult, InstantiatorRequest,
         InstantiationRequest, ProcessStatus, ShutdownRequest)
+from libmuscle.manager.logger import last_lines
 from libmuscle.manager.qcgpj_instantiator import Process, QCGPJInstantiator
 from libmuscle.manager.run_dir import RunDir
 from libmuscle.planner.planner import Planner, Resources
@@ -144,9 +146,19 @@ class InstanceManager:
                     _logger.error(
                             f'Instance {result.instance} quit with error'
                             f' {result.exit_code}')
+
+                    stderr_file = (
+                            self._run_dir.instance_dir(result.instance) /
+                            'stderr.txt')
                     _logger.error(
-                            'Output may be found in'
-                            f' {self._run_dir.instance_dir(result.instance)}')
+                            'The last error output of this instance was:')
+                    _logger.error(
+                            '\n' + indent(last_lines(stderr_file, 20), '    '))
+                    _logger.error(
+                            'More output may be found in'
+                            f' {self._run_dir.instance_dir(result.instance)}\n'
+                            )
+
                     if all_seemingly_okay:
                         self._requests_out.put(CancelAllRequest())
                         all_seemingly_okay = False

--- a/libmuscle/python/libmuscle/manager/logger.py
+++ b/libmuscle/python/libmuscle/manager/logger.py
@@ -146,7 +146,7 @@ def last_lines(file: Path, count: int) -> str:
         return ''
 
     file_size = file.stat().st_size
-    start_point = max(file_size - 5000, 0)
+    start_point = max(file_size - 10000, 0)
 
     lines: List[str] = []
     with file.open('r') as f:

--- a/libmuscle/python/libmuscle/manager/logger.py
+++ b/libmuscle/python/libmuscle/manager/logger.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from libmuscle.logging import LogLevel, Timestamp
 from libmuscle.util import extract_log_file_location
@@ -125,3 +125,36 @@ class Logger:
                 extra={
                     'instance': instance_id,
                     'iasctime': timestamp.to_asctime()})
+
+
+def last_lines(file: Path, count: int) -> str:
+    """Utility function that returns the last lines of a text file.
+
+    This opens the file and returns the final `count` lines. It reads
+    at most 10000 bytes, to avoid memory problems if the file contains
+    e.g. a large amount of binary data.
+
+    Args:
+        file: The file to read
+        count: Number of lines to read
+
+    Return:
+        A string of at most 10000 bytes, containing at most `count`
+        newlines.
+    """
+    if not file.exists():
+        return ''
+
+    file_size = file.stat().st_size
+    start_point = max(file_size - 5000, 0)
+
+    lines: List[str] = []
+    with file.open('r') as f:
+        f.seek(start_point)
+        f.readline()    # skip partial line
+        line = f.readline()
+        while line:
+            lines.append(line)
+            line = f.readline()
+
+    return '\n' + ''.join(lines[-count:])

--- a/muscle3/muscle_manager.py
+++ b/muscle3/muscle_manager.py
@@ -11,6 +11,7 @@ from yatiml import RecognitionError
 import ymmsl
 from ymmsl import Identifier, PartialConfiguration
 
+from libmuscle.manager.logger import last_lines
 from libmuscle.manager.manager import Manager
 from libmuscle.manager.run_dir import RunDir
 
@@ -109,10 +110,20 @@ def manage_simulation(
     success = manager.wait()
 
     if not success:
+        log_file = run_dir_path / 'muscle3_manager.log'
+
+        print()
         print('An error occurred during execution, and the simulation was')
         print('shut down. The manager log should tell you what happened.')
-        print('You can find it at')
-        print('   ', run_dir_path / 'muscle3_manager.log')
+        print('Here are the final lines of the manager log:')
+        print()
+        print('-' * 80)
+        print(last_lines(log_file, 30), '    ')
+        print('-' * 80)
+        print()
+        print('You can find the full log at')
+        print(str(log_file))
+        print()
     else:
         print('Simulation completed successfully.')
 


### PR DESCRIPTION
This outputs the final lines of a crashed instance's stderr to the manager log, and the final lines of the manager log to the console, so that in simple cases you can see the problem right away and don't have to go digging through the files. Example output:
```
An error occurred during execution, and the simulation was
shut down. The manager log should tell you what happened.
Here are the final lines of the manager log:

--------------------------------------------------------------------------------

      File "docs/source/examples/python/build/venv/lib/python3.10/site-packages/libmuscle/mcp/tcp_util.py", line 25, in recv_all
        received_now = socket.recv_into(
    ConnectionResetError: [Errno 104] Connection reset by peer

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "docs/source/examples/python/diffusion.py", line 104, in <module>
        diffusion()
      File "docs/source/examples/python/diffusion.py", line 63, in diffusion
        msg = instance.receive('state_in', default=cur_state_msg)
      File "docs/source/examples/python/build/venv/lib/python3.10/site-packages/libmuscle/instance.py", line 461, in receive
        return self.__receive_message(port_name, slot, default, False)
      File "docs/source/examples/python/build/venv/lib/python3.10/site-packages/libmuscle/instance.py", line 877, in __receive_message
        msg, saved_until = self._communicator.receive_message(
      File "docs/source/examples/python/build/venv/lib/python3.10/site-packages/libmuscle/communicator.py", line 321, in receive_message
        raise RuntimeError(
    RuntimeError: Error while receiving a message: connection with peer 'micro' was lost. Did the peer crash?

muscle_manager 2023-04-15 20:27:35,753 ERROR   libmuscle.manager.instance_manager: More output may be found in docs/source/examples/run_reaction_diffusion_python_20230415_202735/instances/macro

muscle_manager 2023-04-15 20:27:35,753 ERROR   libmuscle.manager.instance_manager: Instance micro quit with error 2
muscle_manager 2023-04-15 20:27:35,753 ERROR   libmuscle.manager.instance_manager: The last error output of this instance was:
muscle_manager 2023-04-15 20:27:35,753 ERROR   libmuscle.manager.instance_manager: 

    INFO:libmuscle.instance:Received peer locations and base settings
    INFO:libmuscle.communicator:Connecting to peer macro at ['tcp:192.168.178.24:37937,[2a02:a46e:fb:1:ec17:81ff:642a:2541]:37937,[2a02:a46e:fb:1:81c2:7bd9:bb99:840c]:37937,192.168.122.1:37937,172.17.0.1:37937']

muscle_manager 2023-04-15 20:27:35,753 ERROR   libmuscle.manager.instance_manager: More output may be found in docs/source/examples/run_reaction_diffusion_python_20230415_202735/instances/micro

     
--------------------------------------------------------------------------------

You can find the full log at
docs/source/examples/run_reaction_diffusion_python_20230415_202735/muscle3_manager.log
```
(I sabotaged the example by adding an `exit(2)`, so there's no useful error output, but if there were, it would have been printed!)