### PR TITLE
Fix and improve profiling

### DIFF
--- a/libmuscle/cpp/src/libmuscle/tests/test_instance.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_instance.cpp
@@ -337,6 +337,8 @@ TEST(libmuscle_instance, receive_parallel_universe) {
     port.set_closed();
     MockCommunicator::get_port_return_value.emplace("in", port);
 
+    MockCommunicator::settings_in_connected_return_value = true;
+
     Settings recv_settings;
     recv_settings["test1"] = 12;
     MockCommunicator::next_received_message["in"] =

--- a/libmuscle/python/libmuscle/manager/test/test_profile_database.py
+++ b/libmuscle/python/libmuscle/manager/test/test_profile_database.py
@@ -48,7 +48,8 @@ def db_file(tmp_path) -> Path:
                 ProfileEvent(
                     ProfileEventType.SEND, t(2600), t(2900),
                     Port('out', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(ProfileEventType.DEREGISTER, t(10000), t(11000))]
+                ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, t(10000), t(11000)),
+                ProfileEvent(ProfileEventType.DEREGISTER, t(11000), t(11100))]
 
         store.add_events(Reference('instance1'), e1)
 
@@ -73,7 +74,8 @@ def db_file(tmp_path) -> Path:
                 ProfileEvent(
                     ProfileEventType.RECEIVE_WAIT, t(2600), t(2870),
                     Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(ProfileEventType.DEREGISTER, t(10000), t(11000))]
+                ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, t(10000), t(11000)),
+                ProfileEvent(ProfileEventType.DEREGISTER, t(11000), t(11100))]
 
         store.add_events(Reference('instance2'), e2)
 
@@ -126,12 +128,12 @@ def test_resource_stats(db_file):
 def test_time_taken(db_file):
     with ProfileDatabase(db_file) as db:
         assert 1000.0 == db.time_taken(etype='REGISTER', instance='instance1')
-        assert 1000.0 == db.time_taken(etype='DEREGISTER')
-        assert 11000.0 == db.time_taken(
+        assert 100.0 == db.time_taken(etype='DEREGISTER')
+        assert 11100.0 == db.time_taken(
                 etype='REGISTER', instance='instance1', etype2='DEREGISTER')
-        assert 9000.0 == db.time_taken(
+        assert 10000.0 == db.time_taken(
                 etype='REGISTER', instance='instance1', time='stop',
                 etype2='DEREGISTER', time2='start')
         assert 200.0 == db.time_taken(etype='SEND')
-        assert 2000.0 == db.time_taken(etype='DEREGISTER', aggregate='sum')
+        assert 200.0 == db.time_taken(etype='DEREGISTER', aggregate='sum')
         assert 600.0 == db.time_taken(etype='SEND', aggregate='sum')

--- a/libmuscle/python/libmuscle/test/test_instance.py
+++ b/libmuscle/python/libmuscle/test/test_instance.py
@@ -78,8 +78,9 @@ def instance(sys_argv_instance, tmp_path, overlay_settings):
         msg = Message(0.0, 1.0, 'message')
         msg_with_settings = Message(0.0, 1.0, 'message', overlay_settings)
 
-        def receive_message(name, slot, default):
+        def receive_message(name, slot, default=None):
             if 'not_connected' in name:
+                assert default is not None
                 return default, 10.0
             if 'settings' in name:
                 return msg_with_settings, 10.0


### PR DESCRIPTION
This ensures that a `SHUTDOWN_WAIT` event is also added to the database if there's no need to wait because we have no incoming ports. It also makes the profiling tools more robust against missing events, for example in the event of a crash.

Addresses #274.