### PR TITLE
Replace the unmaintained netifaces with psutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'click>=7.1,<9',
         'matplotlib>=3,<4',
         'msgpack>=1,<2',
-        'netifaces==0.11.0',
+        'psutil>=5.0.0',
         "numpy<1.22; python_version=='3.7'",
         "numpy>=1.22; python_version>='3.8'",
         'qcg-pilotjob==0.13.1',

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     flake8
     pytest
     pytest-cov
+    types-psutil
     ymmsl
 
 passenv =


### PR DESCRIPTION
This removes `netifaces` as a dependency and uses `psutil` instead. Addresses #282.