### PR TITLE
Remove Codacy, it doesn't help

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,3 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         make test
-
-    - name: Upload coverage report to Codacy
-      uses: codacy/codacy-coverage-reporter-action@master
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,6 @@
     :target: https://github.com/multiscale/muscle3/actions
     :alt: Build Status
 
-.. image:: https://app.codacy.com/project/badge/Coverage/4542a84edcd947ee982a0bfabe617089
-    :target: https://www.codacy.com/gh/multiscale/muscle3/dashboard
-    :alt: Code Coverage
-
-.. image:: https://app.codacy.com/project/badge/Grade/4542a84edcd947ee982a0bfabe617089
-    :target: https://www.codacy.com/gh/multiscale/muscle3/dashboard
-    :alt: Codacy Grade
-
 .. image:: https://zenodo.org/badge/122876985.svg
    :target: https://zenodo.org/badge/latestdoi/122876985
 


### PR DESCRIPTION
This removes Codacy from the repository.

It often says that the code is getting worse even if it isn't (sometimes it even claims it's worse if you've cleaned something up), it claims that complexity has gone up every time you add a feature (well, obviously), it likes to send email about that all the time, and it doesn't seem to be making the code better. So I'm removing it. Maybe we'll experiment with something else at some point, or maybe we'll just rely on code reviews to keeps things reasonably tidy.

Fixes #196