### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_macos14_clang.yaml
+++ b/.github/workflows/ci_macos14_clang.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ci_macos14_gcc_gfortran.yaml
+++ b/.github/workflows/ci_macos14_gcc_gfortran.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ci_macos15_clang.yaml
+++ b/.github/workflows/ci_macos15_clang.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ci_macos15_gcc_gfortran.yaml
+++ b/.github/workflows/ci_macos15_gcc_gfortran.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ci_macos26_clang.yaml
+++ b/.github/workflows/ci_macos26_clang.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ci_macos26_gcc_gfortran.yaml
+++ b/.github/workflows/ci_macos26_gcc_gfortran.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/ci_python_compatibility.yaml
+++ b/.github/workflows/ci_python_compatibility.yaml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Check out the source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache Tox
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.tox
         key: python-compatibility-${{ matrix.python-version }}-tox

--- a/.github/workflows/ci_python_macos.yaml
+++ b/.github/workflows/ci_python_macos.yaml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Check out the source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache Tox
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.tox
         key: python-macos-${{ matrix.python-version }}-tox

--- a/.github/workflows/ci_ubuntu22.04.yaml
+++ b/.github/workflows/ci_ubuntu22.04.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run tests on Ubuntu 22.04
       run: docker run -v "${GITHUB_WORKSPACE}:/workspace" --env LC_ALL=C.UTF-8 --env LANG=C.UTF-8 --env DEBIAN_FRONTEND=noninteractive ubuntu:22.04 /bin/bash -c 'apt-get update && apt-get -y dist-upgrade && apt-get -y install build-essential cmake gfortran git valgrind libopenmpi-dev pkg-config python3 python3-pip python3-venv curl && apt-get -y remove libssl-dev && useradd -m -d /home/muscle3 muscle3 && su muscle3 -c -- "cp -r --preserve=mode /workspace /home/muscle3/muscle3" && su muscle3 -c -- "pip3 install -U pip setuptools wheel" && su muscle3 -c -- "cd /home/muscle3/muscle3 && make test_examples"'

--- a/.github/workflows/ci_ubuntu22.04_clang.yaml
+++ b/.github/workflows/ci_ubuntu22.04_clang.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run tests on Ubuntu 22.04 with Clang
       run: docker run -v "${GITHUB_WORKSPACE}:/workspace" --env LC_ALL=C.UTF-8 --env LANG=C.UTF-8 --env DEBIAN_FRONTEND=noninteractive ubuntu:22.04 /bin/bash -c 'apt-get update && apt-get -y dist-upgrade && apt-get -y install build-essential clang cmake gfortran git valgrind libopenmpi-dev pkg-config python3 python3-pip python3-venv curl && apt-get -y remove libssl-dev && useradd -m -d /home/muscle3 muscle3 && su muscle3 -c -- "cp -r --preserve=mode /workspace /home/muscle3/muscle3" && su muscle3 -c -- "pip3 install -U pip setuptools wheel" && su muscle3 -c -- "cd /home/muscle3/muscle3 && CXXFLAGS=-fPIE OMPI_CXX=clang++ CXX=clang++ make test_examples"'

--- a/.github/workflows/ci_ubuntu22.04_intel.yaml
+++ b/.github/workflows/ci_ubuntu22.04_intel.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run tests on Ubuntu 22.04 with the Intel compiler
       run: docker run -v "${GITHUB_WORKSPACE}:/workspace" --env LC_ALL=C.UTF-8 --env LANG=C.UTF-8 --env DEBIAN_FRONTEND=noninteractive ubuntu:22.04 /bin/bash -c 'apt-get update && apt-get -y install wget && wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && mv GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB /etc/apt/trusted.gpg.d/intel-sw-products.asc && echo "deb https://apt.repos.intel.com/oneapi all main" >/etc/apt/sources.list.d/oneAPI.list && apt-get update && apt-get -y dist-upgrade && apt-get -y install build-essential cmake git valgrind pkg-config python3 python3-pip python3-venv curl intel-oneapi-compiler-dpcpp-cpp intel-oneapi-compiler-fortran intel-oneapi-mpi-devel && apt-get -y remove libssl-dev && useradd -m -d /home/muscle3 muscle3 && su muscle3 -c -- "cp -r --preserve=mode /workspace /home/muscle3/muscle3" && su muscle3 -c -- "pip3 install -U pip setuptools wheel" && su muscle3 -c -- "cd /home/muscle3/muscle3 && . /opt/intel/oneapi/setvars.sh && MPICXX=\"mpiicpc -cxx=icpx\" CXX=icpx MPIFC=\"mpiifort -fc=ifx\" FC=ifx MPI_EXECUTION_MODEL=intelmpi make test_examples"'

