### PR TITLE
Record DISCONNECT_WAIT in profile

### DIFF
--- a/docs/source/examples/python/Makefile
+++ b/docs/source/examples/python/Makefile
@@ -7,6 +7,7 @@ test:
 	. build/venv/bin/activate && DONTPLOT=1 python3 reaction_diffusion.py
 	. build/venv/bin/activate && DONTPLOT=1 python3 reaction_diffusion_qmc.py
 	. build/venv/bin/activate && DONTPLOT=1 python3 interact_coupling.py
+	. build/venv/bin/activate && DONTPLOT=1 python3 dispatch.py
 
 .PHONY: clean
 clean:

--- a/docs/source/examples/python/dispatch.py
+++ b/docs/source/examples/python/dispatch.py
@@ -1,0 +1,54 @@
+import logging
+import time
+
+from libmuscle import Instance, Message
+from libmuscle.runner import run_simulation
+from ymmsl import (
+        Component, Conduit, Configuration, Model, Operator, Ports, Settings)
+
+
+def buffer() -> None:
+    """A component that passes on its input to its output.
+
+    If the input is not connected, it'll generate a message.
+    """
+    instance = Instance({
+        Operator.F_INIT: ['in'],
+        Operator.O_F: ['out']})
+
+    while instance.reuse_instance():
+        # F_INIT
+        msg = instance.receive('in', default=Message(0.0, data='Testing'))
+
+        # S
+        time.sleep(0.25)
+
+        # O_F
+        instance.send('out', msg)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.INFO)
+
+    components = [
+            Component(
+                'component1', 'buffer', None,
+                Ports(o_f=['out'])),
+            Component(
+                'component2', 'buffer', None,
+                Ports(f_init=['in'], o_f=['out'])),
+            Component(
+                'component3', 'buffer', None,
+                Ports(f_init=['in']))]
+
+    conduits = [
+            Conduit('component1.out', 'component2.in'),
+            Conduit('component2.out', 'component3.in')]
+
+    model = Model('dispatch', components, conduits)
+    settings = Settings({})
+    configuration = Configuration(model, settings)
+
+    implementations = {'buffer': buffer}
+    run_simulation(configuration, implementations)

