### PR TITLE
Issue 351 custom implementations

### DIFF
--- a/docs/source/checkpointing.rst
+++ b/docs/source/checkpointing.rst
@@ -351,7 +351,7 @@ repository. Then execute the following command:
 .. code-block:: bash
 
     $ mkdir run_rd_example
-    $ muscle_manager --start-all --run-dir run_rd_example rd_model.ymmsl rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+    $ YMMSL_PATH=. muscle_manager --start-all --run-dir run_rd_example rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 
 .. note::
 
@@ -368,8 +368,8 @@ reaction model and the diffusion model). The ``rd_checkpoints_python.ymmsl`` fil
 contains the checkpoint definitions used in this example:
 
 .. literalinclude:: examples/rd_checkpoints_python.ymmsl
-    :caption: ``docs/source/examples/rd_checkpoints_python.ymmsl, lines 31-33``
-    :lines: 7-9
+    :caption: ``docs/source/examples/rd_checkpoints_python.ymmsl, lines 12-14``
+    :lines: 12-14
     :language: yaml
 
 MUSCLE3 will create the run directory ``run_rd_example`` for you. In it you'll
@@ -420,7 +420,7 @@ point to the snapshot you want to resume from.
     :caption: Resume from an earlier snapshot. Replace ``<date>`` and ``<time>`` to point to an actual snapshot file.
 
     $ mkdir run_rd_resume
-    $ muscle_manager --start-all --run-dir run_rd_resume rd_model.ymmsl rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl run_rd_example/snapshots/snapshot_<date>_<time>.ymmsl
+    $ YMMSL_PATH=. muscle_manager --start-all --run-dir run_rd_resume rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_resources.ymmsl run_rd_example/snapshots/snapshot_<date>_<time>.ymmsl
 
 When the command completes you can see the output in the new working directory
 ``run_rd_resume``.

--- a/docs/source/cplusplus.rst
+++ b/docs/source/cplusplus.rst
@@ -36,7 +36,7 @@ file that specifies the C++ implementation of one or both of the submodels:
 .. code-block:: bash
 
   . python/build/venv/bin/activate
-  muscle_manager --start-all rd_model.ymmsl rd_cpp.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+  YMMSL_PATH=. muscle_manager --start-all rd_cpp.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 
 
 Note that activating the virtual environment is needed to make the
@@ -57,30 +57,23 @@ the messages will end up in ``<rundir>/instances/<instance-id>/stdout.txt`` or
 ``stderr.txt``. If the model logs to a file in the working directory, then
 you'll find it in ``<rundir>/instances/<instance-id>/workdir/``.
 
-Overriding implementations
---------------------------
+Setting implementations
+-----------------------
 
-In the above commands, we use the same ``rd_model.ymmsl`` file that we used for the
-Python version of the reaction-diffusion model. This file specifies the Python
-implementations of the ``macro`` and ``micro`` components. To run the model with the
-alternative C++ implementations, we need to override them, which is done in
-``rd_cpp.ymmsl``:
+The above commands are the same as for the Python version of the reaction-diffusion
+model, except that we're using ``rd_cpp.ymmsl`` instead of ``rd_python.ymmsl``. This
+file is almost the same, except that it imports C++ implementations of the reaction and
+diffusion models:
 
 .. literalinclude:: examples/rd_cpp.ymmsl
   :caption: ``docs/source/examples/rd_cpp.ymmsl``
   :language: yaml
 
-The ``custom_implementations`` section contains a mapping that specifies an
-implementation (to the right of the ``:``) for one or more components (on the left). Any
-implementations specified here will override the implementation set in the model
-description. Multiple yMMSL files with custom implementations may be given and all of
-them will be applied. If a component has a custom implementation in more than one file,
-then the one that is farthest to the right on the command line will be applied.
 
 MUSCLE3 allows programs written in different languages to be used together
-transparently. The ``rd_python_cpp.ymmsl`` file only overrides the implementation for
-``macro``, but leaves ``micro`` to run with the Python reaction program. Give it a try
-and look at the logs to see it in action!
+transparently. The ``rd_python_cpp.ymmsl`` file sets a C++ implementation for ``macro``,
+but makes ``micro`` run with the Python reaction program. Give it a try and look at the
+logs to see it in action!
 
 Can you run the model with the Python diffusion program and the C++ reaction program?
 You'll need to make your own yMMSL file for this.

--- a/docs/source/distributed_execution.rst
+++ b/docs/source/distributed_execution.rst
@@ -86,7 +86,7 @@ This is because there are some examples that mix languages as well.
   :language: yaml
 
 
