### PR TITLE
Relax tox version constraint in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
     python: "3.12"
   jobs:
     post_create_environment:
-      - pip install tox\<4
+      - pip install tox
       # let tox set up a build environment
       - tox -e docs --notest
       # export tox installed packages as requirements for the install step


### PR DESCRIPTION
`tox` v3.x needs doesn't work with pyproject.toml files by default, which caused RTD builds to fail.