### PR TITLE
Fix incorrect LDFLAGS for C++ and Fortran tests

### DIFF
--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -146,8 +146,9 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 $(info pcextra: $(PKG_CONFIG_EXTRA_DIRS))
 CXXFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --cflags msgpack)
 
-LDFLAGS += -pthread -L$(CURDIR)/../ymmsl -lymmsl
-LDFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --libs msgpack)
+LDFLAGS2 = $(LDFLAGS)
+LDFLAGS2 += -pthread -L$(CURDIR)/../ymmsl -lymmsl
+LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --libs msgpack)
 
 # Automatic header dependencies
 -include $(deps)
@@ -207,37 +208,37 @@ libmuscle.a: $(objects)
 	ar rcs $@ $^
 
 libmuscle.so: $(lobjects)
-	$(CXX) -shared -o $@ $^ $(LDFLAGS)
+	$(CXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle.dylib: $(lobjects)
-	$(CXX) -shared -o $@ $^ $(LDFLAGS)
+	$(CXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_d.a: $(dobjects)
 	ar rcs $@ $^
 
 libmuscle_d.so: $(dlobjects)
-	$(CXX) -shared -o $@ $^ $(LDFLAGS)
+	$(CXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_d.dylib: $(dlobjects)
-	$(CXX) -shared -o $@ $^ $(LDFLAGS)
+	$(CXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_mpi.a: $(mobjects)
 	ar rcs $@ $^
 
 libmuscle_mpi.so: $(mlobjects)
-	$(MPICXX) -shared -o $@ $^ $(LDFLAGS)
+	$(MPICXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_mpi.dylib: $(mlobjects)
-	$(MPICXX) -shared -o $@ $^ $(LDFLAGS)
+	$(MPICXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_mpi_d.a: $(mdobjects)
 	ar rcs $@ $^
 
 libmuscle_mpi_d.so: $(mdlobjects)
-	$(MPICXX) -shared -o $@ $^ $(LDFLAGS)
+	$(MPICXX) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_mpi_d.dylib: $(mdlobjects)
-	$(MPICXX) -shared -o $@ $^ $(LDFLAGS)
+	$(MPICXX) -shared -o $@ $^ $(LDFLAGS2)
 
 $(PREFIX)/include/libmuscle/version.h: $(srcdir)/version.h
 	@mkdir -p $(@D)

--- a/libmuscle/cpp/build/libmuscle/tests/Makefile
+++ b/libmuscle/cpp/build/libmuscle/tests/Makefile
@@ -46,6 +46,7 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 EXTRA_LINK_DIRS := $(foreach DIR,$(DEP_DIRS),-Wl,-rpath,$(DIR)/lib)
 
 CXXFLAGS += -I$(libmuscle_testdir) -isystem $(googletest_ROOT)/include -pthread
+CXXFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --cflags msgpack)
 CXXFLAGS += $(DEBUGFLAGS)
 
 LDFLAGS += $(CURDIR)/../libmuscle_d.a $(CURDIR)/../../ymmsl/libymmsl_d.a

--- a/libmuscle/fortran/build/libmuscle/Makefile
+++ b/libmuscle/fortran/build/libmuscle/Makefile
@@ -36,13 +36,15 @@ installed_sources := $(sources:$(srcdir)/%=$(PREFIX)/include/%)
 installed_pkg_config_files := $(pkg_config_files:%=$(PREFIX)/lib/pkgconfig/%)
 
 
-LDFLAGS := -L../ymmsl -lymmsl_fortran
-LDFLAGS += -L../../../cpp/build/libmuscle -lmuscle
-LDFLAGS += -L../../../cpp/build/ymmsl -lymmsl
+LDFLAGS2 := $(LDFLAGS)
+LDFLAGS2 += -L../ymmsl -lymmsl_fortran
+LDFLAGS2 += -L../../../cpp/build/libmuscle -lmuscle
+LDFLAGS2 += -L../../../cpp/build/ymmsl -lymmsl
 
-LDFLAGS_MPI := -L../ymmsl -lymmsl_fortran
-LDFLAGS_MPI += -L../../../cpp/build/libmuscle -lmuscle_mpi
-LDFLAGS_MPI += -L../../../cpp/build/ymmsl -lymmsl
+LDFLAGS2_MPI := $(LDFLAGS_MPI)
+LDFLAGS2_MPI += -L../ymmsl -lymmsl_fortran
+LDFLAGS2_MPI += -L../../../cpp/build/libmuscle -lmuscle_mpi
+LDFLAGS2_MPI += -L../../../cpp/build/ymmsl -lymmsl
 
 FFLAGS := -O3 -I../ymmsl
 ifdef MUSCLE_FC_INTEL
@@ -135,19 +137,19 @@ libmuscle_fortran.a: $(objects)
 	ar rcs $@ $^
 
 libmuscle_fortran.so: $(lobjects)
-	$(FC) -shared -o $@ $^ $(LDFLAGS)
+	$(FC) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_fortran.dylib: $(lobjects)
-	$(FC) -shared -o $@ $^ $(LDFLAGS)
+	$(FC) -shared -o $@ $^ $(LDFLAGS2)
 
 libmuscle_mpi_fortran.a: $(mobjects)
 	ar rcs $@ $^
 
 libmuscle_mpi_fortran.so: $(mlobjects)
-	$(MPIFC) -shared -o $@ $^ $(LDFLAGS_MPI)
+	$(MPIFC) -shared -o $@ $^ $(LDFLAGS2_MPI)
 
 libmuscle_mpi_fortran.dylib: $(mlobjects)
-	$(MPIFC) -shared -o $@ $^ $(LDFLAGS_MPI)
+	$(MPIFC) -shared -o $@ $^ $(LDFLAGS2_MPI)
 
 $(PREFIX)/include/%.f90: $(srcdir)/%.f90
 	@mkdir -p $(@D)

--- a/libmuscle/fortran/build/libmuscle/tests/Makefile
+++ b/libmuscle/fortran/build/libmuscle/tests/Makefile
@@ -47,10 +47,10 @@ endif
 
 CPP_BUILD_DIR := $(CURDIR)/../../../../cpp/build
 
-LDFLAGS += -pthread $(CURDIR)/../libmuscle_fortran.a $(CURDIR)/../../ymmsl/libymmsl_fortran.a
-LDFLAGS += $(CPP_BUILD_DIR)/libmuscle/libmuscle_d.a $(CPP_BUILD_DIR)/ymmsl/libymmsl_d.a
-
 LDFLAGS2 := $(LDFLAGS)
+
+LDFLAGS2 += -pthread $(CURDIR)/../libmuscle_fortran.a $(CURDIR)/../../ymmsl/libymmsl_fortran.a
+LDFLAGS2 += $(CPP_BUILD_DIR)/libmuscle/libmuscle_d.a $(CPP_BUILD_DIR)/ymmsl/libymmsl_d.a
 LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIGPATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --libs msgpack)
 LDFLAGS2 += $(EXTRA_LINK_DIRS)
 LDFLAGS2 += -lstdc++


### PR DESCRIPTION
Should help with #240, and possibly fixes the same issue as #169, but I'm not sure about the latter.