### PR TITLE
Prevent double CI runs in Pull Requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
-# Run Continuous Integration on every push
+# Run Continuous Integration when a PR is updated and for pushes to main/develop
 name: continuous_integration
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_python_compatibility.yaml
+++ b/.github/workflows/ci_python_compatibility.yaml
@@ -1,6 +1,10 @@
-# Run Continuous Integration on every push
+# Run Continuous Integration when a PR is updated and for pushes to main/develop
 name: python_compatibility
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_python_macos.yaml
+++ b/.github/workflows/ci_python_macos.yaml
@@ -1,6 +1,10 @@
-# Run Continuous Integration on every push
+# Run Continuous Integration when a PR is updated and for pushes to main/develop
 name: python_compatibility_macos
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Currently, when a PR is opened and new commits are pushed to the PR, the compatibility and continuous_integration workflows execute twice: once for the `push` trigger, and once for the `pull_request` trigger.

This PR updates the triggers such that the `push` trigger is only activated on the `main` or `develop` branches. Preventing double runs of the workflows.