### PR TITLE
Proposed fix for issue #321 (Upgraded GoogleTest)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ docs/source/examples/*.log
 docs/source/examples/python/performance.sqlite
 
 libmuscle/python/libmuscle/version.py
-
-# Build Artifact from `build cpp`
-libmuscle/cpp/src/libmuscle/version.h-e

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/source/examples/python/performance.sqlite
 libmuscle/python/libmuscle/version.py
 
 libmuscle/cpp/src/libmuscle/version.h-e
+cpp_tests_std*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.egg-info
 *.eggs
 
+.vscode/
+
+
 /dist
 /build
 .tox

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 *.eggs
 
+# Editor environment
 .vscode/
 
 
@@ -25,4 +26,5 @@ docs/source/examples/python/performance.sqlite
 
 libmuscle/python/libmuscle/version.py
 
+# Build Artifact from `build cpp`
 libmuscle/cpp/src/libmuscle/version.h-e

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ docs/source/examples/*.log
 docs/source/examples/python/performance.sqlite
 
 libmuscle/python/libmuscle/version.py
+
+libmuscle/cpp/src/libmuscle/version.h-e

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .pytest_cache
 .mypy_cache
 *.swp
+*.log
 
 htmlcov
 .coverage
@@ -25,4 +26,3 @@ docs/source/examples/python/performance.sqlite
 libmuscle/python/libmuscle/version.py
 
 libmuscle/cpp/src/libmuscle/version.h-e
-cpp_tests_std*

--- a/.gitignore
+++ b/.gitignore
@@ -2,18 +2,12 @@
 *.egg-info
 *.eggs
 
-# Editor environment
-.vscode/
-
-
 /dist
 /build
 .tox
 .cache
 .pytest_cache
 .mypy_cache
-*.swp
-*.log
 
 htmlcov
 .coverage

--- a/libmuscle/cpp/build/Makefile
+++ b/libmuscle/cpp/build/Makefile
@@ -36,7 +36,7 @@ include $(TOOLDIR)/make_available.make
 
 dep_name := googletest
 dep_version_constraint := >= 1.8.1
-dep_version := 1.12.1
+dep_version := 1.17.0
 dep_pkgconfig_name := gtest
 dep_install := 0
 include $(TOOLDIR)/make_available.make

--- a/libmuscle/cpp/build/Makefile
+++ b/libmuscle/cpp/build/Makefile
@@ -36,7 +36,7 @@ include $(TOOLDIR)/make_available.make
 
 dep_name := googletest
 dep_version_constraint := >= 1.8.1
-dep_version := 1.17.0
+dep_version := 1.15.2
 dep_pkgconfig_name := gtest
 dep_install := 0
 include $(TOOLDIR)/make_available.make

--- a/libmuscle/cpp/build/googletest/Makefile
+++ b/libmuscle/cpp/build/googletest/Makefile
@@ -11,15 +11,13 @@ distclean: clean
 	rm -f release-*.tar.gz
 
 
-release-$(googletest_VERSION).tar.gz:
+googletest-$(googletest_VERSION).tar.gz:
 	$(DOWNLOAD) https://github.com/google/googletest/releases/download/v$(googletest_VERSION)/googletest-$(googletest_VERSION).tar.gz
-	mv googletest-$(googletest_VERSION).tar.gz release-$(googletest_VERSION).tar.gz
 
-googletest-release-$(googletest_VERSION): release-$(googletest_VERSION).tar.gz
-	$(TAR) xf release-$(googletest_VERSION).tar.gz
+googletest-release-$(googletest_VERSION): googletest-$(googletest_VERSION).tar.gz
+	$(TAR) xf googletest-$(googletest_VERSION).tar.gz
 
-googletest: release-$(googletest_VERSION).tar.gz
-	tar xf release-$(googletest_VERSION).tar.gz
+googletest: googletest-release-$(googletest_VERSION)
 	cd googletest-$(googletest_VERSION) && mkdir -p build
 	cd googletest-$(googletest_VERSION)/build && cmake -DCMAKE_INSTALL_PREFIX=$(CURDIR)/googletest ..
 	cd googletest-$(googletest_VERSION)/build && $(MAKE) -j $(NCORES) && make install

--- a/libmuscle/cpp/build/googletest/Makefile
+++ b/libmuscle/cpp/build/googletest/Makefile
@@ -12,13 +12,14 @@ distclean: clean
 
 
 release-$(googletest_VERSION).tar.gz:
-	$(DOWNLOAD) https://github.com/google/googletest/archive/release-$(googletest_VERSION).tar.gz
+	$(DOWNLOAD) https://github.com/google/googletest/releases/download/v$(googletest_VERSION)/googletest-$(googletest_VERSION).tar.gz
+	mv googletest-$(googletest_VERSION).tar.gz release-$(googletest_VERSION).tar.gz
 
 googletest-release-$(googletest_VERSION): release-$(googletest_VERSION).tar.gz
 	$(TAR) xf release-$(googletest_VERSION).tar.gz
 
-googletest: googletest-release-$(googletest_VERSION)
-	cd googletest-release-$(googletest_VERSION) && mkdir -p build
-	cd googletest-release-$(googletest_VERSION)/build && cmake -DCMAKE_INSTALL_PREFIX=$(CURDIR)/googletest ..
-	cd googletest-release-$(googletest_VERSION)/build && $(MAKE) -j $(NCORES) && make install
-
+googletest: release-$(googletest_VERSION).tar.gz
+	tar xf release-$(googletest_VERSION).tar.gz
+	cd googletest-$(googletest_VERSION) && mkdir -p build
+	cd googletest-$(googletest_VERSION)/build && cmake -DCMAKE_INSTALL_PREFIX=$(CURDIR)/googletest ..
+	cd googletest-$(googletest_VERSION)/build && $(MAKE) -j $(NCORES) && make install

--- a/libmuscle/cpp/build/googletest/Makefile
+++ b/libmuscle/cpp/build/googletest/Makefile
@@ -3,12 +3,12 @@ all: googletest
 
 .PHONY: clean
 clean:
-	rm -rf googletest-release-*
+	rm -rf googletest-*
 	rm -rf googletest
 
 .PHONY: distclean
 distclean: clean
-	rm -f release-*.tar.gz
+	rm -f googletest-*.tar.gz
 
 
 googletest-$(googletest_VERSION).tar.gz:

--- a/temp.sh
+++ b/temp.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Because I hate writing this over and over again
-# Note to the reviewer: delete this script per your discretion
-
-echo "=== Building C++ tests ==="
-make cpp_tests \
-    > >(tee build_cpp_tests_out.log) \
-    2> >(tee build_cpp_tests_err.log >&2)

--- a/temp.sh
+++ b/temp.sh
@@ -1,4 +1,5 @@
 # Because I hate writing this over and over again
+# Note to the reviewer: delete this script per your discretion
 
 echo "=== Building C++ tests ==="
 make cpp_tests \

--- a/temp.sh
+++ b/temp.sh
@@ -1,7 +1,9 @@
+#!/bin/bash
+
 # Because I hate writing this over and over again
 # Note to the reviewer: delete this script per your discretion
 
 echo "=== Building C++ tests ==="
 make cpp_tests \
-    1>build_cpp_tests_out.log \
-    2>build_cpp_tests_err.log
+    > >(tee build_cpp_tests_out.log) \
+    2> >(tee build_cpp_tests_err.log >&2)

--- a/temp.sh
+++ b/temp.sh
@@ -1,0 +1,6 @@
+# Because I hate writing this over and over again
+
+echo "=== Building C++ tests ==="
+make cpp_tests \
+    1>build_cpp_tests_out.log \
+    2>build_cpp_tests_err.log


### PR DESCRIPTION
Hello,

I upgraded the GoogleTest dependency from 1.12.1 to 1.15.2. You shouldn't be getting the CMake warning anymore.
Keep in mind the latest release of GoogleTest available is 1.17.0, which requires a minimum standard of C++17. 1.15.2 is the latest version that still accepts at least C++14. Consider reformatting codebase to fit C++17 standard.

(Proposed fix for #321)