-As you can see, this has all the same terms we saw in the Python version, but it's not
+As you can see, this has all the same terms we saw in the Python version, but it's
 written in YAML format. You can load a yMMSL file from Python using
 `ymmsl.load
 <https://ymmsl-python.readthedocs.io/en/stable/overview.html#reading-ymmsl-files>`_ and
@@ -124,20 +124,16 @@ should use MarkDown formatting here.
         s: state_in
       description: |
         This is the macro model, which calculates the diffusion
-      implementation: diffusion_python
     micro:
       ports:
         f_init: initial_state
         o_f: final_state
       description: |
         This is the micro model, which calculates the reaction
-      implementation: reaction_python
 
 
 We have seen the ``macro`` and ``micro`` components before. They have the same ports and
-description as in Python, but the implementations have an added ``_python`` in their
-names here, because we have implementations in other languages as well (more on those in
-the language sections).
+description as in Python.
 
 If a component has multiple ports for an operator, then the names can be added to the
 line separated by spaces, or you can specify a list of them in one of these ways:
@@ -166,6 +162,51 @@ on its ``state_out`` port to ``micro``'s ``initial_state``, and ``micro`` sends
 its answer on its ``final_state`` port, which is routed to ``macro``'s
 ``state_in``.
 
+Like in Python, we'll need some implementations. These can be specified directly for
+each component like this:
+
+.. code-block:: yaml
+
+  components:
+    micro:
+      ports:
+        f_init: initial_state
+        o_f: final_state
+      implementation: reaction_python
+
+
+Usually, you have specific models that you're connecting together, and then this is the
+easiest way to specify them.
+
+In this case we have many examples that all run this model, but with implementations
+written in different languages. To avoid duplication, we've made ``rd_model.py``
+generic, and to run the model with Python implementations we have a second file
+``rd_python.py``:
+
+.. code-block:: yaml
+
+  ymmsl_version: v0.2
+
+  imports:
+  - from rd_model import implementation reaction_diffusion
+  - from rd_programs import implementation diffusion_python
+  - from rd_programs import implementation reaction_python
+
+  custom_implementations:
+    reaction_diffusion.macro: diffusion_python
+    reaction_diffusion.micro: reaction_python
+
+
+Here, we import the ``reaction_diffusion`` model from ``rd_model``, and the
+implementations we want to use from ``rd_programs``. Then we use the
+``custom_implementations`` section to specify which implementation should be used for
+which component of the model.
+
+Note the syntax: there's the name of the model we want to customise,
+``reaction_diffusion``, then a period, then the name of the component within that model
+whose implementation we want to set, ``macro``. Then a colon, and the name of the
+implementation ``diffusion_python``.
+
 
 Settings
 ````````
@@ -186,9 +227,9 @@ Programs
 ````````
 
 To run the simulation MUSCLE3 will have to start our Python programs, and we need to
-tell it how to do that. This is done by some definitions in ``rd_programs.ymmsl``. Note
-that this file actually contains definitions for all of our programs, but we'll focus on
-the ``reaction_python`` one here:
+tell it how to do that. This is done by some definitions in ``rd_programs.ymmsl``, which
+we imported above. Note that this file actually contains definitions for all of our
+programs, but we'll focus on the ``reaction_python`` one here:
 
 .. code-block:: yaml
 
@@ -271,7 +312,7 @@ Starting the simulation
 With the above in place, we now have all the pieces we need to start a
 distributed simulation. We do this by starting the MUSCLE3 manager and giving it
 the configuration files. It will then start the needed model instances, help
-then to find each other, and distribute the settings to them. The instances will
+them to find each other, and distribute the settings to them. The instances will
 then connect to each other via the network and run the simulation.
 
 The manager is included with the Python version of MUSCLE3. Running ``make`` or
@@ -283,8 +324,11 @@ directory like this:
 .. code-block:: bash
 
   . python/build/venv/bin/activate
-  muscle_manager --start-all rd_model.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+  YMMSL_PATH=. muscle_manager --start-all rd_python.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 
+
+(The YMMSL_PATH variable points the manager to the ``rd_model.ymmsl`` and
+``rd_programs.ymmsl`` we are importing from.)
 
 This will start the manager, run the simulation, plot the results on the screen,
 and when you close the plot, finish the simulation. It will also produce a

