### PR TITLE
Fix DataConstRef constness

### DIFF
--- a/libmuscle/cpp/src/libmuscle/data.cpp
+++ b/libmuscle/cpp/src/libmuscle/data.cpp
@@ -1039,14 +1039,6 @@ char * Data::as_byte_array() {
 }
 
 void Data::set_dict_item_(
-        uint32_t offset, std::string const & key, DataConstRef const & value
-) {
-    mp_obj_->via.map.ptr[offset].key = msgpack::object(key, *mp_zones_->front());
-    mp_obj_->via.map.ptr[offset].val = msgpack::object(value, *mp_zones_->front());
-    mp_zones_->insert(mp_zones_->end(), value.mp_zones_->cbegin(), value.mp_zones_->cend());
-}
-
-void Data::set_dict_item_(
         uint32_t offset, std::string const & key, Data const & value
 ) {
     mp_obj_->via.map.ptr[offset].key = msgpack::object(key, *mp_zones_->front());

--- a/libmuscle/cpp/src/libmuscle/data.cpp
+++ b/libmuscle/cpp/src/libmuscle/data.cpp
@@ -318,6 +318,26 @@ template DataConstRef DataConstRef::grid<bool>(
 
 #endif
 
+DataConstRef DataConstRef::dict() {
+    DataConstRef dict;
+    dict.init_dict_(0u);
+    return dict;
+}
+
+DataConstRef DataConstRef::list() {
+    DataConstRef list;
+    list.init_list_(0u);
+    return list;
+}
+
+DataConstRef DataConstRef::nils(std::size_t size) {
+    DataConstRef list;
+    list.init_list_(size);
+    for (std::size_t i = 0u; i < size; ++i)
+        list.mp_obj_->via.array.ptr[i].type = msgpack::type::NIL;
+    return list;
+}
+
 DataConstRef::DataConstRef(SettingValue const & value)
     : DataConstRef()
 {
@@ -791,6 +811,26 @@ DataConstRef DataConstRef::grid_dict_() const {
         obj_cache_ = std::make_shared<DataConstRef>(
                 mcp::unpack_data(mp_zones_->at(0), ext.data(), ext.size()));
     return *obj_cache_;
+}
+
+void DataConstRef::set_dict_item_(
+        uint32_t offset, std::string const & key, DataConstRef const & value
+) {
+    mp_obj_->via.map.ptr[offset].key = msgpack::object(key, *mp_zones_->front());
+    mp_obj_->via.map.ptr[offset].val = msgpack::object(value, *mp_zones_->front());
+    mp_zones_->insert(mp_zones_->end(), value.mp_zones_->cbegin(), value.mp_zones_->cend());
+}
+
+void DataConstRef::init_dict_(uint32_t size) {
+    mp_obj_->type = msgpack::type::MAP;
+    mp_obj_->via.map.size = size;
+    mp_obj_->via.map.ptr = zone_alloc_<msgpack::object_kv>(size);
+}
+
+void DataConstRef::init_list_(uint32_t size) {
+    mp_obj_->type = msgpack::type::ARRAY;
+    mp_obj_->via.array.size = size;
+    mp_obj_->via.array.ptr = zone_alloc_<msgpack::object>(size);
 }
 
 /* This is here in the .cpp and instantiated explicitly, because it requires the

--- a/libmuscle/cpp/src/libmuscle/data.hpp
+++ b/libmuscle/cpp/src/libmuscle/data.hpp
@@ -540,13 +540,6 @@ class DataConstRef {
 
         std::vector<double> as_vec_double_() const;
 
-        friend struct msgpack::adaptor::object_with_zone<DataConstRef>;
-        friend struct msgpack::adaptor::pack<DataConstRef>;
-
-        // see comment at Data::init_dict_'s implementation
-        friend class Data;
-        friend bool ::libmuscle::_MUSCLE_IMPL_NS::is_close_port(DataConstRef const &);
-
         bool is_a_grid_() const;
 
         DataConstRef grid_dict_() const;
@@ -596,6 +589,13 @@ class DataConstRef {
         void init_list_(
                 uint32_t offset, Arg const & value,
                 Args const &...args);
+
+        friend struct msgpack::adaptor::object_with_zone<DataConstRef>;
+        friend struct msgpack::adaptor::pack<DataConstRef>;
+
+        // see comment at Data::init_dict_'s implementation
+        friend class Data;
+        friend bool ::libmuscle::_MUSCLE_IMPL_NS::is_close_port(DataConstRef const &);
 };
 
 
@@ -814,10 +814,6 @@ class Data : public DataConstRef {
 
     private:
         // this requires packing, so needs to be non-template
-        void set_dict_item_(
-                uint32_t offset,
-                std::string const & key, DataConstRef const & value);
-
         void set_dict_item_(
                 uint32_t offset,
                 std::string const & key, Data const & value);

--- a/libmuscle/cpp/src/libmuscle/data.hpp
+++ b/libmuscle/cpp/src/libmuscle/data.hpp
@@ -169,6 +169,57 @@ class DataConstRef {
                 std::vector<std::string> const & indexes = {},
                 StorageOrder storage_order = StorageOrder::last_adjacent);
 
+        /** Create a DataConstRef containing an empty dictionary.
+         *
+         * @returns A DataConstRef containing an empty dictionary.
+         */
+        static DataConstRef dict();
+
+        /** Create a DataConstRef of a dictionary with the given keys and values.
+         *
+         * An even number of arguments must be given. The even arguments must be
+         * strings, and are the keys, while the odd arguments are the values.
+         * These are DataConstRef objects, so you can pass those, or a value of
+         * any type representable by DataConstRef.
+         *
+         * Example:
+         *
+         * \code{.cpp}
+         * auto mydict = Data::dict(
+         *     "id", "element1",
+         *     "stress", 12.3,
+         *     "strain", 1.23);
+         * \endcode
+         *
+         * @returns A DataConstRef containing a dictionary with the given keys
+         *          and values.
+         */
+        template <typename... Args>
+        static DataConstRef dict(Args const &... args);
+
+        /** Create a DataConstRef containing an empty list.
+         *
+         * @returns A DataConstRef containing an empty list.
+         */
+        static DataConstRef list();
+
+        /** Create a DataConstRef containing a list of the given size.
+         *
+         * The items in the list will be initialised to the nil value.
+         *
+         * @param size The size of the new list.
+         * @return A DataConstRef containing a list of nil values of length size.
+         */
+        static DataConstRef nils(std::size_t size);
+
+        /** Create a DataConstRef containing a list of the given items.
+         *
+         * Each argument must be either a DataConstRef object, or an object of a
+         * type representable by a DataConstRef object.
+         */
+        template <typename... Args>
+        static DataConstRef list(Args const &... args);
+
         /** Create a DataConstRef object from a SettingValue's value.
          *
          * Note that this will decode to whichever type is stored in the
@@ -502,6 +553,49 @@ class DataConstRef {
 
         template <typename Element>
         DataConstRef grid_data_(Element const * const data, std::size_t num_elems) const;
+
+    private:
+        // this requires packing, so needs to be non-template
+        void set_dict_item_(
+                uint32_t offset,
+                std::string const & key, DataConstRef const & value);
+
+        void init_dict_(uint32_t size);
+
+        template <typename... Args>
+        void init_dict_(
+                uint32_t offset,
+                std::string const & key, DataConstRef const & value,
+                Args const &...args);
+
+        template <typename... Args>
+        void init_dict_(
+                uint32_t offset,
+                std::string const & key, Data const & value,
+                Args const &...args);
+
+        template <typename Arg, typename... Args>
+        void init_dict_(
+                uint32_t offset,
+                std::string const & key, Arg const & value,
+                Args const &...args);
+
+        void init_list_(uint32_t size);
+
+        template <typename... Args>
+        void init_list_(
+                uint32_t offset, DataConstRef const & value,
+                Args const &...args);
+
+        template <typename... Args>
+        void init_list_(
+                uint32_t offset, Data const & value,
+                Args const &...args);
+
+        template <typename Arg, typename... Args>
+        void init_list_(
+                uint32_t offset, Arg const & value,
+                Args const &...args);
 };
 
 
@@ -579,7 +673,6 @@ class Data : public DataConstRef {
          * @returns A Data containing an empty dictionary.
          */
         static Data dict();
-        template <typename... Args>
 
         /** Create a Data containing a dictionary with the given keys and values.
          *
@@ -600,6 +693,7 @@ class Data : public DataConstRef {
          * @returns A Data containing a dictionary with the given keys and
          *          values.
          */
+        template <typename... Args>
         static Data dict(Args const &... args);
 
         /** Create a Data containing an empty list.

--- a/libmuscle/cpp/src/libmuscle/data.tpp
+++ b/libmuscle/cpp/src/libmuscle/data.tpp
@@ -13,6 +13,16 @@
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 
+template <bool B>
+void constness_static_assert_() {
+    // Helper function to get GCC to produce a backtrace telling the user
+    // where their error is. Putting this inline somehow removes the backtrace.
+    static_assert(B,
+        "Putting a DataConstRef into a Data::dict is not allowed,"
+        " because it could allow modifying e.g. a list in the DataConstRef via"
+        " the created Data object. Please use DataConstRef::dict() instead");
+}
+
 template <>
 ymmsl::SettingValue DataConstRef::as<ymmsl::SettingValue>() const;
 
@@ -129,8 +139,7 @@ template <typename... Args>
 void Data::init_dict_(uint32_t offset, std::string const & key, DataConstRef const & value,
                 Args const & ... args)
 {
-    init_dict_(offset + 1, args...);
-    set_dict_item_(offset, key, value);
+    constness_static_assert_<false>();
 }
 
 template <typename... Args>
@@ -153,9 +162,7 @@ void Data::init_dict_(uint32_t offset, std::string const & key, Arg const & valu
 template <typename... Args>
 void Data::init_list_(uint32_t offset, DataConstRef const & value,
                       Args const &...args) {
-    init_list_(offset + 1, args...);
-    mp_obj_->via.array.ptr[offset] = msgpack::object(value, *mp_zones_->front());
-    mp_zones_->insert(mp_zones_->end(), value.mp_zones_->cbegin(), value.mp_zones_->cend());
+    constness_static_assert_<false>();
 }
 
 template <typename... Args>

--- a/libmuscle/cpp/src/libmuscle/data.tpp
+++ b/libmuscle/cpp/src/libmuscle/data.tpp
@@ -38,6 +38,20 @@ T * DataConstRef::zone_alloc_(uint32_t size) {
 }
 
 template <typename... Args>
+DataConstRef DataConstRef::dict(Args const & ... args) {
+    DataConstRef dict;
+    dict.init_dict_(0u, args...);
+    return dict;
+}
+
+template <typename... Args>
+DataConstRef DataConstRef::list(Args const & ... args) {
+    DataConstRef list;
+    list.init_list_(0u, args...);
+    return list;
+}
+
+template <typename... Args>
 Data Data::dict(Args const & ... args) {
     Data dict;
     dict.init_dict_(0u, args...);
@@ -49,6 +63,57 @@ Data Data::list(Args const & ... args) {
     Data list;
     list.init_list_(0u, args...);
     return list;
+}
+
+template <typename... Args>
+void DataConstRef::init_dict_(
+        uint32_t offset, std::string const & key, DataConstRef const & value,
+        Args const & ... args)
+{
+    init_dict_(offset + 1, args...);
+    set_dict_item_(offset, key, value);
+}
+
+template <typename... Args>
+void DataConstRef::init_dict_(
+        uint32_t offset, std::string const & key, Data const & value,
+        Args const & ... args)
+{
+    init_dict_(offset + 1, args...);
+    set_dict_item_(offset, key, value);
+}
+
+template <typename Arg, typename... Args>
+void DataConstRef::init_dict_(
+        uint32_t offset, std::string const & key, Arg const & value,
+        Args const & ... args)
+{
+    init_dict_(offset + 1, args...);
+    mp_obj_->via.map.ptr[offset].key = msgpack::object(key, *mp_zones_->front());
+    mp_obj_->via.map.ptr[offset].val = msgpack::object(value, *mp_zones_->front());
+}
+
+template <typename... Args>
+void DataConstRef::init_list_(
+        uint32_t offset, DataConstRef const & value, Args const &...args) {
+    init_list_(offset + 1, args...);
+    mp_obj_->via.array.ptr[offset] = msgpack::object(value, *mp_zones_->front());
+    mp_zones_->insert(mp_zones_->end(), value.mp_zones_->cbegin(), value.mp_zones_->cend());
+}
+
+template <typename... Args>
+void DataConstRef::init_list_(
+        uint32_t offset, Data const & value, Args const &...args) {
+    init_list_(offset + 1, args...);
+    mp_obj_->via.array.ptr[offset] = msgpack::object(value, *mp_zones_->front());
+    mp_zones_->insert(mp_zones_->end(), value.mp_zones_->cbegin(), value.mp_zones_->cend());
+}
+
+template <typename Arg, typename... Args>
+void DataConstRef::init_list_(
+        uint32_t offset, Arg const & value, Args const &...args) {
+    init_list_(offset + 1, args...);
+    mp_obj_->via.array.ptr[offset] = msgpack::object(value, *mp_zones_->front());
 }
 
 /* Note that we access value's mp_zones_ member here. mp_zones_ is protected,

--- a/libmuscle/cpp/src/libmuscle/mpp_message.cpp
+++ b/libmuscle/cpp/src/libmuscle/mpp_message.cpp
@@ -65,7 +65,7 @@ DataConstRef MPPMessage::encoded() const {
     if (next_timestamp.is_set())
         next_timestamp_data = next_timestamp.get();
 
-    Data msg_dict = Data::dict(
+    DataConstRef msg_dict = DataConstRef::dict(
             "sender", std::string(sender),
             "receiver", std::string(receiver),
             "port_length", port_length_data,

--- a/libmuscle/cpp/src/libmuscle/tests/test_data.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_data.cpp
@@ -136,6 +136,22 @@ TEST(libmuscle_mcp_data, string_value) {
     test<std::string>(std::string("Testing"));
 }
 
+TEST(libmuscle_mcp_dataconstref, dict) {
+    DataConstRef d1(DataConstRef::dict());
+    ASSERT_TRUE(d1.is_a_dict());
+    ASSERT_EQ(d1.size(), 0);
+
+    DataConstRef d2(DataConstRef::dict("a", 1, "b", d1));
+    ASSERT_TRUE(d2.is_a_dict());
+    ASSERT_EQ(d2.size(), 2);
+
+    ASSERT_TRUE(d2["b"].is_a_dict());
+    // d2["b"]["a"] = "test";      // should not compile
+
+    DataConstRef d3(DataConstRef::dict("a", 1, "b", Data::list(1, 2)));
+    ASSERT_TRUE(d3["b"].is_a_list());
+    ASSERT_EQ(d3["b"][1].as<int>(), 2);
+}
 
 TEST(libmuscle_mcp_data, dict) {
     Data d(Data::dict(
@@ -250,6 +266,26 @@ TEST(libmuscle_mcp_data, dict_dataconstref) {
     dict = Data::dict("test", Data());
 }
 
+
+TEST(libmuscle_mcp_dataconstref, list) {
+    DataConstRef l1(DataConstRef::list());
+    ASSERT_TRUE(l1.is_a_list());
+    ASSERT_EQ(l1.size(), 0);
+
+    DataConstRef l2(DataConstRef::nils(3));
+    ASSERT_TRUE(l2.is_a_list());
+    ASSERT_EQ(l2.size(), 3);
+
+    DataConstRef l3(DataConstRef::list(1, l1, l2));
+    ASSERT_TRUE(l3.is_a_list());
+    ASSERT_EQ(l3.size(), 3);
+
+    DataConstRef l4(DataConstRef::list(1, Data::list(1, 2)));
+    ASSERT_TRUE(l4.is_a_list());
+    ASSERT_EQ(l4.size(), 2);
+    ASSERT_EQ(l4[0].as<int>(), 1);
+    ASSERT_EQ(l4[1][0].as<int>(), 1);
+}
 
 TEST(libmuscle_mcp_data, list) {
     Data d(Data::list("test_string", 12, 1.0));
@@ -642,6 +678,71 @@ TEST(libmuscle_mcp_data, byte_array_alloc) {
     ASSERT_EQ(data.size(), test_data.size());
     for (std::size_t i = 0u; i < data.size(); ++i)
         ASSERT_EQ(data.as_byte_array()[i], test_data[i]);
+}
+
+
+// shouldn't compile; passes
+TEST(libmuscle_mcp_data, dataconstref_constness) {
+    DataConstRef dcr1 = Data::list(1);
+    Data d1 = Data::list(dcr1);
+    ASSERT_EQ(d1[0][0].as<int>(), 1);
+    d1[0][0] = 2;
+    ASSERT_EQ(d1[0][0].as<int>(), 2);
+    ASSERT_EQ(dcr1[0].as<int>(), 2);
+}
+
+
+// shouldn't compile; passes
+TEST(libmuscle_mcp_data, dataconstref_data_list) {
+    DataConstRef dcr1(1);
+    DataConstRef dcr2(2);
+
+    DataConstRef dcr3 = Data::list(dcr1, dcr2);
+    ASSERT_EQ(dcr3[0].as<int>(), 1);
+    ASSERT_EQ(dcr3[1].as<int>(), 2);
+}
+
+
+// should pass; doesn't compile
+TEST(libmuscle_mcp_data, dataconstref_dataconstref_list) {
+    DataConstRef dcr1(1);
+    DataConstRef dcr2(2);
+
+    DataConstRef dcr3 = DataConstRef::list(dcr1, dcr2);
+    ASSERT_EQ(dcr3[0].as<int>(), 1);
+    ASSERT_EQ(dcr3[1].as<int>(), 2);
+}
+
+
+// shouldn't compile; passes
+TEST(libmuscle_mcp_data, dataconstref_constness_dict) {
+    DataConstRef dcr1 = Data::dict("a", 1);
+    Data d1 = Data::dict("a", dcr1);
+    ASSERT_EQ(d1["a"]["a"].as<int>(), 1);
+    d1["a"]["a"] = 2;
+    ASSERT_EQ(d1["a"]["a"].as<int>(), 2);
+    ASSERT_EQ(dcr1["a"].as<int>(), 2);
+}
+
+
+// shouldn't compile; passes
+TEST(libmuscle_mcp_data, dataconstref_data_dict) {
+    DataConstRef dcr1(1);
+    DataConstRef dcr2(2);
+
+    DataConstRef dcr3 = Data::list(dcr1, dcr2);
+    ASSERT_EQ(dcr3[0].as<int>(), 1);
+    ASSERT_EQ(dcr3[1].as<int>(), 2);
+}
+
+// should pass; doesn't compile
+TEST(libmuscle_mcp_data, dataconstref_dataconstref_dict) {
+    DataConstRef dcr1(1);
+    DataConstRef dcr2(2);
+
+    DataConstRef dcr3 = DataConstRef::list(dcr1, dcr2);
+    ASSERT_EQ(dcr3[0].as<int>(), 1);
+    ASSERT_EQ(dcr3[1].as<int>(), 2);
 }
 
 

--- a/libmuscle/cpp/src/libmuscle/tests/test_data.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_data.cpp
@@ -262,8 +262,8 @@ TEST(libmuscle_mcp_data, dict_build) {
 
 TEST(libmuscle_mcp_data, dict_dataconstref) {
     // regression test
-    Data dict = Data::dict("test", DataConstRef());
-    dict = Data::dict("test", Data());
+    DataConstRef d1 = DataConstRef::dict("test", DataConstRef());
+    Data d2 = Data::dict("test", Data());
 }
 
 
@@ -409,8 +409,8 @@ TEST(libmuscle_mcp_data, list_list) {
 
 TEST(libmuscle_mcp_data, list_dataconstref) {
     // regression test
-    Data dict = Data::list(DataConstRef());
-    dict = Data::list(Data());
+    DataConstRef l1 = DataConstRef::list(DataConstRef());
+    Data l2 = Data::list(Data());
 }
 
 
@@ -680,30 +680,6 @@ TEST(libmuscle_mcp_data, byte_array_alloc) {
         ASSERT_EQ(data.as_byte_array()[i], test_data[i]);
 }
 
-
-// shouldn't compile; passes
-TEST(libmuscle_mcp_data, dataconstref_constness) {
-    DataConstRef dcr1 = Data::list(1);
-    Data d1 = Data::list(dcr1);
-    ASSERT_EQ(d1[0][0].as<int>(), 1);
-    d1[0][0] = 2;
-    ASSERT_EQ(d1[0][0].as<int>(), 2);
-    ASSERT_EQ(dcr1[0].as<int>(), 2);
-}
-
-
-// shouldn't compile; passes
-TEST(libmuscle_mcp_data, dataconstref_data_list) {
-    DataConstRef dcr1(1);
-    DataConstRef dcr2(2);
-
-    DataConstRef dcr3 = Data::list(dcr1, dcr2);
-    ASSERT_EQ(dcr3[0].as<int>(), 1);
-    ASSERT_EQ(dcr3[1].as<int>(), 2);
-}
-
-
-// should pass; doesn't compile
 TEST(libmuscle_mcp_data, dataconstref_dataconstref_list) {
     DataConstRef dcr1(1);
     DataConstRef dcr2(2);
@@ -713,29 +689,6 @@ TEST(libmuscle_mcp_data, dataconstref_dataconstref_list) {
     ASSERT_EQ(dcr3[1].as<int>(), 2);
 }
 
-
-// shouldn't compile; passes
-TEST(libmuscle_mcp_data, dataconstref_constness_dict) {
-    DataConstRef dcr1 = Data::dict("a", 1);
-    Data d1 = Data::dict("a", dcr1);
-    ASSERT_EQ(d1["a"]["a"].as<int>(), 1);
-    d1["a"]["a"] = 2;
-    ASSERT_EQ(d1["a"]["a"].as<int>(), 2);
-    ASSERT_EQ(dcr1["a"].as<int>(), 2);
-}
-
-
-// shouldn't compile; passes
-TEST(libmuscle_mcp_data, dataconstref_data_dict) {
-    DataConstRef dcr1(1);
-    DataConstRef dcr2(2);
-
-    DataConstRef dcr3 = Data::list(dcr1, dcr2);
-    ASSERT_EQ(dcr3[0].as<int>(), 1);
-    ASSERT_EQ(dcr3[1].as<int>(), 2);
-}
-
-// should pass; doesn't compile
 TEST(libmuscle_mcp_data, dataconstref_dataconstref_dict) {
     DataConstRef dcr1(1);
     DataConstRef dcr2(2);


### PR DESCRIPTION
This fixes the issues reported in #192. It adds the possibility of creating const lists and dicts, and removes the ability to put a `DataConstRef` in a `Data::list` or `Data::dict`.