### PR TITLE
Apply a few small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,6 @@ distclean: docsclean
 	- find docs scripts integration_test muscle3 libmuscle/python -name __pycache__ -type d -depth -exec rm -rf \{\} \;
 	rm -rf ./build
 	rm -rf $(CURDIR)/libmuscle/build/test_install/*
-	rm -rf libmuscle/python/libmuscle/version.py
 
 .PHONY: fortran
 fortran: cpp

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-MUSCLE3
-Copyright 2018-2022, Netherlands eScience Center and University of Amsterdam
-Copyright 2023, Netherlands eScience Center
-Copyright 2022-2023, The ITER Organization
+This product includes MUSCLE3, software developed by the Netherlands eScience Center,
+University of Amsterdam, and Ignition Computing and funded by the Netherlands eScience
+Center, NWO, EUROfusion and the ITER Organization.
+

--- a/docs/source/examples/.gitignore
+++ b/docs/source/examples/.gitignore
@@ -4,3 +4,5 @@ benchmark_programs.ymmsl
 dispatch_programs.ymmsl
 eca_programs.ymmsl
 run_*
+manager_location.txt
+


### PR DESCRIPTION
This fixes `make distclean` to not remove `version.py`, as with the switch to pyproject.toml that is no longer a generated file. It also adds a `manager_location.py` file that is created by the manual execution example to the .gitignore file, and it updates the NOTICE file.