### PR TITLE
Pass selected model when checking configuration consistency

### DIFF
--- a/docs/source/examples/python/requirements.txt
+++ b/docs/source/examples/python/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib>=3,<4
 numpy>=1.22
 sobol_seq==0.2.0
-ymmsl>=0.16.0,<0.17
+ymmsl@git+https://github.com/multiscale/ymmsl-python.git@develop
 yatiml>=0.12,<0.13
 

--- a/muscle3/muscle_manager.py
+++ b/muscle3/muscle_manager.py
@@ -113,7 +113,7 @@ def _manage_simulation(
         sys.exit(1)
 
     try:
-        configuration.check_consistent(start_all)
+        configuration.check_consistent(start_all, model)
     except Exception as exc:
         print('Failed to start the simulation, found a configuration error:\n' +
               textwrap.indent(str(exc), 4*' '), file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "parsimonious",
     "typing_extensions~=4.6",
     "numpy>=1.22",
-    "ymmsl>=0.16.0,<0.17",         # Also in examples requirements.txt
-    # "ymmsl @ git+https://github.com/multiscale/ymmsl-python.git@develop",
+    # "ymmsl>=0.16.0,<0.17",         # Also in examples requirements.txt
+    "ymmsl @ git+https://github.com/multiscale/ymmsl-python.git@develop",
     "yatiml>=0.12,<0.13",
 ]
 


### PR DESCRIPTION
This passes the selected model to `Configuration.check_consistent()` to allow specifying resources only for the selected model.

To do:
- [x] remove the bytes/bytearray fix once #360 is merged
- [x] use ymmsl@develop once https://github.com/multiscale/ymmsl-python/pull/45 is merged
