### PR TITLE
Improve profiling of simulation shutdown

### DIFF
--- a/docs/source/examples/.gitignore
+++ b/docs/source/examples/.gitignore
@@ -1,3 +1,4 @@
 rd_implementations.ymmsl
 benchmark_implementations.ymmsl
+dispatch_implementations.ymmsl
 run_*

--- a/docs/source/examples/Makefile
+++ b/docs/source/examples/Makefile
@@ -69,7 +69,7 @@ endif
 
 
 .PHONY: base
-base: python rd_implementations.ymmsl benchmark_implementations.ymmsl
+base: python rd_implementations.ymmsl benchmark_implementations.ymmsl dispatch_implementations.ymmsl
 
 
 
@@ -106,6 +106,7 @@ clean:
 	$(MAKE) -C python clean
 	rm -f rd_implementations.ymmsl
 	rm -f benchmark_implementations.ymmsl
+	rm -f dispatch_implementations.ymmsl
 	rm -rf run_*/
 
 
@@ -129,6 +130,7 @@ test_cpp: base cpp
 		$$(ls $$(ls -d run_checkpointing_reaction_diffusion_cpp* | tail -n1)/snapshots/*.ymmsl | head -n1)
 	. python/build/venv/bin/activate && muscle_manager --start-all rd_implementations.ymmsl rd_python_cpp.ymmsl rd_settings.ymmsl
 	. python/build/venv/bin/activate && muscle_manager --start-all rd_implementations.ymmsl rdmc_cpp.ymmsl rdmc_settings.ymmsl
+	. python/build/venv/bin/activate && muscle_manager --start-all dispatch_implementations.ymmsl dispatch_cpp.ymmsl
 
 .PHONY: test_cpp_mpi
 test_cpp_mpi: base cpp_mpi

--- a/docs/source/examples/cpp/buffer.cpp
+++ b/docs/source/examples/cpp/buffer.cpp
@@ -1,0 +1,31 @@
+#include "libmuscle/libmuscle.hpp"
+#include "ymmsl/ymmsl.hpp"
+
+#include "unistd.h"
+
+
+using libmuscle::Data;
+using libmuscle::Instance;
+using libmuscle::Message;
+using ymmsl::Operator;
+
+
+int main(int argc, char * argv[]) {
+    Instance instance(argc, argv, {
+            {Operator::F_INIT, {"in"}},
+            {Operator::O_F, {"out"}}});
+
+    while (instance.reuse_instance()) {
+        // F_INIT
+        Message msg = instance.receive("in", Message(0.0, Data("Testing")));
+
+        // S
+        usleep(250000);
+
+        // O_F
+        instance.send("out", msg);
+    }
+
+    return 0;
+}
+

--- a/docs/source/examples/cpp/build/Makefile
+++ b/docs/source/examples/cpp/build/Makefile
@@ -5,7 +5,9 @@ MPI_CXXFLAGS := -std=c++14 -g $(shell pkg-config --cflags libmuscle_mpi ymmsl)
 MPI_LDFLAGS := $(shell pkg-config --libs libmuscle_mpi ymmsl)
 
 
-binaries := reaction diffusion mc_driver load_balancer checkpointing_reaction checkpointing_diffusion benchmark
+binaries := reaction diffusion mc_driver load_balancer
+binaries += checkpointing_reaction checkpointing_diffusion
+binaries += benchmark buffer
 mpi_binaries := reaction_mpi
 
 

--- a/docs/source/examples/dispatch_cpp.ymmsl
+++ b/docs/source/examples/dispatch_cpp.ymmsl
@@ -1,0 +1,34 @@
+ymmsl_version: v0.1
+
+model:
+  name: dispatch_cpp
+
+  components:
+    component1:
+      implementation: buffer_cpp
+      ports:
+        o_f: out
+
+    component2:
+      implementation: buffer_cpp
+      ports:
+        f_init: in
+        o_f: out
+
+    component3:
+      implementation: buffer_cpp
+      ports:
+        f_init: in
+
+  conduits:
+    component1.out: component2.in
+    component2.out: component3.in
+
+resources:
+  component1:
+    threads: 1
+  component2:
+    threads: 1
+  component3:
+    threads: 1
+

--- a/docs/source/examples/dispatch_implementations.ymmsl.in
+++ b/docs/source/examples/dispatch_implementations.ymmsl.in
@@ -1,0 +1,8 @@
+ymmsl_version: v0.1
+
+implementations:
+  buffer_cpp:
+    env:
+      +LD_LIBRARY_PATH: :MUSCLE3_HOME/lib
+    executable: MUSCLE3_EXAMPLES/cpp/build/buffer
+

--- a/libmuscle/cpp/src/libmuscle/communicator.cpp
+++ b/libmuscle/cpp/src/libmuscle/communicator.cpp
@@ -315,13 +315,13 @@ void Communicator::shutdown() {
         client.second->close();
 
     ProfileEvent wait_event(ProfileEventType::disconnect_wait, ProfileTimestamp());
-
     post_office_.wait_for_receivers();
-
     profiler_.record_event(std::move(wait_event));
 
+    ProfileEvent shutdown_event(ProfileEventType::shutdown, ProfileTimestamp());
     for (auto & server : servers_)
         server->close();
+    profiler_.record_event(std::move(shutdown_event));
 }
 
 Communicator::PortMessageCounts Communicator::get_message_counts() {

--- a/libmuscle/cpp/src/libmuscle/instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/instance.cpp
@@ -849,11 +849,16 @@ bool Instance::Impl::have_f_init_connections_() {
  * @return true iff no ClosePort messages were received.
  */
 bool Instance::Impl::pre_receive_() {
+    ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
+
     bool all_ports_open = receive_settings_();
     pre_receive_f_init_();
     for (auto const & ref_msg : f_init_cache_)
         if (is_close_port(ref_msg.second.data()))
                 all_ports_open = false;
+
+    if (!all_ports_open)
+        profiler_->record_event(std::move(sw_event));
     return all_ports_open;
 }
 

--- a/libmuscle/cpp/src/libmuscle/profiling.hpp
+++ b/libmuscle/cpp/src/libmuscle/profiling.hpp
@@ -25,7 +25,9 @@ enum class ProfileEventType {
     receive_wait = 5,
     receive_transfer = 6,
     receive_decode = 7,
+    shutdown_wait = 9,
     disconnect_wait = 8,
+    shutdown = 10,
     deregister = 1
 };
 

--- a/libmuscle/python/libmuscle/communicator.py
+++ b/libmuscle/python/libmuscle/communicator.py
@@ -414,13 +414,13 @@ class Communicator:
             client.close()
 
         wait_event = ProfileEvent(ProfileEventType.DISCONNECT_WAIT, ProfileTimestamp())
-
         self._post_office.wait_for_receivers()
-
         self._profiler.record_event(wait_event)
 
+        shutdown_event = ProfileEvent(ProfileEventType.SHUTDOWN, ProfileTimestamp())
         for server in self._servers:
             server.close()
+        self._profiler.record_event(shutdown_event)
 
     def restore_message_counts(self, port_message_counts: Dict[str, List[int]]
                                ) -> None:

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -1005,11 +1005,17 @@ class Instance:
         Returns:
             True iff no ClosePort messages were received.
         """
+        sw_event = ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, ProfileTimestamp())
+
         all_ports_open = self.__receive_settings()
         self.__pre_receive_f_init()
         for message in self._f_init_cache.values():
             if isinstance(message.data, ClosePort):
                 all_ports_open = False
+
+        if not all_ports_open:
+            self._profiler.record_event(sw_event)
+
         return all_ports_open
 
     def __receive_settings(self) -> bool:

--- a/libmuscle/python/libmuscle/manager/profile_database.py
+++ b/libmuscle/python/libmuscle/manager/profile_database.py
@@ -103,7 +103,7 @@ class ProfileDatabase:
         cur.execute(
                 "SELECT instance, start_time"
                 " FROM all_events"
-                " WHERE type = 'DISCONNECT_WAIT'")
+                " WHERE type = 'SHUTDOWN_WAIT'")
         stop_run = dict(cur.fetchall())
 
         if not stop_run:

--- a/libmuscle/python/libmuscle/profiling.py
+++ b/libmuscle/python/libmuscle/profiling.py
@@ -14,7 +14,9 @@ class ProfileEventType(Enum):
     RECEIVE_WAIT = 5
     RECEIVE_TRANSFER = 6
     RECEIVE_DECODE = 7
+    SHUTDOWN_WAIT = 9
     DISCONNECT_WAIT = 8
+    SHUTDOWN = 10
     DEREGISTER = 1
 
 

--- a/muscle3/profiling.py
+++ b/muscle3/profiling.py
@@ -97,14 +97,16 @@ def plot_resources(performance_file: Path) -> None:
 
 
 _EVENT_TYPES = (
-        'REGISTER', 'CONNECT', 'DISCONNECT_WAIT', 'DEREGISTER',
-        'SEND', 'RECEIVE_WAIT', 'RECEIVE_TRANSFER', 'RECEIVE_DECODE')
+        'REGISTER', 'CONNECT', 'SHUTDOWN_WAIT', 'DISCONNECT_WAIT', 'SHUTDOWN',
+        'DEREGISTER', 'SEND', 'RECEIVE_WAIT', 'RECEIVE_TRANSFER', 'RECEIVE_DECODE')
 
 
 _EVENT_PALETTE = {
         'REGISTER': '#910f33',
         'CONNECT': '#c85172',
+        'SHUTDOWN_WAIT': '#ffdddd',
         'DISCONNECT_WAIT': '#eedddd',
+        'SHUTDOWN': '#c85172',
         'DEREGISTER': '#910f33',
         'RECEIVE_WAIT': '#cccccc',
         'RECEIVE_TRANSFER': '#ff7d00',
@@ -171,6 +173,11 @@ class TimelinePlot:
 
         instances = sorted(begin_times.keys())
         self._instances = instances
+
+        if not begin_times:
+            raise RuntimeError(
+                    'This database appears to be empty. Did the simulation crash'
+                    ' before any data were generated?')
 
         # Rest of plot
         ax.set_title('Execution timeline')

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10'],
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'],
 
     packages=_muscle3_packages,
     package_dir={


### PR DESCRIPTION
This addresses #263, and on top of that also adds a SHUTDOWN event covering shutting down the network servers, which takes tens of milliseconds and could confusingly show up as busy.

The not-yet documented Python dispatch example gets a C++ version in this PR, which I used to test. One day we'll add a Fortran version and make it official :smile: