### PR TITLE
Rewrite version.h generation command to work on macos as well

### DIFF
--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -197,12 +197,13 @@ $(objdir)/%.mdlo: %.cpp $(srcdir)/version.h
 	$(MPICXX) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) $(MPIFLAGS) -fPIC -c $< -o $@
 
 
+INSTANTIATE_VERSION_H := s/@PROJECT_VERSION_MAJOR@/$(major_version)/\n
+INSTANTIATE_VERSION_H += s/@PROJECT_VERSION_MINOR@/$(minor_version)/\n
+INSTANTIATE_VERSION_H += s/@PROJECT_VERSION_PATCH@/$(patch_version)/\n
+INSTANTIATE_VERSION_H += s/@PROJECT_VERSION@/$(muscle_version)/\n
+
 $(srcdir)/version.h: version.h.in
-	cp $< $@
-	sed -i -e 's/@PROJECT_VERSION_MAJOR@/$(major_version)/' $@
-	sed -i -e 's/@PROJECT_VERSION_MINOR@/$(minor_version)/' $@
-	sed -i -e 's/@PROJECT_VERSION_PATCH@/$(patch_version)/' $@
-	sed -i -e 's/@PROJECT_VERSION@/$(muscle_version)/' $@
+	printf "$(INSTANTIATE_VERSION_H)" | sed -f - $< >$@
 
 libmuscle.a: $(objects)
 	ar rcs $@ $^


### PR DESCRIPTION
I think this addresses #325, but I don't have a mac to test it on. @pranavshridar could you give it a try? There should be no `libmuscle/cpp/src/libmuscle/version.h-e` file now, and `libmuscle/cpp/src/libmuscle/version.h` should contain
```
#pragma once

#define MUSCLE3_VERSION_MAJOR 0
#define MUSCLE3_VERSION_MINOR 8
#define MUSCLE3_VERSION_PATCH 1

#define MUSCLE3_VERSION "0.8.1-dev"
```