### PR TITLE
Feature/unit test cleanup threads

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+import threading
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def assert_no_threads_left():
+    assert len(threading.enumerate()) == 1
+    yield
+    assert len(threading.enumerate()) == 1

--- a/libmuscle/python/libmuscle/manager/instance_manager.py
+++ b/libmuscle/python/libmuscle/manager/instance_manager.py
@@ -4,7 +4,7 @@ from textwrap import indent
 from threading import Thread
 from typing import Dict, List, Optional, Tuple, Union
 from multiprocessing import Queue
-import queue
+from queue import Empty
 
 from ymmsl import Configuration, Reference
 
@@ -48,7 +48,7 @@ class LogHandlingThread(Thread):
                 record = self._queue.get(True, 0.1)
                 logger = logging.getLogger(record.name)
                 logger.handle(record)
-            except queue.Empty:
+            except Empty:
                 if self._shutting_down:
                     break
 
@@ -277,4 +277,11 @@ class InstanceManager:
         self._instantiator.join()
         self._log_handler.shutdown()
         self._log_handler.join()
+        # Close multiprocessing.Queues and ensure their feeder threads exit
+        queues: List[Queue] = [
+                self._resources_in, self._requests_out,
+                self._results_in, self._log_records_in]
+        for queue in queues:
+            queue.close()
+            queue.join_thread()
         _logger.debug('Instance manager shut down cleanly')

--- a/libmuscle/python/libmuscle/manager/manager.py
+++ b/libmuscle/python/libmuscle/manager/manager.py
@@ -133,13 +133,12 @@ class Manager:
         Returns:
             True if success, False if an error occurred.
         """
-        if self._instance_manager:
-            try:
+        try:
+            if self._instance_manager:
                 success = self._instance_manager.wait()
-            finally:
-                self._instance_manager.shutdown()
-        else:
-            self._instance_registry.wait()
-            success = True
-        self.stop()
+            else:
+                self._instance_registry.wait()
+                success = True
+        finally:
+            self.stop()
         return success

--- a/libmuscle/python/libmuscle/manager/test/conftest.py
+++ b/libmuscle/python/libmuscle/manager/test/conftest.py
@@ -36,7 +36,7 @@ def mmp_configuration():
 def profile_store(tmp_path):
     test_profile_store = ProfileStore(tmp_path)
     yield test_profile_store
-    test_profile_store.close()
+    test_profile_store.shutdown()
 
 
 @pytest.fixture

--- a/libmuscle/python/libmuscle/manager/test/test_profile_store.py
+++ b/libmuscle/python/libmuscle/manager/test/test_profile_store.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 def test_create_profile_store(tmp_path):
     db = ProfileStore(tmp_path)
-    db.close()
+    db.shutdown()
 
     db_path = tmp_path / 'performance.sqlite'
     conn = sqlite3.connect(db_path, isolation_level=None)
@@ -114,4 +114,4 @@ def test_add_events(tmp_path):
 
     cur.close()
     conn.close()
-    db.close()
+    db.shutdown()

--- a/libmuscle/python/libmuscle/test/test_instance.py
+++ b/libmuscle/python/libmuscle/test/test_instance.py
@@ -142,7 +142,8 @@ def instance_dont_apply_overlay(
 def test_create_instance_manager_location_default(
         instance_argv, MMPClient, declared_ports):
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
+    instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
     MMPClient.assert_called_once_with(Ref('component'), 'tcp:localhost:9000')
 
@@ -150,7 +151,8 @@ def test_create_instance_manager_location_default(
 def test_create_instance_manager_location_argv(
         manager_location_argv, instance_argv, MMPClient, declared_ports):
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
+    instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
     MMPClient.assert_called_once_with(Ref('component'), 'tcp:localhost:9001')
 
@@ -158,7 +160,8 @@ def test_create_instance_manager_location_argv(
 def test_create_instance_manager_location_envvar(
         manager_location_envvar, instance_envvar, MMPClient, declared_ports):
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
+    instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
     MMPClient.assert_called_once_with(Ref('component[13]'), 'tcp:localhost:9002')
 
@@ -167,7 +170,8 @@ def test_create_instance_registration(
         manager_location_argv, instance_argv, mmp_client, communicator, port_manager,
         profiler, declared_ports):
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
+    instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
     locations = communicator.get_locations.return_value
 
@@ -195,9 +199,10 @@ def test_create_instance_registration(
 def test_create_instance_profiling(
         manager_location_argv, instance_argv, profiler, declared_ports):
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
 
     assert len(profiler.record_event.mock_calls) == 2
+    instance.error_shutdown("Ensure all threads and resources are cleaned up")
 
 
 def test_create_instance_connecting(
@@ -214,7 +219,7 @@ def test_create_instance_connecting(
     settings = MagicMock()
     mmp_client.get_settings.return_value = settings
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
 
     port_manager.connect_ports.assert_called_once()
     peer_info = port_manager.connect_ports.call_args[0][0]
@@ -227,13 +232,14 @@ def test_create_instance_connecting(
     assert communicator.set_peer_info.call_args[0][0] == peer_info
 
     assert settings_manager.base == settings
+    instance.error_shutdown("Ensure all threads and resources are cleaned up")
 
 
 def test_create_instance_set_up_checkpointing(
         manager_location_argv, instance_argv, mmp_client, trigger_manager,
         no_resume_snapshot_manager, settings_manager, declared_ports):
 
-    Instance(declared_ports)
+    instance = Instance(declared_ports)
 
     elapsed_time, checkpoints, resume_path, snapshot_path = (
             mmp_client.get_checkpoint_info.return_value)
@@ -242,6 +248,7 @@ def test_create_instance_set_up_checkpointing(
     no_resume_snapshot_manager.prepare_resume.assert_called_with(
             resume_path, snapshot_path)
     assert settings_manager.overlay != no_resume_snapshot_manager.resume_overlay
+    instance.error_shutdown("Ensure all threads and resources are cleaned up")
 
 
 def test_create_instance_set_up_logging(
@@ -272,6 +279,7 @@ def test_create_instance_set_up_logging(
         root_logger.setLevel.assert_called_with(logging.ERROR)
         libmuscle_logger.setLevel.assert_called_with(logging.DEBUG)
         ymmsl_logger.setLevel.assert_called_with(logging.DEBUG)
+    instance.error_shutdown("Ensure all threads and resources are cleaned up")
 
 
 def test_shutdown_instance(
@@ -540,4 +548,5 @@ def test_checkpoint_support(
     mmp_client.get_checkpoint_info.return_value = checkpoint_info
 
     with expectation:
-        Instance(flags=flags)
+        instance = Instance(flags=flags)
+        instance.error_shutdown("Ensure all threads and resources are cleaned up")


### PR DESCRIPTION
This PR adds a fixture to check that no threads are left running after every test.

It also fixes every case where threads were left running, and thereby prevents the following `DeprecationWarning`:

```
DeprecationWarning: This process (pid=......) is multi-threaded, use of fork() may lead to deadlocks in the child.
```