### PR TITLE
Upgrade from messagepack 3.2.0 to 7.0.0

### DIFF
--- a/libmuscle/cpp/build/Makefile
+++ b/libmuscle/cpp/build/Makefile
@@ -28,9 +28,9 @@ distclean:
 # Find dependencies or set up build
 
 dep_name := msgpack
-dep_version_constraint := >= 3.2.0
-dep_version := 3.2.0
-dep_pkgconfig_name := msgpack
+dep_version_constraint := >= 4.0.0
+dep_version := 7.0.0
+dep_pkgconfig_name := msgpack-cxx
 dep_install := 1
 include $(TOOLDIR)/make_available.make
 
@@ -46,7 +46,7 @@ include $(TOOLDIR)/make_available.make
 DEP_DIRS += $(CURDIR)/msgpack/msgpack
 export DEP_DIRS
 
-PKG_CONFIG_EXTRA_DIRS := $(PKG_CONFIG_EXTRA_DIRS):$(CURDIR)/msgpack/msgpack/lib/pkgconfig
+PKG_CONFIG_EXTRA_DIRS := $(PKG_CONFIG_EXTRA_DIRS):$(CURDIR)/msgpack/lib/pkgconfig
 export PKG_CONFIG_EXTRA_DIRS
 
 

--- a/libmuscle/cpp/build/Makefile
+++ b/libmuscle/cpp/build/Makefile
@@ -28,7 +28,7 @@ distclean:
 # Find dependencies or set up build
 
 dep_name := msgpack
-dep_version_constraint := >= 4.0.0
+dep_version_constraint := >= 7.0.0
 dep_version := 7.0.0
 dep_pkgconfig_name := msgpack-cxx
 dep_install := 1

--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -141,7 +141,7 @@ install: all $(installed_headers) $(installed_pkg_config_files)
 	# install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle.dylib
 	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_d.dylib
 	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi.dylib
