### PR TITLE
Protect manager connection from race conditions in MMPClient

### DIFF
--- a/libmuscle/cpp/src/libmuscle/mmp_client.cpp
+++ b/libmuscle/cpp/src/libmuscle/mmp_client.cpp
@@ -325,6 +325,8 @@ void MMPClient::deregister_instance() {
 }
 
 DataConstRef MMPClient::call_manager_(DataConstRef const & request) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, request);
 

--- a/libmuscle/cpp/src/libmuscle/mmp_client.hpp
+++ b/libmuscle/cpp/src/libmuscle/mmp_client.hpp
@@ -6,6 +6,7 @@
 
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -28,7 +29,9 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
  * This class connects to the Manager and communicates with it on behalf of the
  * rest of libmuscle.
  *
- * It manages the connection, and encodes and decodes MsgPack.
+ * It manages the connection, and encodes and decodes MsgPack. Communication is
+ * protected by an internal mutex, so this class can be called simultaneously
+ * from different threads.
  */
 class MMPClient {
     public:
@@ -123,6 +126,7 @@ class MMPClient {
     private:
         ymmsl::Reference instance_id_;
         mcp::TcpTransportClient transport_client_;
+        mutable std::mutex mutex_;
 
         /* Helper function that encodes/decodes and calls the manager.
          */

--- a/libmuscle/python/libmuscle/mmp_client.py
+++ b/libmuscle/python/libmuscle/mmp_client.py
@@ -1,6 +1,7 @@
 import dataclasses
 from pathlib import Path
 from random import uniform
+from threading import Lock
 from time import perf_counter, sleep
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -106,6 +107,9 @@ class MMPClient():
 
     It manages the connection, and converts between our native types
     and the gRPC generated types.
+
+    Communication is protected by an internal lock, so this class can
+    be called simultaneously from different threads.
     """
     def __init__(self, instance_id: Reference, location: str) -> None:
         """Create an MMPClient
@@ -115,6 +119,7 @@ class MMPClient():
         """
         self._instance_id = instance_id
         self._transport_client = TcpTransportClient(location)
+        self._mutex = Lock()
 
     def close(self) -> None:
         """Close the connection
@@ -280,6 +285,7 @@ class MMPClient():
         Returns:
             The decoded response
         """
-        encoded_request = msgpack.packb(request, use_bin_type=True)
-        response, _ = self._transport_client.call(encoded_request)
-        return msgpack.unpackb(response, raw=False)
+        with self._mutex:
+            encoded_request = msgpack.packb(request, use_bin_type=True)
+            response, _ = self._transport_client.call(encoded_request)
+            return msgpack.unpackb(response, raw=False)


### PR DESCRIPTION
This adds locking around the connection to the manager, which ensures there are no race conditions between log messages being sent to the manager by the main thread, and profiling information being sent to the manager by the profiling communication background thread. 