### PR TITLE
Handle instances that quit with 0 before registering

### DIFF
--- a/libmuscle/python/libmuscle/manager/manager.py
+++ b/libmuscle/python/libmuscle/manager/manager.py
@@ -64,7 +64,7 @@ class Manager:
             configuration = self._configuration.as_configuration()
             if self._run_dir is not None:
                 self._instance_manager = InstanceManager(
-                        configuration, self._run_dir)
+                        configuration, self._run_dir, self._instance_registry)
         except ValueError:
             pass
 


### PR DESCRIPTION
This addresses #163 by making the InstanceManager check with the InstanceRegistry that an instance which quit with exit code 0 did register before doing so. If it didn't, that's an error and handled accordingly by shutting down the rest of the simulation and logging an error.

This needs #222 to be merged first.