--- a/libmuscle/cpp/src/libmuscle/communicator.cpp
+++ b/libmuscle/cpp/src/libmuscle/communicator.cpp
@@ -314,7 +314,11 @@ void Communicator::shutdown() {
     for (auto & client : clients_)
         client.second->close();
 
+    ProfileEvent wait_event(ProfileEventType::disconnect_wait, ProfileTimestamp());
+
     post_office_.wait_for_receivers();
+
+    profiler_.record_event(std::move(wait_event));
 
     for (auto & server : servers_)
         server->close();

--- a/libmuscle/cpp/src/libmuscle/profiling.hpp
+++ b/libmuscle/cpp/src/libmuscle/profiling.hpp
@@ -20,12 +20,13 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 enum class ProfileEventType {
     register_ = 0,
     connect = 4,
-    deregister = 1,
     send = 2,
     receive = 3,
     receive_wait = 5,
     receive_transfer = 6,
-    receive_decode = 7
+    receive_decode = 7,
+    disconnect_wait = 8,
+    deregister = 1
 };
 
 

--- a/libmuscle/python/libmuscle/communicator.py
+++ b/libmuscle/python/libmuscle/communicator.py
@@ -413,7 +413,11 @@ class Communicator:
         for client in self._clients.values():
             client.close()
 
+        wait_event = ProfileEvent(ProfileEventType.DISCONNECT_WAIT, ProfileTimestamp())
+
         self._post_office.wait_for_receivers()
+
+        self._profiler.record_event(wait_event)
 
         for server in self._servers:
             server.close()

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -246,10 +246,7 @@ class Instance:
                 self._save_snapshot(None, True, self.__f_init_max_timestamp)
 
         if not do_reuse:
-            self.__close_ports()
-            self._communicator.shutdown()
-            self._deregister()
-            self.__manager.close()
+            self.__shutdown()
 
         self._api_guard.reuse_instance_done(do_reuse)
         return do_reuse
@@ -1251,14 +1248,15 @@ class Instance:
         self.__close_outgoing_ports()
         self.__close_incoming_ports()
 
-    def __shutdown(self, message: str) -> None:
+    def __shutdown(self, message: Optional[str] = None) -> None:
         """Shuts down simulation.
 
-        This logs the given error message, communicates to the peers
-        that we're shutting down, and deregisters from the manager.
+        This logs the given error message, if any, communicates to the
+        peers that we're shutting down, and deregisters from the manager.
         """
         if not self.__is_shut_down:
-            _logger.critical(message)
+            if message is not None:
+                _logger.critical(message)
             self.__close_ports()
             self._communicator.shutdown()
             self._deregister()

--- a/libmuscle/python/libmuscle/manager/profile_store.py
+++ b/libmuscle/python/libmuscle/manager/profile_store.py
@@ -194,7 +194,7 @@ class ProfileStore(ProfileDatabase):
                 "    minor_version INTEGER NOT NULL)")
         cur.execute(
                 "INSERT INTO muscle3_format(major_version, minor_version)"
-                "    VALUES (1, 0)")
+                "    VALUES (1, 1)")
 
         cur.execute(
                 "CREATE TABLE instances ("

--- a/libmuscle/python/libmuscle/manager/test/test_profile_store.py
+++ b/libmuscle/python/libmuscle/manager/test/test_profile_store.py
@@ -18,7 +18,7 @@ def test_create_profile_store(tmp_path):
     cur.execute("SELECT major_version, minor_version FROM muscle3_format")
     major, minor = cur.fetchone()
     assert major == 1
-    assert minor == 0
+    assert minor == 1
 
     cur.execute("SELECT oid, name FROM event_types")
     etypes = cur.fetchall()

--- a/libmuscle/python/libmuscle/profiling.py
+++ b/libmuscle/python/libmuscle/profiling.py
@@ -9,12 +9,13 @@ class ProfileEventType(Enum):
     """Profiling event types for MUSCLE3."""
     REGISTER = 0
     CONNECT = 4
-    DEREGISTER = 1
     SEND = 2
     RECEIVE = 3
     RECEIVE_WAIT = 5
     RECEIVE_TRANSFER = 6
     RECEIVE_DECODE = 7
+    DISCONNECT_WAIT = 8
+    DEREGISTER = 1
 
 
 class ProfileTimestamp:

--- a/muscle3/profiling.py
+++ b/muscle3/profiling.py
@@ -97,13 +97,14 @@ def plot_resources(performance_file: Path) -> None:
 
 
 _EVENT_TYPES = (
-        'REGISTER', 'CONNECT', 'DEREGISTER',
+        'REGISTER', 'CONNECT', 'DISCONNECT_WAIT', 'DEREGISTER',
         'SEND', 'RECEIVE_WAIT', 'RECEIVE_TRANSFER', 'RECEIVE_DECODE')
 
 
 _EVENT_PALETTE = {
         'REGISTER': '#910f33',
         'CONNECT': '#c85172',
+        'DISCONNECT_WAIT': '#eedddd',
         'DEREGISTER': '#910f33',
         'RECEIVE_WAIT': '#cccccc',
         'RECEIVE_TRANSFER': '#ff7d00',
@@ -193,9 +194,16 @@ class TimelinePlot:
         for event_type in _EVENT_TYPES:
             instances, start_times, durations, cutoff = self.get_data(
                     event_type, xmin, self._global_xmax)
+
+            if not instances:
+                # Work around https://github.com/matplotlib/matplotlib/issues/21506
+                instances = ['']
+                start_times = [float('NaN')]
+                durations = [float('NaN')]
+
             self._bars[event_type] = ax.barh(
-                    instances[0:_MAX_EVENTS], durations[0:_MAX_EVENTS], _BAR_WIDTH,
-                    label=event_type, left=start_times[0:_MAX_EVENTS],
+                    instances, durations, _BAR_WIDTH,
+                    label=event_type, left=start_times,
                     color=_EVENT_PALETTE[event_type])
             if cutoff:
                 first_cutoff = min(first_cutoff, cutoff)

--- a/muscle3/profiling.py
+++ b/muscle3/profiling.py
@@ -297,18 +297,19 @@ class TimelinePlot:
                 for i in range(n_cur, n_avail):
                     bars[i].set_visible(False)
 
-            # update cutoff bars
-            bars = self._bars['_CUTOFF'].patches
-            if cutoff:
-                for bar in bars:
-                    bar.set_x(cutoff)
-                    bar.set_width(self._global_xmax - cutoff)
-                    bar.set_visible(True)
-                self._cutoff_warning.set_visible(True)
-            else:
-                for bar in bars:
-                    bar.set_visible(False)
-                self._cutoff_warning.set_visible(False)
+            # update cutoff bars, if any
+            if '_CUTOFF' in self._bars:
+                bars = self._bars['_CUTOFF'].patches
+                if cutoff:
+                    for bar in bars:
+                        bar.set_x(cutoff)
+                        bar.set_width(self._global_xmax - cutoff)
+                        bar.set_visible(True)
+                    self._cutoff_warning.set_visible(True)
+                else:
+                    for bar in bars:
+                        bar.set_visible(False)
+                    self._cutoff_warning.set_visible(False)
 
 
 tplot = None    # type: Optional[TimelinePlot]


### PR DESCRIPTION
This adds a new profiling event called DISCONNECT_WAIT, which measures the time between the moment we close our ports, and the moment the corresponding ClosePort messages have been picked up by our peers and we can continue to shut down. Previously, the component showed as running during this time in the timeline plot, which is not correct, it's waiting.

The plotting code has been adapted to use it when available, and the database format version is incremented to 1.1. Version 1.0 databases remain supported, but will continue to give the old incorrect results. 

This also adds a new example of a three-component dispatch chain, which produces nice test data, and fixes a bug with the timeline plot in case the database is small enough that we'll never have a data cutoff.

Addresses #254.