### PR TITLE
Add Iris as a coauthor

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,6 +15,9 @@ authors:
   -
     family-names: Sebregts
     given-names: Maarten
+  -
+    family-names: Van der Werf
+    given-names: Iris
 
 keywords:
   - multiscale

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'muscle3'
 copyright = '2018-2022 University of Amsterdam and Netherlands eScience Center, 2022-2023, 2026 The ITER Organization, and 2023-2026 Netherlands eScience Center'
-author = 'Lourens Veen'
+author = 'Lourens Veen, Maarten Sebregts and Iris van der Werf'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.rst"
 authors = [
   {name = "Lourens Veen", email = "l.veen@esciencecenter.nl"},
   {name = "Maarten Sebregts", email = "msebregts@ignitioncomputing.com"},
+  {name = "Iris van der Werf", email = "ivanderwerf@ignitioncomputing.com"},
 ]
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]


### PR DESCRIPTION
This adds @IrisvdWerf as a coauthor to the CITATION.cff file.

The new Pytest integration she created is a significant contribution, extending MUSCLE3 from communication and coordination between simulation components at runtime to now also supporting the software development process used to create the coupled model.

Thanks Iris!