### PR TITLE
Update release process post 0.10.0

### DIFF
--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -85,8 +85,8 @@ shows up:
 It may give some warnings about missing references, that's a known issue and
 normally harmless. Next, point your web browser to
 ``docs/build/index.html`` and verify that the documentation built
-correctly. In particular, the new version number should be in the browser's
-title bar as well as in the blue box on the top left of the page.
+correctly. Also check that the new version number is in the browser's
+title bar.
 
 Run tests
 ---------

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -84,7 +84,7 @@ shows up:
 
 It may give some warnings about missing references, that's a known issue and
 normally harmless. Next, point your web browser to
-``docs/build/html/index.html`` and verify that the documentation built
+``docs/build/index.html`` and verify that the documentation built
 correctly. In particular, the new version number should be in the browser's
 title bar as well as in the blue box on the top left of the page.
 

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -67,7 +67,7 @@ Update version
 
 Next, the version should be updated. There is a single version tag in the
 ``VERSION`` file in the root of the repository. On the development branch, the
-version should be set to ``x.y.z-dev``, where ``x.y.z`` is the next expected
+version should be set to ``x.y.z-dev0``, where ``x.y.z`` is the next expected
 version (it's fine if that changes later, e.g. because you end up releasing
 2.0.0 rather than 1.4.0).  On the release branch, it should be set to the number
 of this release of course.
@@ -201,7 +201,7 @@ that we want to have back on the develop branch. So we'll merge it back in:
 
 We use --no-commit to give ourselves a chance to edit the changes before
 committing them. Make sure that README.rst is taken from the develop side,
-and that VERSION is given a new number, probably x.y.{z+1}-dev unless you have big
+and that VERSION is given a new number, probably x.y.{z+1}-dev0 unless you have big
 plans. When done, commit the merge and continue developing.
 
 Update issues

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -201,9 +201,8 @@ that we want to have back on the develop branch. So we'll merge it back in:
 
 We use --no-commit to give ourselves a chance to edit the changes before
 committing them. Make sure that README.rst is taken from the develop side,
-CHANGELOG.md comes from the release branch, and VERSION is given a new number,
-probably x.y.{z+1}-dev unless you have big plans. When done, commit the merge
-and continue developing.
+and that VERSION is given a new number, probably x.y.{z+1}-dev unless you have big
+plans. When done, commit the merge and continue developing.
 
 Update issues
 -------------

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -27,7 +27,7 @@ exactly the same process, so it's best to check.
 Check metadata
 --------------
 
-- Check the metadata in ``setup.py``, and update as necessary
+- Check the metadata in ``pyproject.toml``, and update as necessary
 - Check the dependencies, and fix them to an appropriate range of versions
 - Check the copyright date and owners in ``README.rst`` and ``docs/source/conf.py``
   and update as necessary.
@@ -165,12 +165,7 @@ can start using it. To build, use:
 
 .. code-block:: bash
 
-  rm -r ./build
-  python3 setup.py sdist bdist_wheel
-
-Note that we remove ``./build``, which is the build directory setuptools uses,
-to ensure that we're doing a clean build, I've seen some weird mixes of versions
-on occasion so it's better to be safe than sorry.
+  python3 -m build
 
 We can then check to see if everything is okay using
 

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -201,7 +201,7 @@ that we want to have back on the develop branch. So we'll merge it back in:
 
 We use --no-commit to give ourselves a chance to edit the changes before
 committing them. Make sure that README.rst is taken from the develop side,
-and that VERSION is given a new number, probably x.y.{z+1}-dev0 unless you have big
+and that VERSION is given a new number, probably x.y.{z+1}.dev0 unless you have big
 plans. When done, commit the merge and continue developing.
 
 Update issues

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -67,7 +67,7 @@ Update version
 
 Next, the version should be updated. There is a single version tag in the
 ``VERSION`` file in the root of the repository. On the development branch, the
-version should be set to ``x.y.z-dev0``, where ``x.y.z`` is the next expected
+version should be set to ``x.y.z.dev0``, where ``x.y.z`` is the next expected
 version (it's fine if that changes later, e.g. because you end up releasing
 2.0.0 rather than 1.4.0).  On the release branch, it should be set to the number
 of this release of course.


### PR DESCRIPTION
This updates the release documentation with the things I ran into when releasing 0.10.0.

One issue we still have is that I have to temporarily disable branch protection to merge the release branch back into develop, and another is that we can't use setuptools-scm because develop doesn't have the version tags in its past. I'm going to think about whether we can tweak the release process to fix that, and maybe to automate it a bit more, but that's for another time.