--- a/.github/workflows/ci_ubuntu24.04.yaml
+++ b/.github/workflows/ci_ubuntu24.04.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run tests on Ubuntu 24.04
       run: docker run -v "${GITHUB_WORKSPACE}:/workspace" --env LC_ALL=C.UTF-8 --env LANG=C.UTF-8 --env DEBIAN_FRONTEND=noninteractive ubuntu:24.04 /bin/bash -c 'apt-get update && apt-get -y dist-upgrade && apt-get -y install build-essential cmake gfortran git valgrind libopenmpi-dev pkg-config python3 python3-pip python3-venv curl && apt-get -y remove libssl-dev && useradd -m -d /home/muscle3 muscle3 && su muscle3 -c -- "cp -r --preserve=mode /workspace /home/muscle3/muscle3" && su muscle3 -c -- "cd /home/muscle3/muscle3 && make test_examples"'

--- a/.github/workflows/ci_ubuntu24.04_clang.yaml
+++ b/.github/workflows/ci_ubuntu24.04_clang.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run tests on Ubuntu 24.04 with Clang
       run: docker run -v "${GITHUB_WORKSPACE}:/workspace" --env LC_ALL=C.UTF-8 --env LANG=C.UTF-8 --env DEBIAN_FRONTEND=noninteractive ubuntu:24.04 /bin/bash -c 'apt-get update && apt-get -y dist-upgrade && apt-get -y install build-essential clang cmake gfortran git valgrind libopenmpi-dev pkg-config python3 python3-pip python3-venv curl && apt-get -y remove libssl-dev && useradd -m -d /home/muscle3 muscle3 && su muscle3 -c -- "cp -r --preserve=mode /workspace /home/muscle3/muscle3" && su muscle3 -c -- "cd /home/muscle3/muscle3 && CXXFLAGS=-fPIE OMPI_CXX=clang++ CXX=clang++ make test_examples"'

--- a/.github/workflows/ci_ubuntu24.04_intel.yaml
+++ b/.github/workflows/ci_ubuntu24.04_intel.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run tests on Ubuntu 24.04 with the Intel compiler
       run: docker run -v "${GITHUB_WORKSPACE}:/workspace" --env LC_ALL=C.UTF-8 --env LANG=C.UTF-8 --env DEBIAN_FRONTEND=noninteractive ubuntu:24.04 /bin/bash -c 'apt-get update && apt-get -y install wget && wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && mv GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB /etc/apt/trusted.gpg.d/intel-sw-products.asc && echo "deb https://apt.repos.intel.com/oneapi all main" >/etc/apt/sources.list.d/oneAPI.list && apt-get update && apt-get -y dist-upgrade && apt-get -y install build-essential cmake git valgrind pkg-config python3 python3-pip python3-venv curl intel-oneapi-compiler-dpcpp-cpp intel-oneapi-compiler-fortran intel-oneapi-mpi-devel && apt-get -y remove libssl-dev && useradd -m -d /home/muscle3 muscle3 && su muscle3 -c -- "cp -r --preserve=mode /workspace /home/muscle3/muscle3" && su muscle3 -c -- "cd /home/muscle3/muscle3 && . /opt/intel/oneapi/setvars.sh && MPICXX=\"mpiicpc -cxx=icpx\" CXX=icpx MPIFC=\"mpiifort -fc=ifx\" FC=ifx MPI_EXECUTION_MODEL=intelmpi make test_examples"'


### PR DESCRIPTION
Updates the following actions to a newer version:
- actions/checkout: v4 -> v6
- actions/setup-python: v4 -> v6
- actions/cache: v3 -> v5

Change is required because the old versions used Node.js 20, which will be unsupported after September.