-	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib 
+	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib
 	@mkdir -p $(PREFIX)/bin
 	sed -e 's@%PREFIX%@$(PREFIX)@g' muscle3.env.in >$(PREFIX)/bin/muscle3.env
 	for pc in $(PREFIX)/lib/pkgconfig/* ; do sed -i -e 's@^prefix=.*$$@prefix=$(PREFIX)@' $$pc ; done
@@ -289,9 +289,9 @@ libmuscle.pc:
 	@echo 'URL: https://muscle3.readthedocs.io' >>$@
 	@echo 'Version: $(muscle_version)' >>$@
 	@echo 'Requires: ymmsl = $(muscle_version)' >>$@
-	@echo 'Requires.private: msgpack >= 3.1.0' >>$@
-	@echo 'Cflags: -I$${includedir} -pthread' >>$@
-	@echo 'Cflags.private: -pthread' >>$@
+	@echo 'Requires.private:' >>$@
+	@echo 'Cflags: -I$${includedir} -pthread -DMSGPACK_NO_BOOST' >>$@
+	@echo 'Cflags.private: -pthread -DMSGPACK_NO_BOOST' >>$@
 	@echo 'Libs: -L$${libdir} -lmuscle' >>$@
 	@echo 'Libs.private: -pthread' >>$@
 
@@ -306,8 +306,8 @@ libmuscle_mpi.pc:
 	@echo 'URL: https://muscle3.readthedocs.io' >>$@
 	@echo 'Version: $(muscle_version)' >>$@
 	@echo 'Requires: ymmsl = $(muscle_version)' >>$@
-	@echo 'Requires.private: msgpack >= 3.1.0' >>$@
-	@echo 'Cflags: -I$${includedir} -pthread -DMUSCLE_ENABLE_MPI' >>$@
-	@echo 'Cflags.private: -pthread' >>$@
+	@echo 'Requires.private:' >>$@
+	@echo 'Cflags: -I$${includedir} -pthread -DMUSCLE_ENABLE_MPI -DMSGPACK_NO_BOOST' >>$@
+	@echo 'Cflags.private: -pthread -DMSGPACK_NO_BOOST' >>$@
 	@echo 'Libs: -L$${libdir} -lmuscle_mpi' >>$@
 	@echo 'Libs.private: -pthread' >>$@

--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -137,11 +137,6 @@ install: all $(installed_headers) $(installed_pkg_config_files)
 	-install_name_tool -change libymmsl.dylib @loader_path/libymmsl.dylib $(PREFIX)/lib/libmuscle_mpi.dylib
 	-install_name_tool -change libymmsl.dylib @loader_path/libymmsl.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib
 
-	# Not needed for MessagePack 7.0.0
-	# install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle.dylib
-	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_d.dylib
-	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi.dylib
-	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib
 	@mkdir -p $(PREFIX)/bin
 	sed -e 's@%PREFIX%@$(PREFIX)@g' muscle3.env.in >$(PREFIX)/bin/muscle3.env
 	for pc in $(PREFIX)/lib/pkgconfig/* ; do sed -i -e 's@^prefix=.*$$@prefix=$(PREFIX)@' $$pc ; done
@@ -154,14 +149,12 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 
 # Dependencies
 $(info pcextra: $(PKG_CONFIG_EXTRA_DIRS))
-# MSGPACK_FLAGS := $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_EXTRA_DIRS):$(PKG_CONFIG_PATH) ; pkg-config --cflags msgpack-cxx)
 MSGPACK_INCLUDE_DIR = $(CURDIR)/../msgpack/msgpack/include
 export MSGPACK_INCLUDE_DIR
 CXXFLAGS += -I$(MSGPACK_INCLUDE_DIR)
 
 LDFLAGS2 = $(LDFLAGS)
 LDFLAGS2 += -pthread -L$(CURDIR)/../ymmsl -lymmsl
-# LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_EXTRA_DIRS):$(PKG_CONFIG_PATH) ; pkg-config --libs msgpack-cxx)
 
 # Automatic header dependencies
 -include $(deps)

--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -76,7 +76,7 @@ endif
 
 installed_pkg_config_files := $(pkg_config_files:%=$(PREFIX)/lib/pkgconfig/%)
 
-CXXFLAGS += -Wall -pedantic -std=c++14 -pthread -O3
+CXXFLAGS += -Wall -pedantic -std=c++14 -pthread -O3 -DMSGPACK_NO_BOOST
 export CXXFLAGS
 
 MPIFLAGS := -DMUSCLE_ENABLE_MPI
@@ -136,10 +136,12 @@ install: all $(installed_headers) $(installed_pkg_config_files)
 	-install_name_tool -change libymmsl.dylib @loader_path/libymmsl.dylib $(PREFIX)/lib/libmuscle_d.dylib
 	-install_name_tool -change libymmsl.dylib @loader_path/libymmsl.dylib $(PREFIX)/lib/libmuscle_mpi.dylib
 	-install_name_tool -change libymmsl.dylib @loader_path/libymmsl.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib
-	install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle.dylib
-	-install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_d.dylib
-	-install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi.dylib
-	-install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib
+
+	# Not needed for MessagePack 7.0.0
+	# install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle.dylib
+	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_d.dylib
+	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi.dylib
+	# -install_name_tool -change @rpath/libmsgpackc.2.dylib @loader_path/libmsgpackc.2.dylib $(PREFIX)/lib/libmuscle_mpi_d.dylib 
 	@mkdir -p $(PREFIX)/bin
 	sed -e 's@%PREFIX%@$(PREFIX)@g' muscle3.env.in >$(PREFIX)/bin/muscle3.env
 	for pc in $(PREFIX)/lib/pkgconfig/* ; do sed -i -e 's@^prefix=.*$$@prefix=$(PREFIX)@' $$pc ; done
@@ -152,11 +154,14 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 
 # Dependencies
 $(info pcextra: $(PKG_CONFIG_EXTRA_DIRS))
-CXXFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_EXTRA_DIRS):$(PKG_CONFIG_PATH) ; pkg-config --cflags msgpack)
+# MSGPACK_FLAGS := $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_EXTRA_DIRS):$(PKG_CONFIG_PATH) ; pkg-config --cflags msgpack-cxx)
+MSGPACK_INCLUDE_DIR = $(CURDIR)/../msgpack/msgpack/include
+export MSGPACK_INCLUDE_DIR
+CXXFLAGS += -I$(MSGPACK_INCLUDE_DIR)
 
 LDFLAGS2 = $(LDFLAGS)
 LDFLAGS2 += -pthread -L$(CURDIR)/../ymmsl -lymmsl
-LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_EXTRA_DIRS):$(PKG_CONFIG_PATH) ; pkg-config --libs msgpack)
+# LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_EXTRA_DIRS):$(PKG_CONFIG_PATH) ; pkg-config --libs msgpack-cxx)
 
 # Automatic header dependencies
 -include $(deps)

--- a/libmuscle/cpp/build/libmuscle/tests/Makefile
+++ b/libmuscle/cpp/build/libmuscle/tests/Makefile
@@ -47,7 +47,6 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 EXTRA_LINK_DIRS := $(foreach DIR,$(DEP_DIRS),-Wl,-rpath,$(DIR)/lib)
 
 CXXFLAGS += -I$(libmuscle_testdir) -isystem $(googletest_ROOT)/include -pthread
-# CXXFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --cflags msgpack) # Keep this line anyways, may need it
 CXXFLAGS += -I$(MSGPACK_INCLUDE_DIR)
 CXXFLAGS += -DTESTING $(DEBUGFLAGS)
 
@@ -55,7 +54,6 @@ LDFLAGS += $(CURDIR)/../libmuscle_d.a $(CURDIR)/../../ymmsl/libymmsl_d.a
 LDFLAGS += $(googletest_LIB) -pthread
 
 LDFLAGS2 := $(LDFLAGS)
-# LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --libs msgpack)
 LDFLAGS2 += $(EXTRA_LINK_DIRS)
 
 -include $(deps)

--- a/libmuscle/cpp/build/libmuscle/tests/Makefile
+++ b/libmuscle/cpp/build/libmuscle/tests/Makefile
@@ -47,14 +47,15 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 EXTRA_LINK_DIRS := $(foreach DIR,$(DEP_DIRS),-Wl,-rpath,$(DIR)/lib)
 
 CXXFLAGS += -I$(libmuscle_testdir) -isystem $(googletest_ROOT)/include -pthread
-CXXFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --cflags msgpack)
+# CXXFLAGS += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --cflags msgpack) # Keep this line anyways, may need it
+CXXFLAGS += -I$(MSGPACK_INCLUDE_DIR)
 CXXFLAGS += -DTESTING $(DEBUGFLAGS)
 
 LDFLAGS += $(CURDIR)/../libmuscle_d.a $(CURDIR)/../../ymmsl/libymmsl_d.a
 LDFLAGS += $(googletest_LIB) -pthread
 
 LDFLAGS2 := $(LDFLAGS)
-LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --libs msgpack)
+# LDFLAGS2 += $(shell export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) ; pkg-config --libs msgpack)
 LDFLAGS2 += $(EXTRA_LINK_DIRS)
 
 -include $(deps)

--- a/libmuscle/cpp/build/msgpack/Makefile
+++ b/libmuscle/cpp/build/msgpack/Makefile
@@ -3,8 +3,6 @@ all: msgpack
 
 .PHONY: install
 install: msgpack
-	# mkdir -p $(PREFIX)/lib
-	# cp -a msgpack/lib/* $(PREFIX)/lib/  # Commented: MessagePack 7.0.0 is header-only
 	mkdir -p $(PREFIX)/include
 	cp -a msgpack/include/* $(PREFIX)/include/
 
@@ -17,8 +15,7 @@ distclean: clean
 	rm -rf $$(find . -type d -name 'msgpack-*')
 	rm -rf msgpack
 
-# MSGPACK_LIB=$(CURDIR)/msgpack/lib/libmsgpackc.a  # Commented: MessagePack 7.0.0 is header-only
-MSGPACK_INCLUDE_DIR=$(CURDIR)/msgpack/include
+MSGPACK_HEADERS=$(CURDIR)/msgpack/include/msgpack.hpp
 MSGPACK_SRC=$(CURDIR)/msgpack-cxx-$(msgpack_VERSION)/ChangeLog
 
 msgpack-cxx-$(msgpack_VERSION).tar.gz:
@@ -27,19 +24,10 @@ msgpack-cxx-$(msgpack_VERSION).tar.gz:
 $(MSGPACK_SRC): msgpack-cxx-$(msgpack_VERSION).tar.gz
 	$(TAR) xf msgpack-cxx-$(msgpack_VERSION).tar.gz -m
 
-$(MSGPACK_INCLUDE_DIR): $(MSGPACK_SRC)
+$(MSGPACK_HEADERS): $(MSGPACK_SRC)
 	cd msgpack-cxx-$(msgpack_VERSION) && rm -rf build && mkdir -p build && cd build && \
-		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) && \
 		cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DMSGPACK_USE_BOOST=OFF -DCMAKE_INSTALL_PREFIX=$(CURDIR)/msgpack -DMSGPACK_CXX11=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DMSGPACK_BUILD_TESTS=OFF .. && \
-		$(MAKE) -j $(NCORES) && make install
+		$(MAKE) -j $(NCORES) && make install && touch $@
 
-ifdef MUSCLE_LINUX
+msgpack: $(MSGPACK_HEADERS)
 
-msgpack: $(MSGPACK_INCLUDE_DIR)
-
-else ifdef MUSCLE_MACOS
-
-msgpack: $(MSGPACK_INCLUDE_DIR)
-	# install_name_tool -id $(CURDIR)/msgpack/lib/libmsgpackc.dylib $(CURDIR)/msgpack/lib/libmsgpackc.dylib
-
-endif

--- a/libmuscle/cpp/build/msgpack/Makefile
+++ b/libmuscle/cpp/build/msgpack/Makefile
@@ -3,8 +3,8 @@ all: msgpack
 
 .PHONY: install
 install: msgpack
-	mkdir -p $(PREFIX)/lib
-	cp -a msgpack/lib/* $(PREFIX)/lib/
+	# mkdir -p $(PREFIX)/lib
+	# cp -a msgpack/lib/* $(PREFIX)/lib/  # Commented: MessagePack 7.0.0 is header-only
 	mkdir -p $(PREFIX)/include
 	cp -a msgpack/include/* $(PREFIX)/include/
 
@@ -17,28 +17,29 @@ distclean: clean
 	rm -rf $$(find . -type d -name 'msgpack-*')
 	rm -rf msgpack
 
-MSGPACK_LIB=$(CURDIR)/msgpack/lib/libmsgpackc.a
-MSGPACK_SRC=$(CURDIR)/msgpack-$(msgpack_VERSION)/ChangeLog
+# MSGPACK_LIB=$(CURDIR)/msgpack/lib/libmsgpackc.a  # Commented: MessagePack 7.0.0 is header-only
+MSGPACK_INCLUDE_DIR=$(CURDIR)/msgpack/include
+MSGPACK_SRC=$(CURDIR)/msgpack-cxx-$(msgpack_VERSION)/ChangeLog
 
-msgpack-$(msgpack_VERSION).tar.gz:
-	$(DOWNLOAD) https://github.com/msgpack/msgpack-c/releases/download/cpp-$(msgpack_VERSION)/msgpack-$(msgpack_VERSION).tar.gz
+msgpack-cxx-$(msgpack_VERSION).tar.gz:
+	$(DOWNLOAD) https://github.com/msgpack/msgpack-c/releases/download/cpp-$(msgpack_VERSION)/msgpack-cxx-$(msgpack_VERSION).tar.gz
 
-$(MSGPACK_SRC): msgpack-$(msgpack_VERSION).tar.gz
-	$(TAR) xf msgpack-$(msgpack_VERSION).tar.gz -m
+$(MSGPACK_SRC): msgpack-cxx-$(msgpack_VERSION).tar.gz
+	$(TAR) xf msgpack-cxx-$(msgpack_VERSION).tar.gz -m
 
-$(MSGPACK_LIB): $(MSGPACK_SRC)
-	cd msgpack-$(msgpack_VERSION) && rm -rf build && mkdir -p build && cd build && \
+$(MSGPACK_INCLUDE_DIR): $(MSGPACK_SRC)
+	cd msgpack-cxx-$(msgpack_VERSION) && rm -rf build && mkdir -p build && cd build && \
 		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(PKG_CONFIG_EXTRA_DIRS) && \
-		cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=$(CURDIR)/msgpack -DMSGPACK_CXX11=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DMSGPACK_BUILD_TESTS=OFF .. && \
+		cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DMSGPACK_USE_BOOST=OFF -DCMAKE_INSTALL_PREFIX=$(CURDIR)/msgpack -DMSGPACK_CXX11=ON -DMSGPACK_BUILD_EXAMPLES=OFF -DMSGPACK_BUILD_TESTS=OFF .. && \
 		$(MAKE) -j $(NCORES) && make install
 
 ifdef MUSCLE_LINUX
 
-msgpack: $(MSGPACK_LIB)
+msgpack: $(MSGPACK_INCLUDE_DIR)
 
 else ifdef MUSCLE_MACOS
 
-msgpack: $(MSGPACK_LIB)
-	install_name_tool -id $(CURDIR)/msgpack/lib/libmsgpackc.dylib $(CURDIR)/msgpack/lib/libmsgpackc.dylib
+msgpack: $(MSGPACK_INCLUDE_DIR)
+	# install_name_tool -id $(CURDIR)/msgpack/lib/libmsgpackc.dylib $(CURDIR)/msgpack/lib/libmsgpackc.dylib
 
 endif

--- a/libmuscle/cpp/src/libmuscle/data.cpp
+++ b/libmuscle/cpp/src/libmuscle/data.cpp
@@ -1098,4 +1098,3 @@ DataConstRef DataConstRef::grid_data_<bool>(
 }
 
 } }  // namespace libmuscle::_MUSCLE_IMPL_NS
-

--- a/libmuscle/cpp/src/libmuscle/data.cpp
+++ b/libmuscle/cpp/src/libmuscle/data.cpp
@@ -527,6 +527,7 @@ bool DataConstRef::is_a_byte_array() const {
     return mp_obj_->type == msgpack::type::BIN;
 }
 
+
 template <>
 SettingValue DataConstRef::as<SettingValue>() const {
     DataConstRef const & self = *this;
@@ -1098,3 +1099,4 @@ DataConstRef DataConstRef::grid_data_<bool>(
 }
 
 } }  // namespace libmuscle::_MUSCLE_IMPL_NS
+

--- a/libmuscle/cpp/src/libmuscle/data.cpp
+++ b/libmuscle/cpp/src/libmuscle/data.cpp
@@ -527,7 +527,6 @@ bool DataConstRef::is_a_byte_array() const {
     return mp_obj_->type == msgpack::type::BIN;
 }
 
-
 template <>
 SettingValue DataConstRef::as<SettingValue>() const {
     DataConstRef const & self = *this;

--- a/libmuscle/cpp/src/libmuscle/mpp_message.cpp
+++ b/libmuscle/cpp/src/libmuscle/mpp_message.cpp
@@ -109,4 +109,3 @@ DataConstRef MPPMessage::as_dict_() const {
 }
 
 } }
-

--- a/libmuscle/cpp/src/libmuscle/tests/test_communicator.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_communicator.cpp
@@ -189,7 +189,7 @@ TEST_F(libmuscle_communicator2, receive_message) {
 TEST_F(libmuscle_communicator2, receive_message_vector) {
     MPPMessage msg(
             "peer2.out_v", "component.in_v", 5, 4.0, 6.0,
-            Settings({{"s0", {0.0}}, {"s1", 1.3}}), 0, 3.5, "Testing2");
+            Settings({{"s0", {0.0}}, {"s1", 1.0}}), 0, 3.5, "Testing2");
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
             msg.encoded(), ProfileData());
@@ -205,7 +205,7 @@ TEST_F(libmuscle_communicator2, receive_message_vector) {
     ASSERT_EQ(recv_msg.next_timestamp(), 6.0);
     ASSERT_EQ(recv_msg.data().as<std::string>(), "Testing2");
     ASSERT_EQ(recv_msg.settings().at("s0"), std::vector<double>{0.0});
-    ASSERT_EQ(recv_msg.settings().at("s1"), 1.3);
+    ASSERT_EQ(recv_msg.settings().at("s1"), 1.0);
     ASSERT_EQ(saved_until, 3.5);
 }
 

--- a/libmuscle/cpp/src/libmuscle/tests/test_communicator.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_communicator.cpp
@@ -385,4 +385,3 @@ TEST_F(libmuscle_communicator2, test_shutdown) {
 
     ASSERT_TRUE(expected_receivers.empty());
 }
-

--- a/libmuscle/cpp/src/libmuscle/tests/test_communicator.cpp
+++ b/libmuscle/cpp/src/libmuscle/tests/test_communicator.cpp
@@ -189,7 +189,7 @@ TEST_F(libmuscle_communicator2, receive_message) {
 TEST_F(libmuscle_communicator2, receive_message_vector) {
     MPPMessage msg(
             "peer2.out_v", "component.in_v", 5, 4.0, 6.0,
-            Settings({{"s0", {0.0}}, {"s1", 1.0}}), 0, 3.5, "Testing2");
+            Settings({{"s0", {0.0}}, {"s1", 1.3}}), 0, 3.5, "Testing2");
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
             msg.encoded(), ProfileData());
@@ -205,7 +205,7 @@ TEST_F(libmuscle_communicator2, receive_message_vector) {
     ASSERT_EQ(recv_msg.next_timestamp(), 6.0);
     ASSERT_EQ(recv_msg.data().as<std::string>(), "Testing2");
     ASSERT_EQ(recv_msg.settings().at("s0"), std::vector<double>{0.0});
-    ASSERT_EQ(recv_msg.settings().at("s1"), 1.0);
+    ASSERT_EQ(recv_msg.settings().at("s1"), 1.3);
     ASSERT_EQ(saved_until, 3.5);
 }
 


### PR DESCRIPTION
Hey, y'all!

Finally upgraded MessagePack to the latest dependency of `7.0.0`. This should solve #317, but it's not quite good to merge yet. I am sure that there are better ways to do this.

## Problem: `Data`/`DataConstRef` receives the wrong type
The error faced by the user stated in #317 is a runtime type error, and after a lot of digging I know why: MessagePack 4.0.0, for the sake of minimizing message sizes, packs floating point types with no fractional component as the smallest integer type it can (e.g. 2.0 becomes 2, while 2.3 stays 2.3). I have tried like hell to debug MUSCLE3 to stop this (there is a way, but it involves more time than it should take), but without success.

## Solution: Upgrade to the most recent version
At least this way, we're not locking ourselves in time with a version that doesn't work, but there are changes to how the build system deals with MessagePack.

### MessagePack C/C++ has split
One of the breaking changes in 4.0.0 is the split between the C and the C++ libraries, which are `msgpack-c` and `msgpack-cxx` respectively. Thus, the GitHub URL had to be changed to match this. 

### `msgpack-cxx` does not use `pkgconf`
There is no such thing as a `.pc` file or a `.pc.in` within the `msgpack-cxx` library, so there is no way to use `pkg-config` to get any information about it. Only the C library has it. I was a bit surprised that any compilation was successful under 4.0.0. However, `libmsgpack-dev` lists a `libmsgpack-cxx-dev` as a dependency. I have tried to install this to see if that would be usable with `pkg-config`, but I was unsuccessful, which tells us that the C++ library cannot be used with it at all. The C++ library is also header-only, which might explain the lack of use of the `pkgconf` template files.

### Future detection and installation: 
There is a way that is described in the msgpack-cxx README which is described as the [canonical cmake way](https://github.com/msgpack/msgpack-c/tree/cpp_master?tab=readme-ov-file#usage), but I'm guessing that's not something we want to do.
To that end, the changes in the build system locally download and extract msgpack regardless if the current system has it or not. 4.0.0 has that problematic type compression behavior mentioned earlier, and it's the same version that's the latest available on apt, so this is probably for the better. 

---
There are a lot of lines here that I commented out rather than deleted out of anticipation that we might need to keep it on hand. However, after all issues have been ironed out in this PR, I want to get rid of these lines before merging.



What needs to be done now:
- [x] The minimum required version for MessagePack HAS to be 7.0.0 in the build system. Anything else will invite the same behavior again.
- [ ] Every instance of the string `msgack` in the build system HAS to be changed to `msgpack-cxx`, if it isn't already.
- [ ] An MPI issue in the test suite similar to the one solved in #328 is showing up again. Not to be solved here, but it needs its own fix.
- [ ] **Suggested by @LourensVeen:** We are going to install msgpack, so might as well do away with detection and skip to installing.
- [ ] **Suggested by @LourensVeen:** The documentation should reflect this change as well.
- [x] **Suggested by @LourensVeen:** (see his comment below) Remove msgpack as a dependency listed in `libmuscle.pc` and `libmuscle_mpi.pc` to fix `make test_examples`.