--- a/docs/source/examples/Makefile
+++ b/docs/source/examples/Makefile
@@ -119,49 +119,49 @@ clean:
 
 .PHONY: test_python
 test_python: base
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all rd_model.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all rd_model.ymmsl rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all rd_python.ymmsl rd_settings.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 	# test restarting
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all rd_model.ymmsl rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl \
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all rd_checkpoints_python.ymmsl rd_settings.ymmsl rd_resources.ymmsl \
 		$$(ls $$(ls -d -r -t run_reaction_diffusion* | tail -n1)/snapshots/*.ymmsl | head -n1)
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all eca_python.ymmsl eca_settings.ymmsl eca_programs.ymmsl
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all ecac_python.ymmsl eca_settings.ymmsl eca_programs.ymmsl
-	. python/build/venv/bin/activate && ./rd_manual.sh
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all eca_python.ymmsl eca_settings.ymmsl
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all ecac_python.ymmsl eca_settings.ymmsl
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. ./rd_manual.sh
 	make -C python test
 
 .PHONY: test_cpp
 test_cpp: base cpp
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_cpp.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_checkpoints_cpp.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_cpp.ymmsl rd_settings.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_checkpoints_cpp.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 	# test restarting
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_checkpoints_cpp.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl \
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_checkpoints_cpp.ymmsl rd_settings.ymmsl rd_resources.ymmsl \
 		$$(ls $$(ls -d -r -t run_reaction_diffusion* | tail -n1)/snapshots/*.ymmsl | head -n1)
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_python_cpp.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
-	. python/build/venv/bin/activate && muscle_manager --start-all rdmc_model.ymmsl rdmc_cpp.ymmsl rdmc_settings.ymmsl rd_programs.ymmsl rdmc_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_python_cpp.ymmsl rd_settings.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rdmc_cpp.ymmsl rdmc_settings.ymmsl rdmc_resources.ymmsl
 	. python/build/venv/bin/activate && muscle_manager --start-all nested_rdmc.ymmsl rd_programs.ymmsl
 	. python/build/venv/bin/activate && YMMSL_PATH=./ymmsl muscle_manager --start-all nested_rdmc_imports.ymmsl
-	. python/build/venv/bin/activate && muscle_manager --start-all dispatch_cpp.ymmsl dispatch_programs.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all dispatch_cpp.ymmsl
 
 .PHONY: test_cpp_mpi
 test_cpp_mpi: base cpp_mpi
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all rd_model.ymmsl rd_cpp_mpi.ymmsl rd_programs.ymmsl rd_settings.ymmsl rd_resources_mpi.ymmsl
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all rd_cpp_mpi.ymmsl rd_settings.ymmsl rd_resources_mpi.ymmsl
 
 .PHONY: test_fortran
 test_fortran: base fortran
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_fortran.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_checkpoints_fortran.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_fortran.ymmsl rd_settings.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_checkpoints_fortran.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 	# test restarting
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_checkpoints_fortran.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl \
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_checkpoints_fortran.ymmsl rd_settings.ymmsl rd_resources.ymmsl \
 		$$(ls $$(ls -d -r -t run_reaction_diffusion* | tail -n1)/snapshots/*.ymmsl | head -n1)
-	. python/build/venv/bin/activate && muscle_manager --start-all rd_model.ymmsl rd_python_fortran.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
-	. python/build/venv/bin/activate && muscle_manager --start-all rdmc_model.ymmsl rdmc_fortran.ymmsl rdmc_settings.ymmsl rd_programs.ymmsl rdmc_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rd_python_fortran.ymmsl rd_settings.ymmsl rd_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all rdmc_fortran.ymmsl rdmc_settings.ymmsl rdmc_resources.ymmsl
 
 .PHONY: test_fortran_mpi
 test_fortran_mpi: base fortran_mpi
-	. python/build/venv/bin/activate && DONTPLOT=1 muscle_manager --start-all rd_model.ymmsl rd_fortran_mpi.ymmsl rd_programs.ymmsl rd_settings.ymmsl rd_resources_mpi.ymmsl
+	. python/build/venv/bin/activate && DONTPLOT=1 YMMSL_PATH=. muscle_manager --start-all rd_fortran_mpi.ymmsl rd_settings.ymmsl rd_resources_mpi.ymmsl
 
 .PHONY: benchmark
 benchmark: base cpp
-	. python/build/venv/bin/activate && muscle_manager --start-all benchmark_model.ymmsl benchmark_python.ymmsl benchmark_settings.ymmsl benchmark_programs.ymmsl benchmark_resources.ymmsl
-	. python/build/venv/bin/activate && muscle_manager --start-all benchmark_model.ymmsl benchmark_cpp.ymmsl benchmark_settings.ymmsl benchmark_programs.ymmsl benchmark_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all benchmark_python.ymmsl benchmark_settings.ymmsl benchmark_resources.ymmsl
+	. python/build/venv/bin/activate && YMMSL_PATH=. muscle_manager --start-all benchmark_cpp.ymmsl benchmark_settings.ymmsl benchmark_resources.ymmsl
 

--- a/docs/source/examples/benchmark_cpp.ymmsl
+++ b/docs/source/examples/benchmark_cpp.ymmsl
@@ -1,5 +1,10 @@
 ymmsl_version: v0.2
 
+imports:
+  from benchmark_model import implementation benchmark
+  from benchmark_programs import implementation benchmark_driver_cpp
+  from benchmark_programs import implementation benchmark_mirror_cpp
+
 custom_implementations:
-  driver: benchmark_driver_cpp
-  mirror: benchmark_mirror_cpp
+  benchmark.driver: benchmark_driver_cpp
+  benchmark.mirror: benchmark_mirror_cpp

--- a/docs/source/examples/benchmark_python.ymmsl
+++ b/docs/source/examples/benchmark_python.ymmsl
@@ -1,5 +1,10 @@
 ymmsl_version: v0.2
 
+imports:
+- from benchmark_model import implementation benchmark
+- from benchmark_programs import implementation benchmark_driver_python
+- from benchmark_programs import implementation benchmark_mirror_python
+
 custom_implementations:
-  driver: benchmark_driver_python
-  mirror: benchmark_mirror_python
+  benchmark.driver: benchmark_driver_python
+  benchmark.mirror: benchmark_mirror_python

--- a/docs/source/examples/dispatch_cpp.ymmsl
+++ b/docs/source/examples/dispatch_cpp.ymmsl
@@ -1,5 +1,8 @@
 ymmsl_version: v0.2
 
+imports:
+- from dispatch_programs import implementation buffer_cpp
+
 models:
   dispatch_cpp:
       components:

--- a/docs/source/examples/eca_python.ymmsl
+++ b/docs/source/examples/eca_python.ymmsl
@@ -1,5 +1,9 @@
 ymmsl_version: v0.2
 
+imports:
+- from eca_programs import implementation elemental_ca_macro_python
+- from eca_programs import implementation elemental_ca_micro_python
+
 models:
   elementary_cellular_automata:
     description: A simple cellular automaton model with cache

--- a/docs/source/examples/ecac_python.ymmsl
+++ b/docs/source/examples/ecac_python.ymmsl
@@ -1,5 +1,10 @@
 ymmsl_version: v0.2
 
+imports:
+- from eca_programs import implementation elemental_ca_macro_python
+- from eca_programs import implementation elemental_ca_micro_python
+- from eca_programs import implementation cache_python
+
 models:
   elementary_cellular_automata:
     description: A simple cellular automaton model with cache

--- a/docs/source/examples/python/requirements.txt
+++ b/docs/source/examples/python/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib>=3,<4
 numpy>=1.22
 sobol_seq==0.2.0
-ymmsl>=0.15.0,<0.16
+ymmsl @ git+https://github.com/multiscale/ymmsl-python.git@develop
 yatiml>=0.12,<0.13
 

--- a/docs/source/examples/rd_checkpoints_cpp.ymmsl
+++ b/docs/source/examples/rd_checkpoints_cpp.ymmsl
@@ -1,8 +1,13 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation checkpointing_diffusion_cpp
+- from rd_programs import implementation checkpointing_reaction_cpp
+
 custom_implementations:
-  macro: checkpointing_diffusion_cpp
-  micro: checkpointing_reaction_cpp
+  reaction_diffusion.macro: checkpointing_diffusion_cpp
+  reaction_diffusion.micro: checkpointing_reaction_cpp
 
 checkpoints:
   simulation_time:

--- a/docs/source/examples/rd_checkpoints_fortran.ymmsl
+++ b/docs/source/examples/rd_checkpoints_fortran.ymmsl
@@ -1,8 +1,13 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation checkpointing_diffusion_fortran
+- from rd_programs import implementation checkpointing_reaction_fortran
+
 custom_implementations:
-  macro: checkpointing_diffusion_fortran
-  micro: checkpointing_reaction_fortran
+  reaction_diffusion.macro: checkpointing_diffusion_fortran
+  reaction_diffusion.micro: checkpointing_reaction_fortran
 
 checkpoints:
   simulation_time:

--- a/docs/source/examples/rd_checkpoints_python.ymmsl
+++ b/docs/source/examples/rd_checkpoints_python.ymmsl
@@ -1,8 +1,13 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation checkpointing_diffusion_python
+- from rd_programs import implementation checkpointing_reaction_python
+
 custom_implementations:
-  macro: checkpointing_diffusion_python
-  micro: checkpointing_reaction_python
+  reaction_diffusion.macro: checkpointing_diffusion_python
+  reaction_diffusion.micro: checkpointing_reaction_python
 
 checkpoints:
   simulation_time:

--- a/docs/source/examples/rd_cpp.ymmsl
+++ b/docs/source/examples/rd_cpp.ymmsl
@@ -1,5 +1,10 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation diffusion_cpp
+- from rd_programs import implementation reaction_cpp
+
 custom_implementations:
-  macro: diffusion_cpp
-  micro: reaction_cpp
+  reaction_diffusion.macro: diffusion_cpp
+  reaction_diffusion.micro: reaction_cpp

--- a/docs/source/examples/rd_cpp_mpi.ymmsl
+++ b/docs/source/examples/rd_cpp_mpi.ymmsl
@@ -1,8 +1,13 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation diffusion_python
+- from rd_programs import implementation reaction_cpp_mpi
+
 description: |
-  Sets the micro model to use the C++ MPI implementation. For use with
-  rd_model.ymmsl.
+  Uses a Python macro model and sets the micro model to use the C++ MPI implementation.
 
 custom_implementations:
-  micro: reaction_cpp_mpi
+  reaction_diffusion.macro: diffusion_python
+  reaction_diffusion.micro: reaction_cpp_mpi

--- a/docs/source/examples/rd_fortran.ymmsl
+++ b/docs/source/examples/rd_fortran.ymmsl
@@ -1,5 +1,10 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation diffusion_fortran
+- from rd_programs import implementation reaction_fortran
+
 custom_implementations:
-  macro: diffusion_fortran
-  micro: reaction_fortran
+  reaction_diffusion.macro: diffusion_fortran
+  reaction_diffusion.micro: reaction_fortran

--- a/docs/source/examples/rd_fortran_mpi.ymmsl
+++ b/docs/source/examples/rd_fortran_mpi.ymmsl
@@ -1,8 +1,14 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation diffusion_python
+- from rd_programs import implementation reaction_fortran_mpi
+
 description: |
   Sets the micro model to use the Fortran MPI implementation. For use with
   rd_model.ymmsl.
 
 custom_implementations:
-  micro: reaction_fortran_mpi
+  reaction_diffusion.macro: diffusion_python
+  reaction_diffusion.micro: reaction_fortran_mpi

--- a/docs/source/examples/rd_manual.sh
+++ b/docs/source/examples/rd_manual.sh
@@ -6,9 +6,8 @@ rm -f manager_location.txt
 # Start muscle_manager in the background, which starts the micro instance
 DONTPLOT=1 muscle_manager --start-all \
     --location-file manager_location.txt \
-    rd_model.ymmsl \
+    rd_manual.ymmsl \
     rd_settings.ymmsl \
-    rd_manual_programs.ymmsl \
     rd_resources.ymmsl &
 
 MUSCLE_MANAGER_PID=$!

--- a/docs/source/examples/rd_manual.ymmsl
+++ b/docs/source/examples/rd_manual.ymmsl
@@ -1,0 +1,11 @@
+ymmsl_version: v0.2
+
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_manual_programs import implementation diffusion_python
+- from rd_manual_programs import implementation reaction_python
+
+custom_implementations:
+  reaction_diffusion.macro: diffusion_python
+  reaction_diffusion.micro: reaction_python
+

--- a/docs/source/examples/rd_model.ymmsl
+++ b/docs/source/examples/rd_model.ymmsl
@@ -16,14 +16,12 @@ models:
           s: state_in
         description: |
           This is the macro model, which calculates the diffusion
-        implementation: diffusion_python
       micro:
         ports:
           f_init: initial_state
           o_f: final_state
         description: |
           This is the micro model, which calculates the reaction
-        implementation: reaction_python
 
     conduits:
       macro.state_out: micro.initial_state

--- a/docs/source/examples/rd_python.ymmsl
+++ b/docs/source/examples/rd_python.ymmsl
@@ -2,9 +2,9 @@ ymmsl_version: v0.2
 
 imports:
 - from rd_model import implementation reaction_diffusion
-- from rd_programs import implementation diffusion_cpp
+- from rd_programs import implementation diffusion_python
 - from rd_programs import implementation reaction_python
 
 custom_implementations:
-  reaction_diffusion.macro: diffusion_cpp
+  reaction_diffusion.macro: diffusion_python
   reaction_diffusion.micro: reaction_python

--- a/docs/source/examples/rd_python_fortran.ymmsl
+++ b/docs/source/examples/rd_python_fortran.ymmsl
@@ -1,4 +1,10 @@
 ymmsl_version: v0.2
 
+imports:
+- from rd_model import implementation reaction_diffusion
+- from rd_programs import implementation diffusion_fortran
+- from rd_programs import implementation reaction_python
+
 custom_implementations:
-  macro: diffusion_fortran
+  reaction_diffusion.macro: diffusion_fortran
+  reaction_diffusion.micro: reaction_python

--- a/docs/source/examples/rdmc_cpp.ymmsl
+++ b/docs/source/examples/rdmc_cpp.ymmsl
@@ -1,7 +1,14 @@
 ymmsl_version: v0.2
 
+imports:
+- from rdmc_model import implementation reaction_diffusion_mc
+- from rd_programs import implementation mc_driver_cpp
+- from rd_programs import implementation load_balancer_cpp
+- from rd_programs import implementation diffusion_cpp
+- from rd_programs import implementation reaction_cpp
+
 custom_implementations:
-  mc: mc_driver_cpp
-  rr: load_balancer_cpp
-  macro: diffusion_cpp
-  micro: reaction_cpp
+  reaction_diffusion_mc.mc: mc_driver_cpp
+  reaction_diffusion_mc.rr: load_balancer_cpp
+  reaction_diffusion_mc.macro: diffusion_cpp
+  reaction_diffusion_mc.micro: reaction_cpp

--- a/docs/source/examples/rdmc_fortran.ymmsl
+++ b/docs/source/examples/rdmc_fortran.ymmsl
@@ -1,7 +1,14 @@
 ymmsl_version: v0.2
 
+imports:
+- from rdmc_model import implementation reaction_diffusion_mc
+- from rd_programs import implementation mc_driver_fortran
+- from rd_programs import implementation load_balancer_fortran
+- from rd_programs import implementation diffusion_fortran
+- from rd_programs import implementation reaction_fortran
+
 custom_implementations:
-  mc: mc_driver_fortran
-  rr: load_balancer_fortran
-  macro: diffusion_fortran
-  micro: reaction_fortran
+  reaction_diffusion_mc.mc: mc_driver_fortran
+  reaction_diffusion_mc.rr: load_balancer_fortran
+  reaction_diffusion_mc.macro: diffusion_fortran
+  reaction_diffusion_mc.micro: reaction_fortran

--- a/docs/source/fortran.rst
+++ b/docs/source/fortran.rst
@@ -35,7 +35,7 @@ You can then run the examples using the provided scripts in
 .. code-block:: bash
 
   . python/build/venv/bin/activate
-  muscle_manager --start-all rd_model.ymmsl rd_fortran.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources.ymmsl
+  YMMSL_PATH=. muscle_manager --start-all rd_fortran.ymmsl rd_settings.ymmsl rd_resources.ymmsl
 
 
 Log output
@@ -54,30 +54,22 @@ the messages will end up in ``<rundir>/instances/<instance-id>/stdout.txt`` or
 ``stderr.txt``. If the model logs to a file in the working directory, then
 you'll find it in ``<rundir>/instances/<instance-id>/workdir/``.
 
-Overriding implementations
---------------------------
+Setting implementations
+-----------------------
 
-In the above commands, we use the same ``rd_model.ymmsl`` file that we used for the
-Python version of the reaction-diffusion model. This file specifies the Python
-implementations of the ``macro`` and ``micro`` components. To run the model with the
-alternative C++ implementations, we need to override them, which is done in
-``rd_fortran.ymmsl``:
+The above commands are the same as for the Python version of the reaction-diffusion
+model, except that we're using ``rd_fortran.ymmsl`` instead of ``rd_python.ymmsl``. This
+file is almost the same, except that it imports Fortran implementations of the reaction
+and diffusion models:
 
 .. literalinclude:: examples/rd_fortran.ymmsl
   :caption: ``docs/source/examples/rd_fortran.ymmsl``
   :language: yaml
 
-The ``custom_implementations`` section contains a mapping that specifies an
-implementation (to the right of the ``:``) for one or more components (on the left). Any
-implementations specified here will override the implementation set in the model
-description. Multiple yMMSL files with custom implementations may be given and all of
-them will be applied. If a component has a custom implementation in more than one file,
-then the one that is farthest to the right on the command line will be applied.
-
 MUSCLE3 allows programs written in different languages to be used together
-transparently. The ``rd_python_fortran.ymmsl`` file only overrides the implementation for
-``macro``, but leaves ``micro`` to run with the Python reaction program. Give it a try
-and look at the logs to see it in action!
+transparently. The ``rd_python_fortran.ymmsl`` file sets a Fortran implementation for
+``macro``, but makes ``micro`` run with the Python reaction program. Give it a try and
+look at the logs to see it in action!
 
 Can you run the model with the Python diffusion program and the Fortran reaction
 program? You'll need to make your own yMMSL file for this.

--- a/docs/source/mpi.rst
+++ b/docs/source/mpi.rst
@@ -51,8 +51,8 @@ there's both a C++ and a Fortran implementation of the reaction model:
 .. code-block:: bash
 
   . python/build/venv/bin/activate
-  muscle_manager --start-all rd_model.ymmsl rd_cpp_mpi.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources_mpi.ymmsl
-  muscle_manager --start-all rd_model.ymmsl rd_fortran_mpi.ymmsl rd_settings.ymmsl rd_programs.ymmsl rd_resources_mpi.ymmsl
+  YMMSL_PATH=. muscle_manager --start-all rd_cpp_mpi.ymmsl rd_settings.ymmsl rd_resources_mpi.ymmsl
+  YMMSL_PATH=. muscle_manager --start-all rd_fortran_mpi.ymmsl rd_settings.ymmsl rd_resources_mpi.ymmsl
 
 
 Note that activating the virtual environment is needed to make the

--- a/libmuscle/python/libmuscle/manager/hammer.py
+++ b/libmuscle/python/libmuscle/manager/hammer.py
@@ -93,31 +93,6 @@ being added to the flattened model.
 """
 
 
-def apply_custom_implementations(nested_config: Configuration) -> None:
-    """Applies custom implementations and removes them.
-
-    Custom implementations are keyed by the full component path, so we need to traverse
-    the hierarchy to determine that, then copy the implementation reference.
-
-    After this, the configuration will not have any entries in custom_implementations.
-    """
-    root_model = nested_config.root_model()
-    queue: List[Tuple[Model, Reference]] = [(root_model, Reference([]))]
-    while queue:
-        model, parent_path = queue.pop(0)
-        for component in model.components.values():
-            cmp_path = parent_path + component.name
-            component.implementation = nested_config.custom_implementations.get(
-                    cmp_path, component.implementation)
-
-            if component.implementation:
-                model_impl = nested_config.models.get(component.implementation)
-                if model_impl:
-                    queue.append((model_impl, cmp_path))
-
-    nested_config.custom_implementations.clear()
-
-
 def process_components(
         nested_config: Configuration, flat_model: Model, node: Node) -> List[Node]:
     """Copy components to the flattened model.
@@ -125,7 +100,7 @@ def process_components(
     This copies the components in the given model in nested_config to flat_model,
     prefixing their names with the given path and and multiplicities with the given
     multiplicity. Components that are implemented by a model are recursed into and are
-    note added, and components with a None implementation are skipped and not added
+    not added, and components with a None implementation are skipped and not added
     either.
 
     Args:
@@ -265,7 +240,7 @@ def flatten(
     from the root model and a virtual component with an empty name and multiplicity. As
     it recurses downward, it accumulates component names and multiplicities.
 
-    Program-implemented components inside of the processed model-implemnted components
+    Program-implemented components inside of the processed model-implemented components
     have their names and implementations prefixed with those of the parent component,
     and conduits between them have their endpoints updated accordingly. Finally,
     components leading into and out of submodels are glued together and added as well.
@@ -286,8 +261,6 @@ def flatten(
     flat_model = Model(
             str(root_model.name), Ports(), root_model.description,
             root_model.supported_settings, [], [])
-
-    apply_custom_implementations(config)
 
     queue: List[Node] = [(root_model, Reference([]), [])]
     while queue:

--- a/libmuscle/python/libmuscle/manager/test/test_hammer.py
+++ b/libmuscle/python/libmuscle/manager/test/test_hammer.py
@@ -1,5 +1,5 @@
 from ymmsl import load
-from ymmsl.v0_2 import Conduit, Model, Reference
+from ymmsl.v0_2 import Conduit, Model, Reference, resolve
 
 from libmuscle.manager.hammer import flatten, Plate
 
@@ -593,8 +593,9 @@ def test_flatten_passthrough_overload() -> None:
     assert len(model.conduits) == 1
     assert has_conduit(model, 'c1.out', 'c3.in')
 
-    nested_config.custom_implementations['c2'] = Reference('p2')
-
+    nested_config = load(nested_config_yaml)
+    nested_config.custom_implementations[Reference('framework.c2')] = Reference('p2')
+    resolve(Reference([]), nested_config)      # apply custom_implementations
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
@@ -661,7 +662,9 @@ def test_remove_no_implementation() -> None:
 
     assert len(model.conduits) == 0
 
-    nested_config.custom_implementations['micro'] = Reference('p2')
+    nested_config.custom_implementations[Reference('optional_micro.micro')] = \
+        Reference('p2')
+    resolve(Reference([]), nested_config)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
@@ -680,9 +683,11 @@ def test_remove_no_implementation() -> None:
     assert len(flat_config.custom_implementations) == 0
     assert model.components['micro'].implementation == 'p2'
 
+    nested_config = load(nested_config_yaml)
     nested_config.models['optional_micro'].components['micro'].implementation = \
         Reference('p2')
-    nested_config.custom_implementations['micro'] = None
+    nested_config.custom_implementations[Reference('optional_micro.micro')] = None
+    resolve(Reference([]), nested_config)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
@@ -694,3 +699,76 @@ def test_remove_no_implementation() -> None:
     assert 'macro' in model.components
 
     assert len(model.conduits) == 0
+
+
+def test_nested_custom_implementations() -> None:
+    nested_config_yaml = (
+            'ymmsl_version: v0.2\n'
+            'description: Testing nested custom implementations\n'
+            'models:\n'
+            '  outer:\n'
+            '    description: Outer model\n'
+            '    components:\n'
+            '      c1:\n'
+            '        ports:\n'
+            '          o_f: out\n'
+            '        description: Component c1\n'
+            '        implementation: p1\n'
+            '      c2:\n'
+            '        ports:\n'
+            '          f_init: in\n'
+            '        description: Component c1\n'
+            '        implementation: p1\n'
+            '    conduits:\n'
+            '      c1.out: c2.in\n'
+            '  middle:\n'
+            '    ports:\n'
+            '      o_f: out\n'
+            '    description: Middle model\n'
+            '    components:\n'
+            '      c1:\n'
+            '        ports:\n'
+            '          o_f: out\n'
+            '        description: Another component c1\n'
+            '      c2:\n'
+            '        ports:\n'
+            '          o_f: out\n'
+            '        description: Component c2\n'
+            '    conduits:\n'
+            '      c2.out: out\n'
+            '  inner:\n'
+            '    ports:\n'
+            '      o_f: out\n'
+            '    description: Inner model\n'
+            '    components:\n'
+            '      c1:\n'
+            '        ports:\n'
+            '          o_f: out\n'
+            '        description: Yet another c1, it could happen...\n'
+            '        implementation: p1\n'
+            '    conduits:\n'
+            '      c1.out: out\n'
+            'programs:\n'
+            '  p1:\n'
+            '    description: Program 1\n'
+            '    executable: /home/user/codes/p1\n'
+            '  p2:\n'
+            '    description: Program 2\n'
+            '    executable: /home/user/codes/p2\n'
+            'custom_implementations:\n'
+            '  outer.c1: middle\n'
+            '  outer.c1.c1: inner\n'
+            '  outer.c1.c2: inner\n'
+            '  outer.c1.c2.c1: p2\n'
+            )
+    nested_config = load(nested_config_yaml)
+    resolve(Reference([]), nested_config)
+    flat_config = flatten(nested_config)
+
+    flat_model = flat_config.models['outer']
+    assert len(flat_model.components) == 3
+    assert flat_model.components['c1.c1.c1'].implementation == 'p1'
+    assert flat_model.components['c1.c2.c1'].implementation == 'p2'
+    assert len(flat_model.conduits) == 1
+    assert flat_model.conduits[0].sender == 'c1.c2.c1.out'
+    assert flat_model.conduits[0].receiver == 'c2.in'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
     "psutil>=5.0.0",
     "parsimonious",
     "numpy>=1.22",
-    "ymmsl>=0.15.0,<0.16",         # Also in examples requirements.txt
-    # "ymmsl @ git+https://github.com/multiscale/ymmsl-python.git",
+    # "ymmsl>=0.15.1,<0.16",         # Also in examples requirements.txt
+    "ymmsl @ git+https://github.com/multiscale/ymmsl-python.git@develop",
     "yatiml>=0.12,<0.13",
 ]
 


### PR DESCRIPTION
This removes the application of custom implementations from the hammer, and instead uses the new algorithm that's now built into the `resolve()` function in ymmsl-python. It also updates the examples to use custom implementations and imports more, and the documentation to match.