### PR TITLE
Updated MessagePack's Minimum Version Policy in its Makefile

### DIFF
--- a/libmuscle/cpp/build/msgpack/Makefile
+++ b/libmuscle/cpp/build/msgpack/Makefile
@@ -29,7 +29,7 @@ $(MSGPACK_SRC): msgpack-$(msgpack_VERSION).tar.gz
 $(MSGPACK_LIB): $(MSGPACK_SRC)
 	cd msgpack-$(msgpack_VERSION) && rm -rf build && mkdir -p build && cd build && \
 		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) && \
-		cmake -DCMAKE_INSTALL_PREFIX=$(CURDIR)/msgpack -DMSGPACK_CXX11=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DMSGPACK_BUILD_TESTS=OFF .. && \
+		cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=$(CURDIR)/msgpack -DMSGPACK_CXX11=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DMSGPACK_BUILD_TESTS=OFF .. && \
 		$(MAKE) -j $(NCORES) && make install
 
 ifdef MUSCLE_LINUX
@@ -42,4 +42,3 @@ msgpack: $(MSGPACK_LIB)
 	install_name_tool -id $(CURDIR)/msgpack/lib/libmsgpackc.dylib $(CURDIR)/msgpack/lib/libmsgpackc.dylib
 
 endif
-


### PR DESCRIPTION
In #328, I fixed a deprecation error related to GNU Make's version policy with MessagePack. Since that change warranted its own PR, I’m opening this one to address it separately.
