### PR TITLE
Leak detection on MacOS uses leaks in the absence of Valgrind

### DIFF
--- a/libmuscle/cpp/build/libmuscle/tests/Makefile
+++ b/libmuscle/cpp/build/libmuscle/tests/Makefile
@@ -113,7 +113,7 @@ test_dep_lib_paths := $(subst $(space),:,$(foreach DIR,$(DEP_DIRS),$(DIR)/lib))
 
 .PHONY: run_test%
 run_test%: test%
-	export LD_LIBRARY_PATH=$(test_dep_lib_paths):$(LD_LIBRARY_PATH) ; $(VALGRIND) ./$< $(GTEST_OPTIONS)
+	export LD_LIBRARY_PATH=$(test_dep_lib_paths):$(LD_LIBRARY_PATH) ; $(LEAK_DETECTOR) ./$< $(GTEST_OPTIONS)
 
 # This uses setrlimit, which is not compatible with Valgrind, so run without
 .PHONY: run_test_data_memory_use

--- a/libmuscle/fortran/build/libmuscle/tests/Makefile
+++ b/libmuscle/fortran/build/libmuscle/tests/Makefile
@@ -83,5 +83,4 @@ test_dep_lib_paths := $(subst $(space),:,$(foreach DIR,$(DEP_DIRS),$(DIR)/lib))
 
 .PHONY: run_test%
 run_test%: test%
-	export LD_LIBRARY_PATH=$(test_dep_lib_paths):$(LD_LIBRARY_PATH) ; $(VALGRIND) ./$<
-
+	export LD_LIBRARY_PATH=$(test_dep_lib_paths):$(LD_LIBRARY_PATH) ; $(LEAK_DETECTOR) ./$<

--- a/scripts/gmake/check_tools.make
+++ b/scripts/gmake/check_tools.make
@@ -195,7 +195,6 @@ endif
 
 ifdef MUSCLE_MACOS
     export LEAK_DETECTOR := leaks -atExit --
-    export MallocStackLogging = 1
 endif
 
 ifndef LEAK_DETECTOR

--- a/scripts/gmake/check_tools.make
+++ b/scripts/gmake/check_tools.make
@@ -182,22 +182,27 @@ endif
 
 # Check for valgrind (for testing for memory leaks)
 $(info )
-$(info Looking for valgrind...)
-tool_var := VALGRIND
+$(info Looking for a leak detection tool...)
+tool_var := LEAK_DETECTOR
 include $(TOOLDIR)/check_override.make
 
 tool_command := valgrind
 include $(TOOLDIR)/detect_tool.make
 
-ifeq ($(VALGRIND), valgrind)
-    export VALGRIND := valgrind --leak-check=full --error-exitcode=1
+ifeq ($(LEAK_DETECTOR), valgrind)
+    export LEAK_DETECTOR := valgrind --leak-check=full --error-exitcode=1
 endif
 
-ifndef VALGRIND
+ifdef MUSCLE_MACOS
+    export LEAK_DETECTOR := leaks -atExit --
+    export MallocStackLogging = 1
+endif
+
+ifndef LEAK_DETECTOR
     $(warning - Could not find valgrind, so tests will run without it.)
-    $(warning - To fix this, install valgrind and if necessary set VALGRIND to point to it.)
+    $(warning - To fix this, install valgrind and if necessary set LEAK_DETECTOR to point to it.)
 else
-    $(info - Will check for leaks using $(VALGRIND).)
+    $(info - Will check for leaks using $(LEAK_DETECTOR).)
 endif
 
 # Check number of cores

--- a/scripts/tests/Makefile
+++ b/scripts/tests/Makefile
@@ -33,4 +33,4 @@ test_use_echolib: libecholib.so echolib.f90 test_use_echolib.f90
 	$(FC) -o $@ $(FFLAGS) $(DEBUGFLAGS) echolib.f90 test_use_echolib.f90 -L. -lecholib
 
 test: test_use_echolib
-	LD_LIBRARY_PATH=$(PWD):$(LD_LIBRARY_PATH) $(VALGRIND) ./test_use_echolib
+	LD_LIBRARY_PATH=$(PWD):$(LD_LIBRARY_PATH) $(LEAK_DETECTOR) ./test_use_echolib


### PR DESCRIPTION
This PR should resolve #329, plus renaming some variables to keep a more consistent naming convention.