### PR TITLE
Add more ruff formatting

### DIFF
--- a/integration_test/cluster_test/conftest.py
+++ b/integration_test/cluster_test/conftest.py
@@ -339,7 +339,7 @@ def hwthread_to_core():
     a function that takes a comma-separated list of hwthread ids and returns a list of
     corresponding core ids.
     """
-    with open('/proc/cpuinfo', 'r') as f:
+    with open('/proc/cpuinfo') as f:
         cpuinfo = f.readlines()
 
     def get_values(cpuinfo, field):

--- a/integration_test/test_base_env.py
+++ b/integration_test/test_base_env.py
@@ -21,44 +21,44 @@ def test_base_env(tmpdir):
     test_component = cpp_test_dir / 'component_test'
 
     # make config
-    ymmsl_text = ((
-            'ymmsl_version: v0.2\n'
-            'description: Testing base_env option\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  components:\n'
-            '    macro:\n'
-            '      description: A macro model\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      implementation: component_clean\n'
-            '    micro:\n'
-            '      description: A micro model\n'
-            '      ports:\n'
-            '        f_init: init\n'
-            '        o_f: result\n'
-            '      implementation: component_login\n'
-            '  conduits:\n'
-            '    macro.out: micro.init\n'
-            '    micro.result: macro.in\n'
-            'programs:\n'
-            '  component_clean:\n'
-            '    base_env: clean\n'
-            '    env:\n'
-            '      +LD_LIBRARY_PATH: :{ld_lib_path}\n'
-            '    executable: {test_component}\n'
-            '  component_login:\n'
-            '    base_env: login\n'
-            '    env:\n'
-            '      +LD_LIBRARY_PATH: :{ld_lib_path}\n'
-            '    executable: {test_component}\n'
-            'resources:\n'
-            '  test_model.macro:\n'
-            '    threads: 1\n'
-            '  test_model.micro:\n'
-            '    threads: 1\n'
-            ).format(ld_lib_path=ld_lib_path, test_component=test_component))
+    ymmsl_text = (f"""
+ymmsl_version: v0.2
+description: Testing base_env option
+models:
+- name: test_model
+  components:
+    macro:
+      description: A macro model
+      ports:
+        o_i: out
+        s: in
+      implementation: component_clean
+    micro:
+      description: A micro model
+      ports:
+        f_init: init
+        o_f: result
+      implementation: component_login
+  conduits:
+    macro.out: micro.init
+    micro.result: macro.in
+programs:
+  component_clean:
+    base_env: clean
+    env:
+      +LD_LIBRARY_PATH: :{ld_lib_path}
+    executable: {test_component}
+  component_login:
+    base_env: login
+    env:
+      +LD_LIBRARY_PATH: :{ld_lib_path}
+    executable: {test_component}
+resources:
+  test_model.macro:
+    threads: 1
+  test_model.micro:
+    threads: 1
+""")
 
     config = ymmsl.load(ymmsl_text)
 

--- a/integration_test/test_crash_cleanup.py
+++ b/integration_test/test_crash_cleanup.py
@@ -22,44 +22,43 @@ def test_crash_cleanup(tmpdir):
     crash_component = cpp_test_dir / 'crashing_component_test'
 
     # make config
-    ymmsl_text = ((
-            'ymmsl_version: v0.2\n'
-            'description: A crash cleanup test model\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: A macro-micro model that crashes\n'
-            '  components:\n'
-            '    macro:\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      description: A crashing macro model\n'
-            '      implementation: crashing_component\n'
-            '    micro:\n'
-            '      ports:\n'
-            '        f_init: init\n'
-            '        o_f: result\n'
-            '      description: A non-crashing micro model\n'
-            '      implementation: component\n'
-            '  conduits:\n'
-            '    macro.out: micro.init\n'
-            '    micro.result: macro.in\n'
-            'programs:\n'
-            '  crashing_component:\n'
-            '    env:\n'
-            '      LD_LIBRARY_PATH: {}\n'
-            '    executable: {}\n'
-            '  component:\n'
-            '    env:\n'
-            '      LD_LIBRARY_PATH: {}\n'
-            '    executable: {}\n'
-            'resources:\n'
-            '  test_model.macro:\n'
-            '    threads: 1\n'
-            '  test_model.micro:\n'
-            '    threads: 1\n'
-            ).format(
-                ld_lib_path, crash_component, ld_lib_path, test_component))
+    ymmsl_text = f"""
+ymmsl_version: v0.2
+description: A crash cleanup test model
+models:
+- name: test_model
+  description: A macro-micro model that crashes
+  components:
+    macro:
+      ports:
+        o_i: out
+        s: in
+      description: A crashing macro model
+      implementation: crashing_component
+    micro:
+      ports:
+        f_init: init
+        o_f: result
+      description: A non-crashing micro model
+      implementation: component
+  conduits:
+    macro.out: micro.init
+    micro.result: macro.in
+programs:
+  crashing_component:
+    env:
+      LD_LIBRARY_PATH: {ld_lib_path}
+    executable: {crash_component}
+  component:
+    env:
+      LD_LIBRARY_PATH: {ld_lib_path}
+    executable: {test_component}
+resources:
+  test_model.macro:
+    threads: 1
+  test_model.micro:
+    threads: 1
+"""
 
     config = ymmsl.load(ymmsl_text)
 

--- a/integration_test/test_model_imports.py
+++ b/integration_test/test_model_imports.py
@@ -1,7 +1,7 @@
 from multiprocessing import Process
 import os
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 from muscle3.muscle_manager import _manage_simulation
 

--- a/integration_test/test_mpi_macro_micro.py
+++ b/integration_test/test_mpi_macro_micro.py
@@ -19,7 +19,7 @@ def macro():
 
             # s/b
             msg = instance.receive('in')
-            assert msg.data == 'testing back {}'.format(i)
+            assert msg.data == f'testing back {i}'
             assert msg.timestamp == i * 10.0
 
 

--- a/integration_test/test_registration.py
+++ b/integration_test/test_registration.py
@@ -44,9 +44,9 @@ def test_wiring(log_file_in_tmpdir, mmp_server_process):
             client.request_peers()
 
     for i in range(5):
-        instance = Reference('micro[{}]'.format(i))
+        instance = Reference(f'micro[{i}]')
         client2 = MMPClient(instance, mmp_server_process)
-        location = 'direct:{}'.format(instance)
+        location = f'direct:{instance}'
         client2.register_instance([location], [])
         client2.close()
 
@@ -57,9 +57,9 @@ def test_wiring(log_file_in_tmpdir, mmp_server_process):
             client.request_peers()
 
     for i in range(5, 10):
-        instance = Reference('micro[{}]'.format(i))
+        instance = Reference(f'micro[{i}]')
         client2 = MMPClient(instance, mmp_server_process)
-        location = 'direct:{}'.format(instance)
+        location = f'direct:{instance}'
         client2.register_instance([location], [])
         client2.close()
 

--- a/integration_test/test_start_all.py
+++ b/integration_test/test_start_all.py
@@ -21,38 +21,38 @@ def test_start_all(tmpdir):
     test_component = cpp_test_dir / 'component_test'
 
     # make config
-    ymmsl_text = ((
-            'ymmsl_version: v0.2\n'
-            'description: A simple test model to test starting programs\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  components:\n'
-            '    macro:\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      description: The macro model\n'
-            '      implementation: component\n'
-            '    micro:\n'
-            '      ports:\n'
-            '        f_init: init\n'
-            '        o_f: result\n'
-            '      description: The micro model\n'
-            '      implementation: component\n'
-            '  conduits:\n'
-            '    macro.out: micro.init\n'
-            '    micro.result: macro.in\n'
-            'programs:\n'
-            '  component:\n'
-            '    env:\n'
-            '      +LD_LIBRARY_PATH: :{}\n'
-            '    executable: {}\n'
-            'resources:\n'
-            '  test_model.macro:\n'
-            '    threads: 1\n'
-            '  test_model.micro:\n'
-            '    threads: 1\n'
-            ).format(ld_lib_path, test_component))
+    ymmsl_text = f"""
+ymmsl_version: v0.2
+description: A simple test model to test starting programs
+models:
+- name: test_model
+  components:
+    macro:
+      ports:
+        o_i: out
+        s: in
+      description: The macro model
+      implementation: component
+    micro:
+      ports:
+        f_init: init
+        o_f: result
+      description: The micro model
+      implementation: component
+  conduits:
+    macro.out: micro.init
+    micro.result: macro.in
+programs:
+  component:
+    env:
+      +LD_LIBRARY_PATH: :{ld_lib_path}
+    executable: {test_component}
+resources:
+  test_model.macro:
+    threads: 1
+  test_model.micro:
+    threads: 1
+"""
 
     config = ymmsl.load(ymmsl_text)
 

--- a/integration_test/test_start_mpi.py
+++ b/integration_test/test_start_mpi.py
@@ -23,46 +23,44 @@ def test_start_mpi(tmpdir, mpi_exec_model):
     mpi_test_component = cpp_test_dir / 'mpi_component_test'
 
     # make config
-    ymmsl_text = ((
-            'ymmsl_version: v0.2\n'
-            'description: Configuration to test starting models with MPI\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: Macro-micro model with an MPI implementation\n'
-            '  components:\n'
-            '    macro:\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      description: The macro model\n'
-            '      implementation: component\n'
-            '    micro:\n'
-            '      ports:\n'
-            '        f_init: init\n'
-            '        o_f: result\n'
-            '      description: The micro model, parallel version\n'
-            '      implementation: mpi_component\n'
-            '  conduits:\n'
-            '    macro.out: micro.init\n'
-            '    micro.result: macro.in\n'
-            'programs:\n'
-            '  component:\n'
-            '    env:\n'
-            '      +LD_LIBRARY_PATH: :{}\n'
-            '    executable: {}\n'
-            '  mpi_component:\n'
-            '    env:\n'
-            '      +LD_LIBRARY_PATH: :{}\n'
-            '    executable: {}\n'
-            '    execution_model: {}\n'
-            'resources:\n'
-            '  test_model.macro:\n'
-            '    threads: 1\n'
-            '  test_model.micro:\n'
-            '    mpi_processes: 2\n'
-            ).format(
-                ld_lib_path, test_component, ld_lib_path, mpi_test_component,
-                mpi_exec_model))
+    ymmsl_text = f"""
+ymmsl_version: v0.2
+description: Configuration to test starting models with MPI
+models:
+- name: test_model
+  description: Macro-micro model with an MPI implementation
+  components:
+    macro:
+      ports:
+        o_i: out
+        s: in
+      description: The macro model
+      implementation: component
+    micro:
+      ports:
+        f_init: init
+        o_f: result
+      description: The micro model, parallel version
+      implementation: mpi_component
+  conduits:
+    macro.out: micro.init
+    micro.result: macro.in
+programs:
+  component:
+    env:
+      +LD_LIBRARY_PATH: :{ld_lib_path}
+    executable: {test_component}
+  mpi_component:
+    env:
+      +LD_LIBRARY_PATH: :{ld_lib_path}
+    executable: {mpi_test_component}
+    execution_model: {mpi_exec_model}
+resources:
+  test_model.macro:
+    threads: 1
+  test_model.micro:
+    mpi_processes: 2
+"""
 
     config = ymmsl.load(ymmsl_text)
 

--- a/integration_test/test_start_nested.py
+++ b/integration_test/test_start_nested.py
@@ -22,53 +22,53 @@ def test_start_nested(tmpdir):
     test_component = cpp_test_dir / 'component_test'
 
     # make config
-    ymmsl_text = ((
-            'ymmsl_version: v0.2\n'
-            'description: Nested version of the test_start_all model\n'
-            'models:\n'
-            '  test_model:\n'
-            '    components:\n'
-            '      macro:\n'
-            '        ports:\n'
-            '          o_i: out\n'
-            '          s: in\n'
-            '        description: The macro model\n'
-            '        implementation: component\n'
-            '      micro:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out\n'
-            '        description: The micro model, wrapped in a submodel\n'
-            '    conduits:\n'
-            '      macro.out: micro.in\n'
-            '      micro.out: macro.in\n'
-            '  submodel:\n'
-            '    ports:\n'
-            '      f_init: in\n'
-            '      o_f: out\n'
-            '    components:\n'
-            '      micro:\n'
-            '        ports:\n'
-            '          f_init: init\n'
-            '          o_f: result\n'
-            '        description: The micro model\n'
-            '        implementation: component\n'
-            '    conduits:\n'
-            '      in: micro.init\n'
-            '      micro.result: out\n'
-            'custom_implementations:\n'
-            '  micro.implementation: submodel\n'
-            'programs:\n'
-            '  component:\n'
-            '    env:\n'
-            '      +LD_LIBRARY_PATH: :{}\n'
-            '    executable: {}\n'
-            'resources:\n'
-            '  test_model.macro:\n'
-            '    threads: 1\n'
-            '  test_model.micro.micro:\n'
-            '    threads: 1\n'
-            ).format(ld_lib_path, test_component))
+    ymmsl_text = f"""
+ymmsl_version: v0.2
+description: Nested version of the test_start_all model
+models:
+  test_model:
+    components:
+      macro:
+        ports:
+          o_i: out
+          s: in
+        description: The macro model
+        implementation: component
+      micro:
+        ports:
+          f_init: in
+          o_f: out
+        description: The micro model, wrapped in a submodel
+    conduits:
+      macro.out: micro.in
+      micro.out: macro.in
+  submodel:
+    ports:
+      f_init: in
+      o_f: out
+    components:
+      micro:
+        ports:
+          f_init: init
+          o_f: result
+        description: The micro model
+        implementation: component
+    conduits:
+      in: micro.init
+      micro.result: out
+custom_implementations:
+  micro.implementation: submodel
+programs:
+  component:
+    env:
+      +LD_LIBRARY_PATH: :{ld_lib_path}
+    executable: {test_component}
+resources:
+  test_model.macro:
+    threads: 1
+  test_model.micro.micro:
+    threads: 1
+"""
 
     config = flatten(ymmsl.load(ymmsl_text))
 

--- a/integration_test/test_start_script.py
+++ b/integration_test/test_start_script.py
@@ -23,52 +23,51 @@ def test_start_script(tmpdir):
     mpi_test_component = cpp_test_dir / 'mpi_component_test'
 
     # make config
-    ymmsl_text = ((
-            'ymmsl_version: v0.2\n'
-            'description: Configuration with a program with a start script\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: A macro micro model\n'
-            '  components:\n'
-            '    macro:\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      description: The macro model\n'
-            '      implementation: program\n'
-            '    micro:\n'
-            '      ports:\n'
-            '        f_init: init\n'
-            '        o_f: result\n'
-            '      description: The micro model, with a script implementation\n'
-            '      implementation: mpi_program\n'
-            '  conduits:\n'
-            '    macro.out: micro.init\n'
-            '    micro.result: macro.in\n'
-            'programs:\n'
-            '  program:\n'
-            '    description: A program that is started with a script\n'
-            '    script: |\n'
-            '      #!/bin/bash\n'
-            '\n'
-            '      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{}\n'
-            '\n'
-            '      {}\n'
-            '  mpi_program:\n'
-            '    description: An MPI program that is started with a script\n'
-            '    script:\n'
-            '    - "#!/bin/bash"\n'
-            '    - ""\n'
-            '    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{}\n'
-            '    - ""\n'
-            '    - mpirun -n ${{MUSCLE_MPI_PROCESSES}} {}\n'
-            'resources:\n'
-            '  test_model.macro:\n'
-            '    threads: 1\n'
-            '  test_model.micro:\n'
-            '    mpi_processes: 2\n'
-            ).format(
-                ld_lib_path, test_component, ld_lib_path, mpi_test_component))
+    ymmsl_text = f"""
+ymmsl_version: v0.2
+description: Configuration with a program with a start script
+models:
+- name: test_model
+  description: A macro micro model
+  components:
+    macro:
+      ports:
+        o_i: out
+        s: in
+      description: The macro model
+      implementation: program
+    micro:
+      ports:
+        f_init: init
+        o_f: result
+      description: The micro model, with a script implementation
+      implementation: mpi_program
+  conduits:
+    macro.out: micro.init
+    micro.result: macro.in
+programs:
+  program:
+    description: A program that is started with a script
+    script: |
+      #!/bin/bash
+
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{ld_lib_path}
+
+      {test_component}
+  mpi_program:
+    description: An MPI program that is started with a script
+    script:
+    - "#!/bin/bash"
+    - ""
+    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{ld_lib_path}
+    - ""
+    - mpirun -n ${{MUSCLE_MPI_PROCESSES}} {mpi_test_component}
+resources:
+  test_model.macro:
+    threads: 1
+  test_model.micro:
+    mpi_processes: 2
+"""
 
     config = ymmsl.load(ymmsl_text)
 

--- a/libmuscle/python/libmuscle/checkpoint_triggers.py
+++ b/libmuscle/python/libmuscle/checkpoint_triggers.py
@@ -1,7 +1,7 @@
 import bisect
 import logging
 import time
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from ymmsl.v0_2 import (
         CheckpointRangeRule, CheckpointAtRule, CheckpointRule, Checkpoints)
@@ -44,7 +44,7 @@ class AtCheckpointTrigger(CheckpointTrigger):
     This triggers at the specified times.
     """
 
-    def __init__(self, at_rules: List[CheckpointAtRule]) -> None:
+    def __init__(self, at_rules: list[CheckpointAtRule]) -> None:
         """Create an "at" checkpoint trigger
 
         Args:
@@ -118,14 +118,14 @@ class CombinedCheckpointTriggers(CheckpointTrigger):
     """Checkpoint trigger based on a combination of "at" and "ranges"
     """
 
-    def __init__(self, checkpoint_rules: List[CheckpointRule]) -> None:
+    def __init__(self, checkpoint_rules: list[CheckpointRule]) -> None:
         """Create a new combined checkpoint trigger from the given rules
 
         Args:
             checkpoint_rules: checkpoint rules (from ymmsl)
         """
-        self._triggers: List[CheckpointTrigger] = []
-        at_rules: List[CheckpointAtRule] = []
+        self._triggers: list[CheckpointTrigger] = []
+        at_rules: list[CheckpointAtRule] = []
         for rule in checkpoint_rules:
             if isinstance(rule, CheckpointAtRule):
                 if rule.at:
@@ -162,7 +162,7 @@ class TriggerManager:
 
     def __init__(self) -> None:
         self._has_checkpoints = False
-        self._last_triggers: List[str] = []
+        self._last_triggers: list[str] = []
         self._cpts_considered_until = float('-inf')
 
     def set_checkpoint_info(
@@ -251,7 +251,7 @@ class TriggerManager:
         self._prevsim = timestamp
         self._nextsim = self._sim.next_checkpoint(timestamp)
 
-    def get_triggers(self) -> List[str]:
+    def get_triggers(self) -> list[str]:
         """Get trigger description(s) for the current reason for checkpointing.
         """
         triggers = self._last_triggers

--- a/libmuscle/python/libmuscle/communicator.py
+++ b/libmuscle/python/libmuscle/communicator.py
@@ -378,7 +378,7 @@ class Communicator:
         try:
             port = Identifier(port_name)
         except ValueError as e:
-            raise ValueError(f'"{port_name}" is not a valid port name: {e}')
+            raise ValueError(f'"{port_name}" is not a valid port name: {e}') from None
 
         return Endpoint(self._kernel, self._index, port, slot)
 

--- a/libmuscle/python/libmuscle/communicator.py
+++ b/libmuscle/python/libmuscle/communicator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Optional, cast
 from ymmsl.v0_2 import Identifier, Reference, Settings
 
 from libmuscle.endpoint import Endpoint
@@ -71,7 +71,7 @@ class Communicator:
     servers and clients.
     """
     def __init__(
-            self, kernel: Reference, index: List[int],
+            self, kernel: Reference, index: list[int],
             port_manager: PortManager, profiler: Profiler,
             manager: MMPClient) -> None:
         """Create a Communicator.
@@ -98,9 +98,9 @@ class Communicator:
         self._server = MPPServer()
 
         # indexed by remote instance id
-        self._clients: Dict[Reference, MPPClient] = {}
+        self._clients: dict[Reference, MPPClient] = {}
 
-    def get_locations(self) -> List[str]:
+    def get_locations(self) -> list[str]:
         """Returns a list of locations that we can be reached at.
 
         These locations are of the form 'protocol:location', where
@@ -150,10 +150,10 @@ class Communicator:
                 should save a snapshot (wallclock time).
         """
         if slot is None:
-            _logger.debug('Sending message on {}'.format(port_name))
-            slot_list: List[int] = []
+            _logger.debug(f'Sending message on {port_name}')
+            slot_list: list[int] = []
         else:
-            _logger.debug('Sending message on {}[{}]'.format(port_name, slot))
+            _logger.debug(f'Sending message on {port_name}[{slot}]')
             slot_list = [slot]
 
         snd_endpoint = self.__get_endpoint(port_name, slot_list)
@@ -194,7 +194,7 @@ class Communicator:
             self._profiler.record_event(profile_event)
 
     def receive_message(
-            self, port_name: str, slot: Optional[int] = None) -> Tuple[Message, float]:
+            self, port_name: str, slot: Optional[int] = None) -> tuple[Message, float]:
         """Receive a message and attached settings overlay.
 
         Receiving is a blocking operation. This function will contact
@@ -227,11 +227,11 @@ class Communicator:
 
         if slot is None:
             port_and_slot = port_name
-            slot_list: List[int] = []
+            slot_list: list[int] = []
         else:
             port_and_slot = f"{port_name}[{slot}]"
             slot_list = [slot]
-        _logger.debug('Waiting for message on {}'.format(port_and_slot))
+        _logger.debug(f'Waiting for message on {port_and_slot}')
 
         recv_endpoint = self.__get_endpoint(port_name, slot_list)
 
@@ -325,9 +325,9 @@ class Communicator:
                                ' from an inconsistent snapshot?')
         port.increment_num_messages(slot)
 
-        _logger.debug('Received message on {}'.format(port_and_slot))
+        _logger.debug(f'Received message on {port_and_slot}')
         if isinstance(mpp_message.data, ClosePort):
-            _logger.debug('Port {} is now closed'.format(port_and_slot))
+            _logger.debug(f'Port {port_and_slot} is now closed')
 
         return message, mpp_message.saved_until
 
@@ -368,7 +368,7 @@ class Communicator:
 
         return self._clients[instance]
 
-    def __get_endpoint(self, port_name: str, slot: List[int]) -> Endpoint:
+    def __get_endpoint(self, port_name: str, slot: list[int]) -> Endpoint:
         """Determines the endpoint on our side.
 
         Args:
@@ -378,8 +378,7 @@ class Communicator:
         try:
             port = Identifier(port_name)
         except ValueError as e:
-            raise ValueError('"{}" is not a valid port name: {}'.format(
-                port_name, e))
+            raise ValueError(f'"{port_name}" is not a valid port name: {e}')
 
         return Endpoint(self._kernel, self._index, port, slot)
 
@@ -395,9 +394,9 @@ class Communicator:
         """
         message = Message(float('inf'), None, ClosePort(), Settings())
         if slot is None:
-            _logger.debug('Closing port {}'.format(port_name))
+            _logger.debug(f'Closing port {port_name}')
         else:
-            _logger.debug('Closing port {}[{}]'.format(port_name, slot))
+            _logger.debug(f'Closing port {port_name}[{slot}]')
         self.send_message(port_name, message, slot)
 
     def _close_outgoing_ports(self) -> None:

--- a/libmuscle/python/libmuscle/endpoint.py
+++ b/libmuscle/python/libmuscle/endpoint.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ymmsl.v0_2 import Identifier, Reference
 
 
@@ -38,8 +36,8 @@ class Endpoint:
     Conduit instances are never actually created in the code, but
     Endpoints are.
     """
-    def __init__(self, kernel: Reference, index: List[int], port: Identifier,
-                 slot: List[int]) -> None:
+    def __init__(self, kernel: Reference, index: list[int], port: Identifier,
+                 slot: list[int]) -> None:
         """Create an Endpoint
 
         Note: kernel is a Reference, not an Identifier, because it may

--- a/libmuscle/python/libmuscle/grid.py
+++ b/libmuscle/python/libmuscle/grid.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -16,10 +16,10 @@ class Grid:
 
     Attributes:
         array (np.ndarray): An array of data
-        indexes (Optional[List[str]]): The names of the array's indexes.
+        indexes (Optional[list[str]]): The names of the array's indexes.
     """
     def __init__(
-            self, array: np.ndarray, indexes: Optional[List[str]] = None
+            self, array: np.ndarray, indexes: Optional[list[str]] = None
             ) -> None:
         """Creates a Grid object.
 

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -3,7 +3,7 @@ from enum import Flag, auto
 import logging
 import os
 import sys
-from typing import cast, Dict, List, Literal, Optional, Tuple, overload
+from typing import cast, Literal, Optional, overload
 
 from ymmsl.v0_2 import (
         Identifier, Operator, SettingValue, Port, Reference, Settings)
@@ -28,7 +28,7 @@ from libmuscle.util import extract_log_file_location
 _logger = logging.getLogger(__name__)
 
 
-_FInitCacheType = Dict[Tuple[str, Optional[int]], Message]
+_FInitCacheType = dict[tuple[str, Optional[int]], Message]
 
 
 class InstanceFlags(Flag):
@@ -109,7 +109,7 @@ class Instance:
     to use.
     """
     def __init__(
-            self, ports: Optional[Dict[Operator, List[str]]] = None,
+            self, ports: Optional[dict[Operator, list[str]]] = None,
             flags: InstanceFlags = InstanceFlags(0)) -> None:
         """Create an Instance.
 
@@ -294,8 +294,8 @@ class Instance:
         """
         self.__shutdown(message)
 
-    def list_settings(self) -> List[str]:
-        """List settings by name.
+    def list_settings(self) -> list[str]:
+        """list settings by name.
 
         This function returns a list of names of the available settings.
 
@@ -328,18 +328,18 @@ class Instance:
 
     @overload
     def get_setting(self, name: str, typ: Literal['[int]'], *,
-                    default: Optional[List[int]] = None) -> List[int]:
+                    default: Optional[list[int]] = None) -> list[int]:
         ...
 
     @overload
     def get_setting(self, name: str, typ: Literal['[float]'], *,
-                    default: Optional[List[float]] = None) -> List[float]:
+                    default: Optional[list[float]] = None) -> list[float]:
         ...
 
     @overload
     def get_setting(
             self, name: str, typ: Literal['[[float]]'], *,
-            default: Optional[List[List[float]]] = None) -> List[List[float]]:
+            default: Optional[list[list[float]]] = None) -> list[list[float]]:
         ...
 
     @overload
@@ -382,7 +382,7 @@ class Instance:
                 return default
             raise
 
-    def list_ports(self) -> Dict[Operator, List[str]]:
+    def list_ports(self) -> dict[Operator, list[str]]:
         """Returns a description of the ports that this Instance has.
 
         Note that the result has almost the same format as the port
@@ -829,7 +829,7 @@ class Instance:
         """
         id_str = str(self._instance_id)
 
-        logfile = extract_log_file_location('muscle3.{}.log'.format(id_str))
+        logfile = extract_log_file_location(f'muscle3.{id_str}.log')
         if logfile is not None:
             local_handler = logging.FileHandler(str(logfile), mode='w')
             formatter = logging.Formatter(
@@ -971,31 +971,31 @@ class Instance:
                     raise RuntimeError(err_msg)
             else:
                 if port.is_connected():
-                    err_msg = (('Tried to receive twice on the same'
-                                ' port "{}", that\'s not possible.'
-                                ' Did you forget to call'
-                                ' reuse_instance() in your reuse loop?'
-                                ).format(port_name))
+                    err_msg = ('Tried to receive twice on the same'
+                               f' port "{port_name}", that\'s not possible.'
+                               ' Did you forget to call'
+                               ' reuse_instance() in your reuse loop?'
+                               )
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
                 else:
                     if default is not None:
                         return default
-                    err_msg = (('Tried to receive on port "{}",'
-                                ' which is not connected, and no'
-                                ' default value was given. Please'
-                                ' connect this port!').format(port_name))
+                    err_msg = (f'Tried to receive on port "{port_name}",'
+                               ' which is not connected, and no'
+                               ' default value was given. Please'
+                               ' connect this port!')
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
 
         else:
             if not port.is_connected():
                 if default is None:
-                    raise RuntimeError(('Tried to receive on port "{}", which is'
-                                        ' disconnected, and no default value was'
+                    raise RuntimeError(f'Tried to receive on port "{port_name}", which'
+                                        ' is disconnected, and no default value was'
                                         ' given. Either specify a default, or'
                                         ' connect a sending component to this'
-                                        ' port.').format(port_name))
+                                        ' port.')
                 else:
                     _logger.debug(
                             f'No message received on {port_name} as it is not'
@@ -1005,9 +1005,8 @@ class Instance:
             else:
                 msg, saved_until = self._communicator.receive_message(port_name, slot)
                 if not port.is_open(slot):
-                    err_msg = (('Port {} was closed while trying to'
-                                ' receive on it, did the peer crash?'
-                                ).format(port_name))
+                    err_msg = (f'Port {port_name} was closed while trying to'
+                                ' receive on it, did the peer crash?')
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
                 if not with_settings:
@@ -1017,14 +1016,14 @@ class Instance:
         return msg
 
     def __make_full_name(self
-                         ) -> Tuple[Reference, List[int]]:
+                         ) -> tuple[Reference, list[int]]:
         """Returns instance name and index.
 
         This takes the argument to the --muscle-instance= command-line
         option and splits it into a component name and an index.
         """
-        def split_reference(ref: Reference) -> Tuple[Reference, List[int]]:
-            index: List[int] = []
+        def split_reference(ref: Reference) -> tuple[Reference, list[int]]:
+            index: list[int] = []
             i = 0
             while i < len(ref) and isinstance(ref[i], Identifier):
                 i += 1
@@ -1051,13 +1050,13 @@ class Instance:
                 prefix_ref = Reference(os.environ['MUSCLE_INSTANCE'])
                 name, index = split_reference(prefix_ref)
             else:
-                raise RuntimeError((
+                raise RuntimeError(
                     'A --muscle-instance command line argument or'
                     ' MUSCLE_INSTANCE environment variable is required to'
-                    ' identify this instance. Please add one.'))
+                    ' identify this instance. Please add one.')
         return name, index
 
-    def __list_declared_ports(self) -> List[Port]:
+    def __list_declared_ports(self) -> list[Port]:
         """Returns a list of declared ports.
 
         This returns a list of ymmsl.Port objects, which have only the
@@ -1076,9 +1075,9 @@ class Instance:
             self, port_name: str, slot: Optional[int], is_send: bool,
             allow_slot_out_of_range: bool = False) -> None:
         if not self._port_manager.port_exists(port_name):
-            err_msg = (('Port "{}" does not exist on "{}". Please check'
-                        ' the name and the list of ports you gave for'
-                        ' this component.').format(port_name, self._name))
+            err_msg = (f'Port "{port_name}" does not exist on "{self._name}". Please'
+                        ' check the name and the list of ports you gave for'
+                        ' this component.')
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 
@@ -1163,11 +1162,9 @@ class Instance:
         if isinstance(message.data, ClosePort):
             return False
         if not isinstance(message.data, Settings):
-            err_msg = ('"{}" received a message on'
-                       ' muscle_settings_in that is not a'
-                       ' Settings. It seems that your'
-                       ' simulation is miswired or the sending'
-                       ' instance is broken.'.format(self._instance_id))
+            err_msg = (f'"{self._instance_id}" received a message on'
+                       ' muscle_settings_in that is not a Settings. It seems that your'
+                       ' simulation is miswired or the sending instance is broken.')
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 
@@ -1199,7 +1196,7 @@ class Instance:
         self._f_init_cache = dict()
         ports = self._port_manager.list_ports()
         for port_name in ports.get(Operator.F_INIT, []):
-            _logger.debug('Pre-receiving on port {}'.format(port_name))
+            _logger.debug(f'Pre-receiving on port {port_name}')
             port = self._port_manager.get_port(port_name)
             if not port.is_connected():
                 continue
@@ -1240,10 +1237,9 @@ class Instance:
 
         except KeyError:
             _logger.warning(
-                ('muscle_remote_log_level is set to {}, which is not a'
-                 ' valid remote log level. Please use one of DEBUG, INFO,'
-                 ' WARNING, ERROR, CRITICAL, or DISABLED').format(
-                     log_level_str))
+                f'muscle_remote_log_level is set to {log_level_str}, which is not a'
+                ' valid remote log level. Please use one of DEBUG, INFO, WARNING,'
+                ' ERROR, CRITICAL, or DISABLED')
             return
 
     def _set_local_log_level(self) -> None:
@@ -1266,10 +1262,9 @@ class Instance:
             log_level = LogLevel[log_level_str.upper()]
         except KeyError:
             _logger.warning(
-                ('muscle_local_log_level is set to {}, which is not a'
-                 ' valid log level. Please use one of DEBUG, INFO,'
-                 ' WARNING, ERROR, CRITICAL, or DISABLED').format(
-                     log_level_str))
+                f'muscle_local_log_level is set to {log_level_str}, which is not a'
+                ' valid log level. Please use one of DEBUG, INFO, WARNING, ERROR,'
+                ' CRITICAL, or DISABLED')
             return
 
         py_level = log_level.as_python_level()
@@ -1298,12 +1293,11 @@ class Instance:
         if overlay is None:
             return
         if self._settings_manager.overlay != overlay:
-            err_msg = (('Unexpectedly received data from a'
-                        ' parallel universe on port "{}". My'
-                        ' settings are "{}" and I received'
-                        ' from a universe with "{}".').format(
-                            port_name, self._settings_manager.overlay,
-                            overlay))
+            err_msg = (
+                    'Unexpectedly received data from a parallel universe on port'
+                    f' "{port_name}". My settings are'
+                    f' "{self._settings_manager.overlay}" and I received from a'
+                    f' universe with "{overlay}".')
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -102,6 +102,9 @@ _CHECKPOINT_SUPPORT_MASK = (
         InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE)
 
 
+_NO_INSTANCE_FLAGS = InstanceFlags(0)
+
+
 class Instance:
     """Represents a component instance in a MUSCLE3 simulation.
 
@@ -110,7 +113,7 @@ class Instance:
     """
     def __init__(
             self, ports: Optional[dict[Operator, list[str]]] = None,
-            flags: InstanceFlags = InstanceFlags(0)) -> None:
+            flags: InstanceFlags = _NO_INSTANCE_FLAGS) -> None:
         """Create an Instance.
 
         Args:

--- a/libmuscle/python/libmuscle/manager/deadlock_detector.py
+++ b/libmuscle/python/libmuscle/manager/deadlock_detector.py
@@ -1,6 +1,6 @@
 import logging
 from threading import Lock
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 
 _logger = logging.getLogger(__name__)
@@ -21,12 +21,12 @@ class DeadlockDetector:
         """Construct a new DeadlockDetector."""
         self._mutex = Lock()
         """Mutex that should be locked before accessing instance variables."""
-        self._waiting_instances: Dict[str, str] = {}
+        self._waiting_instances: dict[str, str] = {}
         """Maps instance IDs to the peer instance IDs they are waiting for."""
-        self._waiting_instance_ports: Dict[str, Tuple[str, Optional[int]]] = {}
+        self._waiting_instance_ports: dict[str, tuple[str, Optional[int]]] = {}
         """Maps instance IDs to the port/slot they are waiting for.."""
-        self._detected_deadlocks: List[List[str]] = []
-        """List of deadlocked instance cycles. Set by _handle_potential_deadlock."""
+        self._detected_deadlocks: list[list[str]] = []
+        """list of deadlocked instance cycles. Set by _handle_potential_deadlock."""
 
     def waiting_for_receive(
             self, instance_id: str, peer_instance_id: str,
@@ -110,7 +110,7 @@ class DeadlockDetector:
             deadlock_instances.append(cur_instance)
         _logger.debug("No deadlock detected")
 
-    def _handle_potential_deadlock(self, deadlock_instances: List[str]) -> None:
+    def _handle_potential_deadlock(self, deadlock_instances: list[str]) -> None:
         """Handle a potential deadlock.
 
         Make sure to lock self._mutex before calling this.
@@ -120,7 +120,7 @@ class DeadlockDetector:
         """
         self._detected_deadlocks.append(deadlock_instances)
 
-    def _format_deadlock(self, deadlock_instances: List[str]) -> str:
+    def _format_deadlock(self, deadlock_instances: list[str]) -> str:
         """Create and return formatted deadlock debug info.
 
         Args:

--- a/libmuscle/python/libmuscle/manager/hammer.py
+++ b/libmuscle/python/libmuscle/manager/hammer.py
@@ -214,8 +214,8 @@ def glue_partial_conduits(
     for port in ports:
         incoming_conduits = plate.pop_by_receiver(parent_path + port)
         outgoing_conduits = plate.pop_by_sender(parent_path + port)
-        for incoming, (in_cdt, snd_final) in incoming_conduits.items():
-            for outgoing, (out_cdt, recv_final) in outgoing_conduits.items():
+        for in_cdt, snd_final in incoming_conduits.values():
+            for out_cdt, recv_final in outgoing_conduits.values():
                 joined_cdt = Conduit(
                         str(in_cdt.sender), str(out_cdt.receiver),
                         in_cdt.filters + out_cdt.filters)

--- a/libmuscle/python/libmuscle/manager/hammer.py
+++ b/libmuscle/python/libmuscle/manager/hammer.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from ymmsl.v0_2 import Conduit, Configuration, Model, Ports, Reference
 
 
-ConduitIndex = Dict[Reference, Tuple[Conduit, bool]]
+ConduitIndex = dict[Reference, tuple[Conduit, bool]]
 
 
 class Plate:
@@ -28,8 +28,8 @@ class Plate:
     """
     def __init__(self) -> None:
         """Create a Plate."""
-        self._by_snd: Dict[Reference, ConduitIndex] = {}
-        self._by_recv: Dict[Reference, ConduitIndex] = {}
+        self._by_snd: dict[Reference, ConduitIndex] = {}
+        self._by_recv: dict[Reference, ConduitIndex] = {}
 
     def add(self, conduit: Conduit, snd_final: bool, recv_final: bool) -> None:
         """Add a conduit to the plate.
@@ -84,7 +84,7 @@ class Plate:
         return result
 
 
-Node = Tuple[Model, Reference, List[int]]
+Node = tuple[Model, Reference, list[int]]
 """Describes a model to be processed while flattening.
 
 This contains a model, its component path from the root, and a multiplicity.
@@ -94,7 +94,7 @@ being added to the flattened model.
 
 
 def process_components(
-        nested_config: Configuration, flat_model: Model, node: Node) -> List[Node]:
+        nested_config: Configuration, flat_model: Model, node: Node) -> list[Node]:
     """Copy components to the flattened model.
 
     This copies the components in the given model in nested_config to flat_model,
@@ -262,7 +262,7 @@ def flatten(
             str(root_model.name), Ports(), root_model.description,
             root_model.supported_settings, [], [])
 
-    queue: List[Node] = [(root_model, Reference([]), [])]
+    queue: list[Node] = [(root_model, Reference([]), [])]
     while queue:
         node = queue.pop(0)
         queue.extend(process_components(config, flat_model, node))

--- a/libmuscle/python/libmuscle/manager/instance_manager.py
+++ b/libmuscle/python/libmuscle/manager/instance_manager.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from textwrap import indent
 from threading import Thread
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 from multiprocessing import Queue
 from queue import Empty
 
@@ -87,7 +87,7 @@ class InstanceManager:
         self._log_handler = LogHandlingThread(self._log_records_in)
         self._log_handler.start()
 
-        self._allocations: Optional[Dict[Reference, ResourceAssignment]] = None
+        self._allocations: Optional[dict[Reference, ResourceAssignment]] = None
 
         resources = self._resources_in.get()
         _logger.debug(f'Got resources {resources}')
@@ -149,7 +149,7 @@ class InstanceManager:
             self._requests_out.put(request)
             self._num_running += 1
 
-    def get_resources(self) -> Dict[Reference, ResourceAssignment]:
+    def get_resources(self) -> dict[Reference, ResourceAssignment]:
         """Returns the resources allocated to each instance.
 
         Only call this after start_all() has been called, or it will raise
@@ -175,7 +175,7 @@ class InstanceManager:
                 all_seemingly_okay = False
 
         # Get all results
-        results: List[Process] = list()
+        results: list[Process] = list()
 
         while self._num_running > 0:
             result = self._results_in.get()
@@ -197,8 +197,8 @@ class InstanceManager:
             self._num_running -= 1
 
         # Summarise outcome
-        crashes: List[Tuple[Process, Path]] = list()
-        indirect_crashes: List[Tuple[Process, Path]] = list()
+        crashes: list[tuple[Process, Path]] = list()
+        indirect_crashes: list[tuple[Process, Path]] = list()
 
         for result in results:
             if result.status == ProcessStatus.CANCELED:
@@ -307,7 +307,7 @@ class InstanceManager:
         self._log_handler.shutdown()
         self._log_handler.join()
         # Close multiprocessing.Queues and ensure their feeder threads exit
-        queues: List[Queue] = [
+        queues: list[Queue] = [
                 self._resources_in, self._requests_out,
                 self._results_in, self._log_records_in]
         for queue in queues:

--- a/libmuscle/python/libmuscle/manager/instance_registry.py
+++ b/libmuscle/python/libmuscle/manager/instance_registry.py
@@ -1,5 +1,4 @@
 from threading import Condition
-from typing import Dict, List, Set
 
 from ymmsl.v0_2 import Port, Reference
 
@@ -17,19 +16,19 @@ class InstanceRegistry:
     def __init__(self) -> None:
         """Construct an empty InstanceRegistry"""
         self._deregistered_one = Condition()    # doubles as lock
-        self._locations: Dict[Reference, List[str]] = {}
-        self._ports: Dict[Reference, List[Port]] = {}
-        self._seen: Set[Reference] = set()
+        self._locations: dict[Reference, list[str]] = {}
+        self._ports: dict[Reference, list[Port]] = {}
+        self._seen: set[Reference] = set()
         self._startup = True
 
-    def add(self, name: Reference, locations: List[str], ports: List[Port]
+    def add(self, name: Reference, locations: list[str], ports: list[Port]
             ) -> None:
         """Add an instance to the registry.
 
         Args:
             name: Name of the instance.
             locations: Network locations where it can be reached.
-            ports: List of ports of this instance.
+            ports: list of ports of this instance.
 
         Raises:
             ValueError: If an instance with this name has already been
@@ -37,15 +36,14 @@ class InstanceRegistry:
         """
         with self._deregistered_one:
             if name in self._locations:
-                raise AlreadyRegistered(
-                        'Instance {} tried to register twice'.format(name))
+                raise AlreadyRegistered(f'Instance {name} tried to register twice')
 
             self._locations[name] = locations
             self._ports[name] = ports
             self._seen.add(name)
             self._startup = False
 
-    def get_locations(self, name: Reference) -> List[str]:
+    def get_locations(self, name: Reference) -> list[str]:
         """Retrieves the locations of a registered instance.
 
         Args:
@@ -57,7 +55,7 @@ class InstanceRegistry:
         with self._deregistered_one:
             return self._locations[name]
 
-    def get_ports(self, name: Reference) -> List[Port]:
+    def get_ports(self, name: Reference) -> list[Port]:
         """Retrieves the ports of a registered instance.
 
         Args:

--- a/libmuscle/python/libmuscle/manager/instantiator.py
+++ b/libmuscle/python/libmuscle/manager/instantiator.py
@@ -4,7 +4,7 @@ import multiprocessing as mp
 import os
 from pathlib import Path
 import traceback
-from typing import Dict, Optional
+from typing import Optional
 
 from ymmsl.v0_2 import BaseEnv, Program, Reference, ResourceRequirements
 
@@ -158,8 +158,8 @@ def reconfigure_logging(queue: mp.Queue) -> None:
 
 
 def create_instance_env(
-        instance: Reference, base_env: BaseEnv, overlay: Dict[str, str]
-        ) -> Dict[str, str]:
+        instance: Reference, base_env: BaseEnv, overlay: dict[str, str]
+        ) -> dict[str, str]:
     """Creates an environment for an instance.
 
     This takes the current (manager) environment variables and makes

--- a/libmuscle/python/libmuscle/manager/logger.py
+++ b/libmuscle/python/libmuscle/manager/logger.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from libmuscle.logging import LogLevel, Timestamp
 from libmuscle.util import extract_log_file_location
@@ -25,12 +25,13 @@ class Formatter(logging.Formatter):
         Returns:
             The formatted message.
         """
+        # disabled the linter here; this follows the Python logging docs
         if 'instance' in record.__dict__:
             return (
-                    '%(instance)-14s %(iasctime)-15s %(levelname)-7s'
-                    ' %(name)s: %(message)s' % record.__dict__)
+                    '%(instance)-14s %(iasctime)-15s %(levelname)-7s'   # noqa: UP031
+                    ' %(name)s: %(message)s' % record.__dict__)         # noqa: UP031
         return (
-                'muscle_manager %(asctime)s %(levelname)-7s %(name)s:'
+                'muscle_manager %(asctime)s %(levelname)-7s %(name)s:'  # noqa: UP031
                 ' %(message)s' % record.__dict__)
 
 
@@ -141,7 +142,7 @@ def last_lines(file: Path, count: int) -> str:
     file_size = file.stat().st_size
     start_point = max(file_size - 10000, 0)
 
-    lines: List[str] = []
+    lines: list[str] = []
     with file.open('r') as f:
         f.seek(start_point)
         f.readline()    # skip partial line

--- a/libmuscle/python/libmuscle/manager/mmp_server.py
+++ b/libmuscle/python/libmuscle/manager/mmp_server.py
@@ -1,7 +1,7 @@
 import errno
 import logging
 import time
-from typing import Any, Dict, cast, List, Optional
+from typing import Any, cast, Optional
 from typing_extensions import Buffer
 
 import msgpack
@@ -36,12 +36,12 @@ def decode_operator(data: str) -> Operator:
     return Operator[data]
 
 
-def decode_port(data: List[str]) -> Port:
+def decode_port(data: list[str]) -> Port:
     """Create a Port from a MsgPack-compatible value."""
     return Port(Identifier(data[0]), decode_operator(data[1]))
 
 
-def encode_conduit(conduit: Conduit) -> List[str]:
+def encode_conduit(conduit: Conduit) -> list[str]:
     """Convert a Conduit to a MsgPack-compatible value."""
     return [str(conduit.sender), str(conduit.receiver)]
 
@@ -54,7 +54,7 @@ def encode_ports(ports: Ports) -> list[list[str]]:
     ]
 
 
-def encode_checkpoint_rule(rule: CheckpointRule) -> Dict[str, Any]:
+def encode_checkpoint_rule(rule: CheckpointRule) -> dict[str, Any]:
     """Convert a CheckpointRule to a MsgPack-compatible value."""
     if isinstance(rule, CheckpointAtRule):
         return {'at': list(map(float, rule.at))}
@@ -66,7 +66,7 @@ def encode_checkpoint_rule(rule: CheckpointRule) -> Dict[str, Any]:
     raise TypeError(f"Unknown checkpoint rule type: {type(rule)}.")
 
 
-def encode_checkpoints(checkpoints: Checkpoints) -> Dict[str, Any]:
+def encode_checkpoints(checkpoints: Checkpoints) -> dict[str, Any]:
     """Convert a Checkpoins to a MsgPack-compatible value."""
     return {
         "at_end": checkpoints.at_end,
@@ -154,8 +154,8 @@ class MMPRequestHandler(RequestHandler):
         self._profile_store.close()
 
     def _register_instance(
-            self, instance_id: str, locations: List[str],
-            ports: List[List[str]], version: str = '') -> Any:
+            self, instance_id: str, locations: list[str],
+            ports: list[list[str]], version: str = '') -> Any:
         """Handle a register instance request.
 
         Args:
@@ -203,10 +203,10 @@ class MMPRequestHandler(RequestHandler):
             A list containing the following values on success:
 
             status (ResponseType): SUCCESS
-            conduits (List[List[str]]): Conduits from/to peers
-            dimensions (Dict[str, List[int]]): Dimensions of peer
+            conduits (list[list[str]]): Conduits from/to peers
+            dimensions (dict[str, list[int]]): Dimensions of peer
                 components
-            locations (Dict[str, List[str]]): Locations where peer
+            locations (dict[str, list[str]]): Locations where peer
                 instances can be contacted.
             ports (list[list[str]]): Ports declaration from the yMMSL configuration
 
@@ -282,7 +282,7 @@ class MMPRequestHandler(RequestHandler):
             A list containing the following values on success:
 
             status (ResponseType): SUCCESS
-            settings (Dict[str, SettingValue]): The global settings
+            settings (dict[str, SettingValue]): The global settings
         """
         return [
                 ResponseType.SUCCESS.value,
@@ -309,7 +309,7 @@ class MMPRequestHandler(RequestHandler):
         return [ResponseType.SUCCESS.value]
 
     def _submit_profile_events(
-            self, instance_id: str, events: List[List[Any]]) -> Any:
+            self, instance_id: str, events: list[list[Any]]) -> Any:
         """Handle a submit profile events request.
 
         Args:
@@ -333,7 +333,7 @@ class MMPRequestHandler(RequestHandler):
         return [ResponseType.SUCCESS.value]
 
     def _submit_snapshot(
-            self, instance_id: str, snapshot: Dict[str, Any]) -> Any:
+            self, instance_id: str, snapshot: dict[str, Any]) -> Any:
         """Handle a submit snapshot request.
 
         Returns:
@@ -358,7 +358,7 @@ class MMPRequestHandler(RequestHandler):
             status (ResponseType): SUCCESS
             wallclock_reference_time (float): Unix timestamp (in UTC) indicating
                 wallclock time of the start of the workflow.
-            checkpoints (dict): Dictionary encoding a ymmsl.Checkpoints object.
+            checkpoints (dict): dictionary encoding a ymmsl.Checkpoints object.
             resume_path (Optional[str]): Checkpoint filename to resume from.
             snapshot_directory (Optional[str]): Directory to store instance
                 snapshots.

--- a/libmuscle/python/libmuscle/manager/profile_database.py
+++ b/libmuscle/python/libmuscle/manager/profile_database.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sqlite3
 import threading
 from types import TracebackType
-from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, cast, Optional, Union
 from warnings import warn
 
 
@@ -57,7 +57,7 @@ class ProfileDatabase:
             self._local.conn.close()
 
     def instance_stats(
-            self) -> Tuple[List[str], List[float], List[float], List[float]]:
+            self) -> tuple[list[str], list[float], list[float], list[float]]:
         """Calculate per-instance statistics.
 
         This calculates the total time spent computing, the total time
@@ -176,7 +176,7 @@ class ProfileDatabase:
 
         return complete_instances, run_times, comm_times, wait_times
 
-    def resource_stats(self) -> Dict[str, Dict[str, float]]:
+    def resource_stats(self) -> dict[str, dict[str, float]]:
         """Calculate per-core statistics.
 
         This function calculates the amount of time each core has
@@ -211,7 +211,7 @@ class ProfileDatabase:
         cur.execute("COMMIT")
         cur.close()
 
-        result: Dict[str, Dict[str, float]] = defaultdict(dict)
+        result: dict[str, dict[str, float]] = defaultdict(dict)
         for core, instances in instances_by_core.items():
             for instance in instances:
                 result[core][instance] = active_times[instance]
@@ -397,14 +397,15 @@ class ProfileDatabase:
         def get_sum_count(
                 cur: sqlite3.Cursor, etype: Optional[str], timestamp: str,
                 instance: Optional[str], port: Optional[str],
-                slot: Optional[int]) -> Tuple[int, int, int]:
+                slot: Optional[int]) -> tuple[int, int, int]:
             """Get sums and count for one time point."""
             cur.execute("BEGIN TRANSACTION")
             query = (
-                    "SELECT SUM({0} >> 32), SUM({0} & 0xffffffff), COUNT(*)"
+                    f"SELECT SUM({timestamp} >> 32), SUM({timestamp} & 0xffffffff),"
+                    " COUNT(*)"
                     " FROM all_events"
-                    " WHERE type = ?".format(timestamp))
-            qargs: List[Any] = [etype]
+                    " WHERE type = ?")
+            qargs: list[Any] = [etype]
 
             if instance is not None:
                 query += " AND instance = ?"
@@ -421,7 +422,7 @@ class ProfileDatabase:
             cur.execute(query, qargs)
             result = cur.fetchone()
             cur.execute("COMMIT")
-            return cast(Tuple[int, int, int], result)
+            return cast(tuple[int, int, int], result)
 
         cur = self._get_cursor()
         sum1_high, sum1_low, count1 = get_sum_count(
@@ -455,7 +456,7 @@ class ProfileDatabase:
         return self
 
     def __exit__(
-            self, exc_type: Optional[Type[BaseException]],
+            self, exc_type: Optional[type[BaseException]],
             exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
             ) -> None:
         self.close()

--- a/libmuscle/python/libmuscle/manager/profile_database.py
+++ b/libmuscle/python/libmuscle/manager/profile_database.py
@@ -109,7 +109,7 @@ class ProfileDatabase:
                 warn(
                         f'Instance {name} seems to have never registered with the'
                         ' manager, and will be omitted from the results. Did it crash'
-                        ' on startup?')
+                        ' on startup?', stacklevel=2)
 
         cur.execute(
                 "SELECT instance, start_time"
@@ -132,7 +132,7 @@ class ProfileDatabase:
                     # as a last resort, just take the last registered event
                     warn(
                             f'Instance {name} did not shut down cleanly, data may be'
-                            ' inaccurate or missing')
+                            ' inaccurate or missing', stacklevel=2)
 
                     cur.execute(
                             "SELECT stop_time"

--- a/libmuscle/python/libmuscle/manager/profile_store.py
+++ b/libmuscle/python/libmuscle/manager/profile_store.py
@@ -1,9 +1,10 @@
+from collections.abc import Iterable
 import logging
 from pathlib import Path
 from queue import Queue
 from sqlite3 import Cursor
 from threading import Thread
-from typing import cast, Dict, Iterable, List, Optional, Tuple
+from typing import cast, Optional
 
 from libmuscle.planner.planner import ResourceAssignment
 from libmuscle.profiling import ProfileEvent, ProfileEventType
@@ -46,7 +47,7 @@ class ProfileStore(ProfileDatabase):
         self._init_database()
 
         # 500 batches is about 250MB
-        Item = Optional[Tuple[Reference, Iterable[ProfileEvent]]]
+        Item = Optional[tuple[Reference, Iterable[ProfileEvent]]]
         self._queue: Queue[Item] = Queue(500)
         self._confirmation_queue: Queue[None] = Queue()
         self._thread = Thread(target=self._storage_thread, daemon=True)
@@ -62,7 +63,7 @@ class ProfileStore(ProfileDatabase):
         super().close()
 
     def store_instances(
-            self, instances: List[Reference]) -> None:
+            self, instances: list[Reference]) -> None:
         """Store names of instances in the simulation.
 
         Args:
@@ -77,7 +78,7 @@ class ProfileStore(ProfileDatabase):
         cur.execute("COMMIT")
         cur.close()
 
-    def store_resources(self, resources: Dict[Reference, ResourceAssignment]) -> None:
+    def store_resources(self, resources: dict[Reference, ResourceAssignment]) -> None:
         """Store resource assignments into the database.
 
         Args:
@@ -122,7 +123,7 @@ class ProfileStore(ProfileDatabase):
         threads. So we use a single background thread now to do the
         writing.
         """
-        Record = Tuple[
+        Record = tuple[
                 int, int, float, float, Optional[str], Optional[int],
                 Optional[int], Optional[int], Optional[int], Optional[int],
                 Optional[float]]

--- a/libmuscle/python/libmuscle/manager/snapshot_registry.py
+++ b/libmuscle/python/libmuscle/manager/snapshot_registry.py
@@ -491,7 +491,11 @@ class SnapshotRegistry(Thread):
                 peer_snapshot.consistent_peers[snapshot.instance].remove(
                         snapshot)
 
-    @cache
+    # The use of @cache on class methods can lead to a memory leak because the global
+    # cache keeps a reference to the instance, keeping it from being garbage collected.
+    # However, there's normally only one instance of this and it lives as long as the
+    # simulation, so that's not a problem here.
+    @cache  # noqa: B019
     def _get_peers(self, instance: Reference) -> frozenset[Reference]:
         """Return the set of peers for the given instance.
 
@@ -506,7 +510,7 @@ class SnapshotRegistry(Thread):
         """
         return frozenset(self._topology_store.get_peer_instances(instance))
 
-    @cache
+    @cache  # noqa: B019
     def _get_connections(self, instance: Reference, peer: Reference
                          ) -> list[_ConnectionType]:
         """Get the list of connections between instance and peer.
@@ -563,7 +567,7 @@ class SnapshotRegistry(Thread):
                         conn_type))
         return connected_ports
 
-    @cache
+    @cache  # noqa: B019
     def _implementation(self, kernel: Reference) -> Optional[Program]:
         """Return the implementation of a kernel.
 

--- a/libmuscle/python/libmuscle/manager/snapshot_registry.py
+++ b/libmuscle/python/libmuscle/manager/snapshot_registry.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Flag, auto
-from functools import lru_cache
+from functools import cache
 from itertools import chain, zip_longest
 from operator import attrgetter
 from pathlib import Path
 from queue import Queue
 from threading import Thread
-from typing import Dict, Optional, Set, FrozenSet, List, Tuple, TypeVar
+from typing import Optional, TypeVar
 
 from ymmsl.v0_2 import Configuration, Identifier, Program, Reference
 from ymmsl import save
@@ -18,16 +18,16 @@ from libmuscle.snapshot import SnapshotMetadata
 
 _MAX_FILE_EXISTS_CHECK = 100
 
-_SnapshotDictType = Dict[Reference, List["SnapshotNode"]]
-_ConnectionType = Tuple[Identifier, Identifier, "_ConnectionInfo"]
-_QueueItemType = Optional[Tuple[Reference, SnapshotMetadata]]
+_SnapshotdictType = dict[Reference, list["SnapshotNode"]]
+_ConnectionType = tuple[Identifier, Identifier, "_ConnectionInfo"]
+_QueueItemType = Optional[tuple[Reference, SnapshotMetadata]]
 _T = TypeVar("_T")
 
 # this snapshot is used as a placeholder for restarting from scratch
 _NULL_SNAPSHOT = SnapshotMetadata(["Instance start"], 0, 0, None, {}, True, '')
 
 
-def safe_get(lst: List[_T], index: int, default: _T) -> _T:
+def safe_get(lst: list[_T], index: int, default: _T) -> _T:
     """Get an item from the list, returning default when it does not exist.
 
     Args:
@@ -68,7 +68,7 @@ def calc_consistency(
 
 
 def calc_consistency_list(
-        num1: List[int], num2: List[int], first_is_sent: bool,
+        num1: list[int], num2: list[int], first_is_sent: bool,
         num2_is_restart: bool) -> bool:
     """Calculate consistency of message counts.
 
@@ -108,8 +108,8 @@ class SnapshotNode:
     num: int
     instance: Reference
     snapshot: SnapshotMetadata
-    peers: FrozenSet[Reference]
-    consistent_peers: Dict[Reference, List["SnapshotNode"]] = field(
+    peers: frozenset[Reference]
+    consistent_peers: dict[Reference, list["SnapshotNode"]] = field(
             default_factory=dict, repr=False)
 
     def __hash__(self) -> int:
@@ -124,7 +124,7 @@ class SnapshotNode:
     def do_consistency_check(
             self,
             peer_node: "SnapshotNode",
-            connections: List[_ConnectionType]) -> bool:
+            connections: list[_ConnectionType]) -> bool:
         """Check if the snapshot of the peer is consistent with us.
 
         When the peer snapshot is consistent, adds it to our list of consistent
@@ -196,9 +196,9 @@ class SnapshotRegistry(Thread):
         self._topology_store = topology_store
 
         self._queue: Queue[_QueueItemType] = Queue()
-        self._snapshots: _SnapshotDictType = {}
+        self._snapshots: _SnapshotdictType = {}
 
-        self._instances: Set[Reference] = set()
+        self._instances: set[Reference] = set()
         for component in self._model.components.values():
             self._instances.update(component.instances())
 
@@ -269,7 +269,7 @@ class SnapshotRegistry(Thread):
         self._cleanup_snapshots(workflow_snapshots)
 
     def _get_workflow_snapshots(
-            self, snapshot: SnapshotNode) -> List[List[SnapshotNode]]:
+            self, snapshot: SnapshotNode) -> list[list[SnapshotNode]]:
         """Return all workflow snapshots which contain the provided node.
 
         Args:
@@ -289,7 +289,7 @@ class SnapshotRegistry(Thread):
         # to further restrict the sets of snapshots as peer snapshots are
         # selected.
         # First restriction is that the snapshots have to be locally consistent.
-        allowed_snapshots: Dict[Reference, FrozenSet[SnapshotNode]] = {}
+        allowed_snapshots: dict[Reference, frozenset[SnapshotNode]] = {}
         for instance in instances_to_cover:
             allowed_snapshots[instance] = frozenset(
                     i_snapshot
@@ -316,7 +316,7 @@ class SnapshotRegistry(Thread):
         workflow_snapshots = []
         selected_snapshots = [snapshot]
         # This stack stores history of allowed_snapshots and enables roll back
-        stack: List[Dict[Reference, FrozenSet[SnapshotNode]]] = []
+        stack: list[dict[Reference, frozenset[SnapshotNode]]] = []
 
         # Update allowed_snapshots for peers of the selected snapshot
         for peer, snapshots in snapshot.consistent_peers.items():
@@ -383,7 +383,7 @@ class SnapshotRegistry(Thread):
                 return workflow_snapshots
 
     def _write_snapshot_ymmsl(
-            self, selected_snapshots: List[SnapshotNode]) -> None:
+            self, selected_snapshots: list[SnapshotNode]) -> None:
         """Write the snapshot ymmsl file to the snapshot folder.
 
         Args:
@@ -406,7 +406,7 @@ class SnapshotRegistry(Thread):
                            ' exists.')
 
     def _generate_snapshot_config(
-                self, selected_snapshots: List[SnapshotNode], now: datetime
+                self, selected_snapshots: list[SnapshotNode], now: datetime
                 ) -> Configuration:
         """Generate ymmsl configuration for snapshot file
         """
@@ -422,10 +422,10 @@ class SnapshotRegistry(Thread):
         return Configuration(resume=resume, description=description)
 
     def _generate_description(
-            self, selected_snapshots: List[SnapshotNode], now: datetime) -> str:
+            self, selected_snapshots: list[SnapshotNode], now: datetime) -> str:
         """Generate a human-readable description of the workflow snapshot.
         """
-        triggers: Dict[str, List[str]] = {}
+        triggers: dict[str, list[str]] = {}
         component_info = []
         max_instance_len = len('Instance ')
         for node in selected_snapshots:
@@ -454,7 +454,7 @@ class SnapshotRegistry(Thread):
                 '\n'.join(component_table) + '\n')
 
     def _cleanup_snapshots(
-            self, workflow_snapshots: List[List[SnapshotNode]]) -> None:
+            self, workflow_snapshots: list[list[SnapshotNode]]) -> None:
         """Remove all snapshots that are older than the selected snapshots.
 
         Args:
@@ -472,7 +472,7 @@ class SnapshotRegistry(Thread):
                     newest_snapshots[snapshot.instance] = snapshot
 
         # Remove all snapshots that are older than the newest snapshots
-        removed_snapshots: Set[SnapshotNode] = set()
+        removed_snapshots: set[SnapshotNode] = set()
         for snapshot in newest_snapshots.values():
             all_snapshots = self._snapshots[snapshot.instance]
             idx = all_snapshots.index(snapshot)
@@ -491,8 +491,8 @@ class SnapshotRegistry(Thread):
                 peer_snapshot.consistent_peers[snapshot.instance].remove(
                         snapshot)
 
-    @lru_cache(maxsize=None)
-    def _get_peers(self, instance: Reference) -> FrozenSet[Reference]:
+    @cache
+    def _get_peers(self, instance: Reference) -> frozenset[Reference]:
         """Return the set of peers for the given instance.
 
         Note: instance is assumed to contain the full index, not just the
@@ -506,9 +506,9 @@ class SnapshotRegistry(Thread):
         """
         return frozenset(self._topology_store.get_peer_instances(instance))
 
-    @lru_cache(maxsize=None)
+    @cache
     def _get_connections(self, instance: Reference, peer: Reference
-                         ) -> List[_ConnectionType]:
+                         ) -> list[_ConnectionType]:
         """Get the list of connections between instance and peer.
 
         Args:
@@ -533,7 +533,7 @@ class SnapshotRegistry(Thread):
         instance_kernel = instance.without_trailing_ints()
         peer_kernel = peer.without_trailing_ints()
 
-        connected_ports: List[_ConnectionType] = []
+        connected_ports: list[_ConnectionType] = []
         for conduit in self._model.conduits:
             if (conduit.sending_component() == instance_kernel and
                     conduit.receiving_component() == peer_kernel):
@@ -563,7 +563,7 @@ class SnapshotRegistry(Thread):
                         conn_type))
         return connected_ports
 
-    @lru_cache(maxsize=None)
+    @cache
     def _implementation(self, kernel: Reference) -> Optional[Program]:
         """Return the implementation of a kernel.
 

--- a/libmuscle/python/libmuscle/manager/test/conftest.py
+++ b/libmuscle/python/libmuscle/manager/test/conftest.py
@@ -78,7 +78,7 @@ def loaded_instance_registry(instance_registry):
     for j in range(10):
         for i in range(10):
             name = Reference('micro') + j + i
-            location = 'direct:{}'.format(name)
+            location = f'direct:{name}'
             instance_registry.add(name, [location], [])
     return instance_registry
 
@@ -135,13 +135,13 @@ def loaded_instance_registry2():
 
     for j in range(5):
         name = Reference('meso') + j
-        location = 'direct:{}'.format(name)
+        location = f'direct:{name}'
         instance_registry.add(name, [location], [])
 
     for j in range(5):
         for i in range(10):
             name = Reference('micro') + j + i
-            location = 'direct:{}'.format(name)
+            location = f'direct:{name}'
             instance_registry.add(name, [location], [])
     return instance_registry
 

--- a/libmuscle/python/libmuscle/manager/test/test_snapshot_registry.py
+++ b/libmuscle/python/libmuscle/manager/test/test_snapshot_registry.py
@@ -398,7 +398,7 @@ def test_heuristic_rollbacks() -> None:
         snapshot_registry._add_snapshot(comp1, make_snapshot(o_f=[i]))
     assert len(snapshot_registry._snapshots[comp1]) == 4
 
-    for i in range(10):
+    for _ in range(10):
         snapshot_registry._add_snapshot(
                 comp2, make_snapshot(f_i=[1], o_f=[0]))
         snapshot_registry._add_snapshot(

--- a/libmuscle/python/libmuscle/manager/topology_store.py
+++ b/libmuscle/python/libmuscle/manager/topology_store.py
@@ -1,4 +1,3 @@
-from typing import Dict, List
 from libmuscle.util import generate_indices, instance_indices
 
 from ymmsl.v0_2 import Conduit, Configuration, Reference, Ports
@@ -11,7 +10,7 @@ class TopologyStore:
     submodels are connected.
 
     Attributes:
-        conduits (List[Conduit]): A list of conduits.
+        conduits (list[Conduit]): A list of conduits.
     """
     def __init__(self, config: Configuration) -> None:
         """Creates a TopologyStore.
@@ -32,7 +31,7 @@ class TopologyStore:
         """
         return component in self.model.components
 
-    def get_conduits(self, component: Reference) -> List[Conduit]:
+    def get_conduits(self, component: Reference) -> list[Conduit]:
         """Returns the list of conduits that attach to the given component.
 
         Args:
@@ -61,7 +60,7 @@ class TopologyStore:
         return self.model.components[component].ports
 
     def get_peer_dimensions(self, component: Reference
-                            ) -> Dict[Reference, List[int]]:
+                            ) -> dict[Reference, list[int]]:
         """Returns the dimensions of peer components.
 
         For each component that the given component shares a conduit with,
@@ -83,7 +82,7 @@ class TopologyStore:
                 ret[snd] = self.model.components[snd].multiplicity
         return ret
 
-    def get_peer_instances(self, instance: Reference) -> List[Reference]:
+    def get_peer_instances(self, instance: Reference) -> list[Reference]:
         """Generates the names of all peer instances of an instance.
 
         Args:

--- a/libmuscle/python/libmuscle/mcp/session_state.py
+++ b/libmuscle/python/libmuscle/mcp/session_state.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Optional, Tuple
+from typing import Optional
 from typing_extensions import Buffer
 
 
@@ -41,7 +41,7 @@ class SessionState:
         self._response_ready = threading.Condition()
 
         self._cur_request = 0
-        self._response: Optional[Buffer] = bytes()
+        self._response: Optional[Buffer] = b''
 
     def __str__(self) -> str:
         with self._response_ready:
@@ -50,7 +50,7 @@ class SessionState:
     def __repr__(self) -> str:
         return self.__str__()
 
-    def triage_request(self, request_nr: int) -> Tuple[bool, bool]:
+    def triage_request(self, request_nr: int) -> tuple[bool, bool]:
         """Decide what to do about an incoming request
 
         This returns a tuple (should_process, should_send) that tells the handler

--- a/libmuscle/python/libmuscle/mcp/tcp_transport_client.py
+++ b/libmuscle/python/libmuscle/mcp/tcp_transport_client.py
@@ -2,7 +2,7 @@ import select
 import logging
 import socket
 import time
-from typing import Optional, Tuple
+from typing import Optional
 from typing_extensions import Buffer
 
 from libmuscle.mcp.transport_client import ProfileData, TransportClient, TimeoutHandler
@@ -54,7 +54,7 @@ class TcpTransportClient(TransportClient):
         self._reconnect(False)
 
     def call(self, request: Buffer, timeout_handler: Optional[TimeoutHandler] = None
-             ) -> Tuple[Buffer, ProfileData]:
+             ) -> tuple[Buffer, ProfileData]:
         """Send a request to the server and receive the response.
 
         This is a blocking call.

--- a/libmuscle/python/libmuscle/mcp/tcp_transport_server.py
+++ b/libmuscle/python/libmuscle/mcp/tcp_transport_server.py
@@ -2,7 +2,7 @@ import logging
 import socket
 import socketserver as ss
 import threading
-from typing import Any, cast, Dict, List, Tuple, Type
+from typing import Any, cast
 
 import psutil
 
@@ -20,8 +20,8 @@ class TcpTransportServerImpl(ss.ThreadingMixIn, ss.TCPServer):
     daemon_threads = True
     allow_reuse_address = True
 
-    def __init__(self, host_port_tuple: Tuple[str, int],
-                 streamhandler: Type, transport_server: 'TcpTransportServer'
+    def __init__(self, host_port_tuple: tuple[str, int],
+                 streamhandler: type, transport_server: 'TcpTransportServer'
                  ) -> None:
         super().__init__(host_port_tuple, streamhandler)
         self.transport_server = transport_server
@@ -30,7 +30,7 @@ class TcpTransportServerImpl(ss.ThreadingMixIn, ss.TCPServer):
         if hasattr(socket, "TCP_QUICKACK"):
             self.socket.setsockopt(socket.SOL_TCP, socket.TCP_QUICKACK, 1)
 
-        self.session_store: Dict[int, SessionState] = dict()
+        self.session_store: dict[int, SessionState] = dict()
         self.session_lock = threading.Lock()
         self.next_session = 1
 
@@ -159,9 +159,9 @@ class TcpTransportServer(TransportServer):
         # IPv6 may give two more (unneeded) items, so can't unpack directly
         port = self._server.server_address[1]
 
-        locs: List[str] = []
+        locs: list[str] = []
         for address in self._get_if_addresses():
-            locs.append('{}:{}'.format(address, port))
+            locs.append(f'{address}:{port}')
         return 'tcp:{}'.format(','.join(locs))
 
     def close(self, graceful: bool = True) -> None:
@@ -185,7 +185,7 @@ class TcpTransportServer(TransportServer):
         self._server_thread.join()
         self._server.server_close()
 
-    def _get_if_addresses(self) -> List[str]:
+    def _get_if_addresses(self) -> list[str]:
         """Returns a list of local addresses.
 
         This returns a list of strings containing all IPv4 and IPv6 network
@@ -194,7 +194,7 @@ class TcpTransportServer(TransportServer):
         from the client. So we get all of them here, and the client can
         then try them all and find one that works.
         """
-        all_addresses: List[str] = []
+        all_addresses: list[str] = []
         ifs = psutil.net_if_addrs()
         for _, addresses in ifs.items():
             for addr in addresses:

--- a/libmuscle/python/libmuscle/mcp/transport_client.py
+++ b/libmuscle/python/libmuscle/mcp/transport_client.py
@@ -1,10 +1,10 @@
-from typing import Optional, Tuple
+from typing import Optional
 from typing_extensions import Buffer
 
 from libmuscle.profiling import ProfileTimestamp
 
 
-ProfileData = Tuple[ProfileTimestamp, ProfileTimestamp, ProfileTimestamp]
+ProfileData = tuple[ProfileTimestamp, ProfileTimestamp, ProfileTimestamp]
 
 
 class TimeoutHandler:
@@ -49,7 +49,7 @@ class TransportClient:
         raise NotImplementedError()     # pragma: no cover
 
     def call(self, request: Buffer, timeout_handler: Optional[TimeoutHandler] = None
-             ) -> Tuple[Buffer, ProfileData]:
+             ) -> tuple[Buffer, ProfileData]:
         """Send a request to the server and receive the response.
 
         This is a blocking call. Besides the result, this function

--- a/libmuscle/python/libmuscle/mmp_client.py
+++ b/libmuscle/python/libmuscle/mmp_client.py
@@ -1,9 +1,10 @@
+from collections.abc import Iterable
 import dataclasses
 from pathlib import Path
 from random import uniform
 from threading import get_ident, RLock
 from time import perf_counter, sleep
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Optional
 
 import msgpack
 from ymmsl.v0_2 import (
@@ -26,7 +27,7 @@ PEER_TIMEOUT = 600
 PEER_INTERVAL_MIN = 5.0
 PEER_INTERVAL_MAX = 10.0
 
-_CheckpointInfoType = Tuple[
+_CheckpointInfoType = tuple[
         float, Checkpoints, Optional[Path], Optional[Path]]
 
 
@@ -35,7 +36,7 @@ def encode_operator(op: Operator) -> str:
     return op.name
 
 
-def encode_port(port: Port) -> List[str]:
+def encode_port(port: Port) -> list[str]:
     """Convert a Port to a MsgPack-compatible value."""
     return [str(port.name), encode_operator(port.operator)]
 
@@ -62,7 +63,7 @@ def encode_profile_event(event: ProfileEvent) -> Any:
             event.message_number, event.message_size, event.message_timestamp]
 
 
-def decode_checkpoint_rule(rule: Dict[str, Any]) -> CheckpointRule:
+def decode_checkpoint_rule(rule: dict[str, Any]) -> CheckpointRule:
     """Decode a checkpoint rule from a MsgPack-compatible value."""
     if rule.keys() == {'at'}:
         return CheckpointAtRule(**rule)
@@ -73,7 +74,7 @@ def decode_checkpoint_rule(rule: Dict[str, Any]) -> CheckpointRule:
 
 def decode_checkpoint_info(
         elapsed_time: float,
-        checkpoints_dict: Dict[str, Any],
+        checkpoints_dict: dict[str, Any],
         resume: Optional[str],
         snapshot_dir: Optional[str]
         ) -> _CheckpointInfoType:
@@ -106,7 +107,7 @@ class ConnectionLockedError(RuntimeError):
     pass
 
 
-class MMPClient():
+class MMPClient:
     """The client for the MUSCLE Manager Protocol.
 
     This class connects to the Manager and communicates with it on
@@ -222,7 +223,7 @@ class MMPClient():
         return decode_checkpoint_info(*response[1:])
 
     def register_instance(
-            self, locations: List[str], ports: List[Port]) -> None:
+            self, locations: list[str], ports: list[Port]) -> None:
         """Register a component instance with the manager.
 
         Args:
@@ -273,8 +274,7 @@ class MMPClient():
             raise RuntimeError('Timeout waiting for peers to appear')
 
         if response[0] == ResponseType.ERROR.value:
-            raise RuntimeError('Error getting peers from manager: {}'.format(
-                    response[1]))
+            raise RuntimeError(f'Error getting peers from manager: {response[1]}')
 
         conduits = [Conduit(snd, recv) for snd, recv in response[1]]
 
@@ -301,8 +301,7 @@ class MMPClient():
         response = self._call_manager(request)
 
         if response[0] == ResponseType.ERROR.value:
-            raise RuntimeError('Error deregistering instance: {}'.format(
-                    response[1]))
+            raise RuntimeError(f'Error deregistering instance: {response[1]}')
 
     def waiting_for_receive(
             self, peer_instance_id: Reference, port_name: str, slot: Optional[int]

--- a/libmuscle/python/libmuscle/mmsf_validator.py
+++ b/libmuscle/python/libmuscle/mmsf_validator.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import types
-from typing import List, Optional
+from typing import Optional
 
 from libmuscle.port_manager import PortManager
 from ymmsl.v0_2 import Operator
@@ -95,7 +95,7 @@ class MMSFValidator:
                     "which are not supported by the MMSF Validator.")
 
         # State tracking
-        self._current_ports_used: List[str] = []
+        self._current_ports_used: list[str] = []
         self._current_operator: Operator = Operator.NONE
 
     def check_send(self, port_name: str, slot: Optional[int]) -> None:

--- a/libmuscle/python/libmuscle/mpp_client.py
+++ b/libmuscle/python/libmuscle/mpp_client.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Optional
 from typing_extensions import Buffer
 
 import msgpack
@@ -15,7 +15,7 @@ class MPPClient:
     This client connects to a peer to retrieve messages. It uses an MCP
     Transport to connect.
     """
-    def __init__(self, locations: List[str]) -> None:
+    def __init__(self, locations: list[str]) -> None:
         """Create an MPPClient for the given peer.
 
         The client will connect to the peer on one of its locations. It
@@ -42,7 +42,7 @@ class MPPClient:
         self._transport_client = client
 
     def receive(self, receiver: Reference, timeout_handler: Optional[TimeoutHandler]
-                ) -> Tuple[Buffer, ProfileData]:
+                ) -> tuple[Buffer, ProfileData]:
         """Receive a message from a port this client connects to.
 
         Args:

--- a/libmuscle/python/libmuscle/mpp_message.py
+++ b/libmuscle/python/libmuscle/mpp_message.py
@@ -118,7 +118,7 @@ def _data_encoder(obj: Any) -> Any:
     numpy.ndarray objects the user may want to send.
     """
     if isinstance(obj, ClosePort):
-        return msgpack.ExtType(ExtTypeId.CLOSE_PORT, bytes())
+        return msgpack.ExtType(ExtTypeId.CLOSE_PORT, b'')
     elif isinstance(obj, Settings):
         packed_data = msgpack.packb(obj.as_ordered_dict(),
                                     use_bin_type=True)

--- a/libmuscle/python/libmuscle/mpp_server.py
+++ b/libmuscle/python/libmuscle/mpp_server.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing_extensions import Buffer
 
 import msgpack
@@ -53,13 +52,13 @@ class MPPServer:
     def __init__(self) -> None:
         self._post_office = PostOffice()
         self._handler = MPPRequestHandler(self._post_office)
-        self._servers: List[TransportServer] = []
+        self._servers: list[TransportServer] = []
 
         for server_type in transport_server_types:
             server = server_type(self._handler)
             self._servers.append(server)
 
-    def get_locations(self) -> List[str]:
+    def get_locations(self) -> list[str]:
         """Returns a list of locations that we can be reached at.
 
         These locations are of the form 'protocol:location', where

--- a/libmuscle/python/libmuscle/native_instantiator/agent/__main__.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent/__main__.py
@@ -4,7 +4,6 @@ import psutil
 from socket import gethostname
 import sys
 from time import sleep
-from typing import Dict, Set, Tuple
 
 from libmuscle.native_instantiator.process_manager import ProcessManager
 from libmuscle.native_instantiator.agent.map_client import MAPClient
@@ -82,17 +81,17 @@ class Agent:
             A dict mapping resource types to resource descriptions.
         """
         if hasattr(os, 'sched_getaffinity'):
-            hwthreads_by_core_tuple: Dict[Tuple[int, int], Set[int]] = dict()
+            hwthreads_by_core_tuple: dict[tuple[int, int], set[int]] = dict()
 
             # these are the logical hwthread ids that we can use
             hwthread_ids = list(os.sched_getaffinity(0))
 
             for hwthread_id in hwthread_ids:
                 topdir = f'/sys/devices/system/cpu/cpu{hwthread_id}/topology'
-                with open(f'{topdir}/core_id', 'r') as f:
+                with open(f'{topdir}/core_id') as f:
                     # this gets the logical core id for the hwthread
                     core_id = int(f.read())
-                with open(f'{topdir}/physical_package_id', 'r') as f:
+                with open(f'{topdir}/physical_package_id') as f:
                     # this gets the die/socket id for the hwthread
                     package_id = int(f.read())
 
@@ -148,14 +147,14 @@ class Agent:
                         ' still appreciate an issue, because it is unexpected for sure.'
                         )
 
-            cores = CoreSet((
+            cores = CoreSet(
                     Core(
                         cid,
                         set(range(
                             cid * hwthreads_per_core, (cid + 1) * hwthreads_per_core))
                         )
                     for cid in range(ncores)
-                    ))
+                    )
 
         resources = OnNodeResources(self._node_name, cores)
         _logger.info(f'Found resources: {resources}')

--- a/libmuscle/python/libmuscle/native_instantiator/agent/agent_commands.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent/agent_commands.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List
 
 
 class AgentCommand:
@@ -11,8 +10,8 @@ class AgentCommand:
 class StartCommand(AgentCommand):
     name: str
     work_dir: Path
-    args: List[str]
-    env: Dict[str, str]
+    args: list[str]
+    env: dict[str, str]
     stdout: Path
     stderr: Path
 

--- a/libmuscle/python/libmuscle/native_instantiator/agent/map_client.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent/map_client.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import msgpack
 
@@ -76,7 +76,7 @@ class MAPClient:
 
         raise Exception('Unknown AgentCommand')
 
-    def report_result(self, names_exit_codes: List[Tuple[str, int]]) -> None:
+    def report_result(self, names_exit_codes: list[tuple[str, int]]) -> None:
         """Report results of finished processes.
 
         Args:

--- a/libmuscle/python/libmuscle/native_instantiator/agent_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent_manager.py
@@ -4,7 +4,6 @@ from subprocess import Popen, TimeoutExpired
 import sys
 from threading import Lock
 from time import sleep
-from typing import Dict, List, Tuple
 
 from libmuscle.native_instantiator.agent.agent_commands import (
         CancelAllCommand, StartCommand, ShutdownCommand)
@@ -39,11 +38,11 @@ class AgentManager(IAgentManager):
             agent_dir: Directory in which agents can write log files.
         """
         self._expected_nodes = global_resources().nodes
-        self._nodes: Dict[str, str] = dict()
+        self._nodes: dict[str, str] = dict()
         self._resources: Resources = Resources([])
         self._resources_lock = Lock()   # protects _nodes and _resources
 
-        self._finished_processes: List[Tuple[str, int]] = list()
+        self._finished_processes: list[tuple[str, int]] = list()
         self._finished_processes_lock = Lock()
 
         self._server = MAPServer(self)
@@ -60,8 +59,8 @@ class AgentManager(IAgentManager):
         return self._resources
 
     def start(
-            self, node_name: str, name: str, work_dir: Path, args: List[str],
-            env: Dict[str, str], stdout: Path, stderr: Path) -> None:
+            self, node_name: str, name: str, work_dir: Path, args: list[str],
+            env: dict[str, str], stdout: Path, stderr: Path) -> None:
         """Start a process on a node.
 
         The files that the output is directed to will be overwritten if they already
@@ -90,7 +89,7 @@ class AgentManager(IAgentManager):
         for node_host_name in self._nodes.values():
             self._server.deposit_command(node_host_name, CancelAllCommand())
 
-    def get_finished(self) -> List[Tuple[str, int]]:
+    def get_finished(self) -> list[tuple[str, int]]:
         """Returns names and exit codes of finished processes.
 
         This returns all processes that have finished running since the previous call;
@@ -153,7 +152,7 @@ class AgentManager(IAgentManager):
             self._nodes[resources.node_name] = agent_hostname
             self._resources.add_node(resources)
 
-    def report_result(self, names_exit_codes: List[Tuple[str, int]]) -> None:
+    def report_result(self, names_exit_codes: list[tuple[str, int]]) -> None:
         """Report results of finished processes.
 
         Called by MAPServer from a server thread.

--- a/libmuscle/python/libmuscle/native_instantiator/global_resources.py
+++ b/libmuscle/python/libmuscle/native_instantiator/global_resources.py
@@ -1,7 +1,7 @@
 from enum import Enum
 import logging
 from socket import gethostname
-from typing import List, Optional
+from typing import Optional
 
 import psutil
 
@@ -55,7 +55,7 @@ class GlobalResources:
         """Return whether we're running on a cluster."""
         return self.scheduler != Scheduler.NONE
 
-    def agent_launch_command(self, agent_cmd: List[str]) -> List[str]:
+    def agent_launch_command(self, agent_cmd: list[str]) -> list[str]:
         """Return a command for launching one agent on each node.
 
         Args:

--- a/libmuscle/python/libmuscle/native_instantiator/iagent_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/iagent_manager.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 from libmuscle.planner.resources import OnNodeResources
 
 
@@ -20,7 +18,7 @@ class IAgentManager:
         """
         raise NotImplementedError()
 
-    def report_result(self, names_exit_codes: List[Tuple[str, int]]) -> None:
+    def report_result(self, names_exit_codes: list[tuple[str, int]]) -> None:
         """Report results of finished processes.
 
         Called by MAPServer from a server thread.

--- a/libmuscle/python/libmuscle/native_instantiator/map_server.py
+++ b/libmuscle/python/libmuscle/native_instantiator/map_server.py
@@ -1,6 +1,6 @@
 import errno
 import logging
-from typing import Any, Dict, cast, List, Optional
+from typing import Any, cast, Optional
 from typing_extensions import Buffer
 
 import msgpack
@@ -54,7 +54,7 @@ class MAPRequestHandler(RequestHandler):
         return cast(Buffer, msgpack.packb(response, use_bin_type=True))
 
     def _report_resources(
-            self, node_name: str, data: Dict[str, Any]) -> Any:
+            self, node_name: str, data: dict[str, Any]) -> Any:
         """Handle a report resources request.
 
         This is used by the agent to report available resources on its node when
@@ -67,7 +67,7 @@ class MAPRequestHandler(RequestHandler):
                 id at index [0] followed by the hwthread ids of all hwthreads in this
                 core.
         """
-        cores = CoreSet((Core(ids[0], set(ids[1:])) for ids in data['cpu']))
+        cores = CoreSet(Core(ids[0], set(ids[1:])) for ids in data['cpu'])
         node_resources = OnNodeResources(node_name, cores)
         self._agent_manager.report_resources(node_resources)
         return [ResponseType.SUCCESS.value]
@@ -95,14 +95,14 @@ class MAPRequestHandler(RequestHandler):
 
         return [ResponseType.PENDING.value]
 
-    def _report_result(self, instances: List[List[Any]]) -> Any:
+    def _report_result(self, instances: list[list[Any]]) -> Any:
         """Handle a report result request.
 
         This is sent by the agent if an instance it launched exited.
 
         Args:
             instances: List of instance descriptions, comprising an id str and exit
-                    code int. Really a List[Tuple[str, int]] but msgpack doesn't know
+                    code int. Really a list[Tuple[str, int]] but msgpack doesn't know
                     about tuples.
         """
         self._agent_manager.report_result(list(map(tuple, instances)))

--- a/libmuscle/python/libmuscle/native_instantiator/native_instantiator.py
+++ b/libmuscle/python/libmuscle/native_instantiator/native_instantiator.py
@@ -5,7 +5,7 @@ import queue
 import sys
 from time import sleep
 import traceback
-from typing import Dict, List, Optional
+from typing import Optional
 
 from libmuscle.errors import ConfigurationError
 from libmuscle.manager.instantiator import (
@@ -44,7 +44,7 @@ class NativeInstantiator(mp.Process):
         self._log_records_out = log_records
         self._run_dir = run_dir
 
-        self._processes: Dict[str, Process] = dict()
+        self._processes: dict[str, Process] = dict()
 
     def run(self) -> None:
         """Entry point for the process"""
@@ -244,7 +244,7 @@ class NativeInstantiator(mp.Process):
         return run_script_file
 
     def _add_resources(
-            self, env: Dict[str, str], res_req: ResourceRequirements) -> None:
+            self, env: dict[str, str], res_req: ResourceRequirements) -> None:
         """Add resource env vars to the given env."""
         if isinstance(res_req, ThreadedResReq):
             num_threads = res_req.threads
@@ -265,7 +265,7 @@ class NativeInstantiator(mp.Process):
 
     def _report_failed_processes(self) -> None:
         """Get processes that failed to start and report their status."""
-        failed_processes: List[str] = list()
+        failed_processes: list[str] = list()
 
         for name, process in self._processes.items():
             if process.status == ProcessStatus.ERROR:

--- a/libmuscle/python/libmuscle/native_instantiator/process_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/process_manager.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 from subprocess import Popen
-from typing import Dict, List, Tuple
 
 
 _logger = logging.getLogger(__name__)
@@ -11,10 +10,10 @@ class ProcessManager:
     """Manages a set of running processes."""
     def __init__(self) -> None:
         """Create a ProcessManager."""
-        self._processes: Dict[str, Popen] = dict()
+        self._processes: dict[str, Popen] = dict()
 
     def start(
-            self, name: str, work_dir: Path, args: List[str], env: Dict[str, str],
+            self, name: str, work_dir: Path, args: list[str], env: dict[str, str],
             stdout: Path, stderr: Path) -> None:
         """Start a process.
 
@@ -49,13 +48,13 @@ class ProcessManager:
         for process in self._processes.values():
             process.kill()
 
-    def get_finished(self) -> List[Tuple[str, int]]:
+    def get_finished(self) -> list[tuple[str, int]]:
         """Returns names and exit codes of finished processes.
 
         This returns all processes that have finished running since the previous call;
         each started process will be returned exactly once.
         """
-        result: List[Tuple[str, int]] = list()
+        result: list[tuple[str, int]] = list()
 
         for name, process in self._processes.items():
             exit_code = process.poll()

--- a/libmuscle/python/libmuscle/native_instantiator/run_script.py
+++ b/libmuscle/python/libmuscle/native_instantiator/run_script.py
@@ -1,6 +1,7 @@
+from collections.abc import Iterable
 import logging
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Optional
 
 from libmuscle.errors import ConfigurationError
 from libmuscle.native_instantiator.slurm import slurm
@@ -10,7 +11,7 @@ from ymmsl.v0_2 import (
         ResourceRequirements, ThreadedResReq)
 
 
-def direct_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, str]]:
+def direct_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, str]]:
     """Create resources for a non-MPI program with taskset.
 
     Taskset expects a set of hwthreads on the command line, either as a comma-separated
@@ -23,18 +24,18 @@ def direct_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str,
     Return:
         No rank file, and a set of environment variables.
     """
-    env: Dict[str, str] = dict()
+    env: dict[str, str] = dict()
     only_node_hwthreads_list = list(resources.by_rank[0].hwthreads())
 
     env['MUSCLE_BIND_LIST'] = ','.join(map(str, only_node_hwthreads_list))
 
-    mask_int = sum((1 << c for c in only_node_hwthreads_list))
+    mask_int = sum(1 << c for c in only_node_hwthreads_list)
     env['MUSCLE_BIND_MASK'] = format(mask_int, 'X')
 
     return '', env
 
 
-def openmpi_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, str]]:
+def openmpi_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, str]]:
     """Create resource description for OpenMPI mpirun
 
     Args:
@@ -43,7 +44,7 @@ def openmpi_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str
     Return:
         The contents of the rankfile, and a set of environment variables
     """
-    ranklines: List[str] = list()
+    ranklines: list[str] = list()
     all_cores = (
             (node_res, ','.join(map(str, sorted(node_res.hwthreads()))))
             for node_res in resources.by_rank)
@@ -56,7 +57,7 @@ def openmpi_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str
     return rankfile, dict()
 
 
-def impi_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, str]]:
+def impi_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, str]]:
     """Create resource description for Intel MPI mpirun
 
     Args:
@@ -65,13 +66,13 @@ def impi_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, s
     Return:
         The contents of the machinefile, and a set of environment variables
     """
-    env: Dict[str, str] = dict()
-    machine_nodes: List[str] = list()
-    pin_masks: List[int] = list()
+    env: dict[str, str] = dict()
+    machine_nodes: list[str] = list()
+    pin_masks: list[int] = list()
 
     for rank, res in enumerate(resources.by_rank):
         machine_nodes.append(res.node_name)
-        pin_masks.append(sum((1 << c for c in res.hwthreads())))
+        pin_masks.append(sum(1 << c for c in res.hwthreads()))
 
     # coalesce machine lines
     proc_counts = [1] * len(machine_nodes)
@@ -106,7 +107,7 @@ def impi_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, s
     return machinefile, env
 
 
-def mpich_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, str]]:
+def mpich_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, str]]:
     """Create resource description for MPICH mpirun
 
     Args:
@@ -121,7 +122,7 @@ def mpich_prep_resources(resources: ResourceAssignment) -> Tuple[str, Dict[str, 
 
 def srun_prep_resources(
         resources: ResourceAssignment, rankfile_location: Path
-        ) -> Tuple[str, Dict[str, str]]:
+        ) -> tuple[str, dict[str, str]]:
     """Create resource description for srun
 
     Args:
@@ -131,9 +132,9 @@ def srun_prep_resources(
     Return:
         The contents of the hostfile, and a set of environment variables
     """
-    hostfile = '\n'.join((
+    hostfile = '\n'.join(
         node_res.node_name for node_res in resources.by_rank
-        for _ in node_res.hwthreads()))
+        for _ in node_res.hwthreads())
 
     env = {'SLURM_HOSTFILE': str(rankfile_location)}
 
@@ -151,7 +152,7 @@ def srun_prep_resources(
 
 def prep_resources(
         model: ExecutionModel, resources: ResourceAssignment, rankfile_location: Path
-        ) -> Tuple[str, Dict[str, str]]:
+        ) -> tuple[str, dict[str, str]]:
     """Create resource description for the given execution model.
 
     Args:
@@ -356,7 +357,7 @@ def make_script(
     """
     enable_debug = logging.getLogger('libmuscle').getEffectiveLevel() <= logging.DEBUG
 
-    lines: List[str] = list()
+    lines: list[str] = list()
 
     if program.base_env == BaseEnv.LOGIN:
         # We try to emulate an interactive login shell here by starting a

--- a/libmuscle/python/libmuscle/native_instantiator/run_script.py
+++ b/libmuscle/python/libmuscle/native_instantiator/run_script.py
@@ -70,7 +70,7 @@ def impi_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, s
     machine_nodes: list[str] = list()
     pin_masks: list[int] = list()
 
-    for rank, res in enumerate(resources.by_rank):
+    for _, res in enumerate(resources.by_rank):
         machine_nodes.append(res.node_name)
         pin_masks.append(sum(1 << c for c in res.hwthreads()))
 

--- a/libmuscle/python/libmuscle/native_instantiator/slurm.py
+++ b/libmuscle/python/libmuscle/native_instantiator/slurm.py
@@ -1,10 +1,11 @@
+from collections.abc import Sequence
 from itertools import product
 import logging
 import os
 from parsimonious import Grammar, NodeVisitor
 from parsimonious.nodes import Node
 import subprocess
-from typing import Any, cast, List, Optional, Sequence, Tuple
+from typing import Any, cast, Optional
 
 
 _logger = logging.getLogger(__name__)
@@ -33,8 +34,8 @@ class NREVisitor(NodeVisitor):
     """
     def visit_nre(
             self, node: Node,
-            visited_children: Tuple[List[str], Sequence[Tuple[Any, List[str]]]]
-            ) -> List[str]:
+            visited_children: tuple[list[str], Sequence[tuple[Any, list[str]]]]
+            ) -> list[str]:
         """Return a list of nodes corresponding to the NRE."""
         nodes = visited_children[0].copy()
         for _, more_nodes in visited_children[1]:
@@ -42,17 +43,17 @@ class NREVisitor(NodeVisitor):
         return nodes
 
     def visit_nre_parts(
-            self, node: Node, visited_children: Sequence[Tuple[str, List[str]]]
-            ) -> List[str]:
+            self, node: Node, visited_children: Sequence[tuple[str, list[str]]]
+            ) -> list[str]:
         """Return a list of node ids for the part."""
         fmt = ''.join([c[0] + '{}' for c in visited_children])
         index_lists = [c[1] for c in visited_children]
         return [fmt.format(*idxs) for idxs in product(*index_lists)]
 
     def visit_nre_part(
-            self, node: Node, visited_children: Tuple[
-                str, Sequence[Tuple[Any, List[str], Any]]]
-            ) -> Tuple[str, List[str]]:
+            self, node: Node, visited_children: tuple[
+                str, Sequence[tuple[Any, list[str], Any]]]
+            ) -> tuple[str, list[str]]:
         """Return the identifier part and a list of indexes for the set."""
         identifier = visited_children[0]
         if not visited_children[1]:
@@ -63,8 +64,8 @@ class NREVisitor(NodeVisitor):
 
     def visit_index_set(
             self, node: Node,
-            visited_children: Tuple[List[str], Sequence[Tuple[Any, List[str]]]]
-            ) -> List[str]:
+            visited_children: tuple[list[str], Sequence[tuple[Any, list[str]]]]
+            ) -> list[str]:
         """Return a list of indexes corresponding to the set."""
         indexes = visited_children[0].copy()
         for _, more_indexes in visited_children[1]:
@@ -73,12 +74,12 @@ class NREVisitor(NodeVisitor):
 
     def visit_index_range(
             self, node: Node,
-            visited_children: Tuple[
-                Tuple[int, int],
+            visited_children: tuple[
+                tuple[int, int],
                 Sequence[
-                    Tuple[Any, Tuple[int, int]]
+                    tuple[Any, tuple[int, int]]
                     ]]
-            ) -> List[str]:
+            ) -> list[str]:
         """Return a list of indexes corresponding to the range."""
 
         def format_str(width: int) -> str:
@@ -99,16 +100,16 @@ class NREVisitor(NodeVisitor):
         return node.text
 
     def visit_integer(
-            self, node: Node, visited_children: Sequence[Tuple[int, int]]
-            ) -> Tuple[int, int]:
+            self, node: Node, visited_children: Sequence[tuple[int, int]]
+            ) -> tuple[int, int]:
         """Returns the value of the int, and a field width or -1."""
         return visited_children[0]
 
-    def visit_int(self, node: Node, _: Sequence[Any]) -> Tuple[int, int]:
+    def visit_int(self, node: Node, _: Sequence[Any]) -> tuple[int, int]:
         """Returns the value and a field width of -1."""
         return int(node.text), -1
 
-    def visit_padded_int(self, node: Node, _: Sequence[Any]) -> Tuple[int, int]:
+    def visit_padded_int(self, node: Node, _: Sequence[Any]) -> tuple[int, int]:
         """Returns the value of the int and the field width."""
         return int(node.text), len(node.text)
 
@@ -120,7 +121,7 @@ class NREVisitor(NodeVisitor):
 _nre_visitor = NREVisitor()
 
 
-def parse_slurm_nodelist(s: str) -> List[str]:
+def parse_slurm_nodelist(s: str) -> list[str]:
     """Parse a SLURM node range expression and produce node names.
 
     Exactly what the syntax is for a "node range expression" isn't entirely
@@ -147,7 +148,7 @@ def parse_slurm_nodelist(s: str) -> List[str]:
     corresponding list of node names.
     """
     ast = _node_range_expression_grammar.parse(s)
-    return cast(List[str], _nre_visitor.visit(ast))
+    return cast(list[str], _nre_visitor.visit(ast))
 
 
 _nodes_cores_expression_grammar = Grammar(
@@ -168,8 +169,8 @@ class NCEVisitor(NodeVisitor):
     """
     def visit_nce(
             self, node: Node,
-            visited_children: Tuple[List[int], Sequence[Tuple[Any, List[int]]]]
-            ) -> List[int]:
+            visited_children: tuple[list[int], Sequence[tuple[Any, list[int]]]]
+            ) -> list[int]:
         """Return a list of nodes corresponding to the NRE."""
         nodes_cores = visited_children[0].copy()
         for _, more_nodes_cores in visited_children[1]:
@@ -178,8 +179,8 @@ class NCEVisitor(NodeVisitor):
 
     def visit_nce_run(
             self, node: Node,
-            visited_children: Tuple[int, Sequence[Tuple[Any, int, Any]]]
-            ) -> List[int]:
+            visited_children: tuple[int, Sequence[tuple[Any, int, Any]]]
+            ) -> list[int]:
         """Return a list of core counts produced by this run."""
         num_cores = visited_children[0]
         result = [num_cores]
@@ -190,7 +191,7 @@ class NCEVisitor(NodeVisitor):
         return result
 
     def visit_run_length(
-            self, node: Node, visited_children: Tuple[str, int]) -> int:
+            self, node: Node, visited_children: tuple[str, int]) -> int:
         """Return the number of repetitions."""
         return visited_children[1]
 
@@ -206,7 +207,7 @@ class NCEVisitor(NodeVisitor):
 _nce_visitor = NCEVisitor()
 
 
-def parse_slurm_nodes_cores(s: str) -> List[int]:
+def parse_slurm_nodes_cores(s: str) -> list[int]:
     """Parse a SLURM nodes cores expression and produce node names.
 
     The sbatch documentation page describes the format under
@@ -220,7 +221,7 @@ def parse_slurm_nodes_cores(s: str) -> List[int]:
     node names.
     """
     ast = _nodes_cores_expression_grammar.parse(s)
-    return cast(List[int], _nce_visitor.visit(ast))
+    return cast(list[int], _nce_visitor.visit(ast))
 
 
 class SlurmQuirks:
@@ -249,7 +250,7 @@ class SlurmInfo:
         """
         return 'SLURM_JOB_ID' in os.environ
 
-    def get_nodes(self) -> List[str]:
+    def get_nodes(self) -> list[str]:
         """Get a list of node names from SLURM_JOB_NODELIST.
 
         This inspects SLURM_JOB_NODELIST or SLURM_NODELIST and returns an
@@ -268,7 +269,7 @@ class SlurmInfo:
 
         return parse_slurm_nodelist(nodelist)
 
-    def get_logical_cpus_per_node(self) -> List[int]:
+    def get_logical_cpus_per_node(self) -> list[int]:
         """Return the number of logical CPU cores per node.
 
         This returns a list with the number of cores of each node in the result of
@@ -297,7 +298,7 @@ class SlurmInfo:
                 ' SLURM_NNODES is set. Please create an issue on GitHub with the output'
                 ' of "sbatch --version" on this cluster.')
 
-    def agent_launch_command(self, agent_cmd: List[str], nnodes: int) -> List[str]:
+    def agent_launch_command(self, agent_cmd: list[str], nnodes: int) -> list[str]:
         """Return a command for launching one agent on each node.
 
         Args:
@@ -320,7 +321,7 @@ class SlurmInfo:
 
         return srun_cmd + agent_cmd
 
-    def _slurm_version(self) -> Tuple[int, int]:
+    def _slurm_version(self) -> tuple[int, int]:
         """Obtains current version of SLURM from srun -v.
 
         This returns only the first two numbers, hopefully there won't be any changes in

--- a/libmuscle/python/libmuscle/peer_info.py
+++ b/libmuscle/python/libmuscle/peer_info.py
@@ -1,4 +1,4 @@
-from typing import cast, Dict, List, Tuple
+from typing import cast
 
 from ymmsl.v0_2 import Conduit, Identifier, Reference, Port
 
@@ -8,10 +8,10 @@ from libmuscle.endpoint import Endpoint
 class PeerInfo:
     """Interprets information about peers for a Communicator
     """
-    def __init__(self, kernel: Reference, index: List[int],
-                 conduits: List[Conduit],
-                 peer_dims: Dict[Reference, List[int]],
-                 peer_locations: Dict[Reference, List[str]],
+    def __init__(self, kernel: Reference, index: list[int],
+                 conduits: list[Conduit],
+                 peer_dims: dict[Reference, list[int]],
+                 peer_locations: dict[Reference, list[str]],
                  ymmsl_ports: list[Port]) -> None:
         """Create a PeerInfo.
 
@@ -37,11 +37,11 @@ class PeerInfo:
         self._index = index
         self._conduits = conduits
 
-        self._incoming_ports: List[Reference] = []
-        self._outgoing_ports: List[Reference] = []
+        self._incoming_ports: list[Reference] = []
+        self._outgoing_ports: list[Reference] = []
 
         # peer port ids, indexed by local kernel.port id
-        self._peers: Dict[Reference, List[Reference]] = {}
+        self._peers: dict[Reference, list[Reference]] = {}
 
         for conduit in conduits:
             if str(conduit.sending_component()) == str(kernel):
@@ -54,10 +54,9 @@ class PeerInfo:
             if str(conduit.receiving_component()) == str(kernel):
                 # we receive on the port this conduit attaches to
                 if conduit.receiver in self._peers:
-                    raise RuntimeError(('Receiving port "{}" is connected by'
-                                        ' multiple conduits, but at most one'
-                                        ' is allowed.'
-                                        ).format(conduit.receiving_port()))
+                    raise RuntimeError(
+                            f'Receiving port "{conduit.receiving_port()}" is connected'
+                            ' by multiple conduits, but at most one is allowed.')
                 self._incoming_ports.append(conduit.receiver)
                 self._peers[conduit.receiver] = [conduit.sender]
 
@@ -66,11 +65,11 @@ class PeerInfo:
         self._ymmsl_ports = ymmsl_ports
 
     def list_ymmsl_ports(self) -> list[Port]:
-        """List ports declared in the yMMSL configuration"""
+        """list ports declared in the yMMSL configuration"""
         return self._ymmsl_ports
 
-    def list_incoming_ports(self) -> List[Tuple[Identifier, Reference]]:
-        """List incoming ports.
+    def list_incoming_ports(self) -> list[tuple[Identifier, Reference]]:
+        """list incoming ports.
 
         Returns:
             A list of tuples containing a port id and a reference to the
@@ -80,8 +79,8 @@ class PeerInfo:
                 (cast(Identifier, port_ref[-1]), self._peers[port_ref][0])
                 for port_ref in self._incoming_ports]
 
-    def list_outgoing_ports(self) -> List[Tuple[Identifier, List[Reference]]]:
-        """List outgoing ports.
+    def list_outgoing_ports(self) -> list[tuple[Identifier, list[Reference]]]:
+        """list outgoing ports.
 
         Returns:
             A list of tuples containing a port id and a list of references
@@ -100,7 +99,7 @@ class PeerInfo:
         recv_port_full = self._kernel + port
         return recv_port_full in self._peers
 
-    def get_peer_ports(self, port: Identifier) -> List[Reference]:
+    def get_peer_ports(self, port: Identifier) -> list[Reference]:
         """Get a reference for the peer ports.
 
         Args:
@@ -108,7 +107,7 @@ class PeerInfo:
         """
         return self._peers[self._kernel + port]
 
-    def get_peer_dims(self, peer_kernel: Reference) -> List[int]:
+    def get_peer_dims(self, peer_kernel: Reference) -> list[int]:
         """Get the dimensions of a peer kernel.
 
         Args:
@@ -116,7 +115,7 @@ class PeerInfo:
         """
         return self._peer_dims[peer_kernel]
 
-    def get_peer_locations(self, peer_instance: Reference) -> List[str]:
+    def get_peer_locations(self, peer_instance: Reference) -> list[str]:
         """Get the locations of a peer instance.
 
         There may be multiple, if the peer supports more than one
@@ -127,8 +126,8 @@ class PeerInfo:
         """
         return self._peer_locations[peer_instance]
 
-    def get_peer_endpoints(self, port: Identifier, slot: List[int]
-                           ) -> List[Endpoint]:
+    def get_peer_endpoints(self, port: Identifier, slot: list[int]
+                           ) -> list[Endpoint]:
         """Determine the peer endpoints for the given port and slot.
 
         Args:

--- a/libmuscle/python/libmuscle/planner/planner.py
+++ b/libmuscle/python/libmuscle/planner/planner.py
@@ -1,6 +1,6 @@
+from collections.abc import Iterable, Mapping
 from copy import copy
 import logging
-from typing import Dict, Iterable, List, Mapping, Set, Tuple
 
 from ymmsl.v0_2 import (
         Component, Configuration, Model, MPICoresResReq,
@@ -13,7 +13,7 @@ from libmuscle.util import instance_indices
 _logger = logging.getLogger(__name__)
 
 
-_PredSuccType = Dict[Component, Set[Tuple[Component, int]]]
+_PredSuccType = dict[Component, set[tuple[Component, int]]]
 
 
 class ModelGraph:
@@ -93,7 +93,7 @@ class ModelGraph:
         """
         return self._model.components[name]
 
-    def successors(self, component: Component) -> Set[Tuple[Component, int]]:
+    def successors(self, component: Component) -> set[tuple[Component, int]]:
         """Return the successors of the given component.
 
         Args:
@@ -109,7 +109,7 @@ class ModelGraph:
         """
         return self._successors[component]
 
-    def predecessors(self, component: Component) -> Set[Tuple[Component, int]]:
+    def predecessors(self, component: Component) -> set[tuple[Component, int]]:
         """Return the predecessors of the given component.
 
         Args:
@@ -125,7 +125,7 @@ class ModelGraph:
         """
         return self._predecessors[component]
 
-    def macros(self, component: Component) -> Set[Tuple[Component, int]]:
+    def macros(self, component: Component) -> set[tuple[Component, int]]:
         """Return the macros of the given component.
 
         These are components that are both before the component's
@@ -140,7 +140,7 @@ class ModelGraph:
         """
         return self._superpreds[component] & self._supersuccs[component]
 
-    def micros(self, component: Component) -> Set[Tuple[Component, int]]:
+    def micros(self, component: Component) -> set[tuple[Component, int]]:
         """Return the micros of the given component.
 
         These are components that are in between the component's
@@ -156,8 +156,8 @@ class ModelGraph:
         return self._subsuccs[component] & self._subpreds[component]
 
     def _propagate(
-            self, from_set: Set[Tuple[Component, int]],
-            to_set: Set[Tuple[Component, int]], shared_dims: int
+            self, from_set: set[tuple[Component, int]],
+            to_set: set[tuple[Component, int]], shared_dims: int
             ) -> None:
         """Propagates from_set into to_set.
 
@@ -201,10 +201,10 @@ class ModelGraph:
                 for c in self._model.components.values()}
 
         todo = set(self._model.components.values())
-        started: Set[Component] = set()
-        doing: Set[Component] = set()
-        finished: Set[Component] = set()
-        done: Set[Component] = set()
+        started: set[Component] = set()
+        doing: set[Component] = set()
+        finished: set[Component] = set()
+        done: set[Component] = set()
         while todo or doing:
             started.clear()
             for component in todo:
@@ -299,10 +299,10 @@ class ModelGraph:
                 for c in self._model.components.values()}
 
         todo = set(self._model.components.values())
-        started: Set[Component] = set()
-        doing: Set[Component] = set()
-        finished: Set[Component] = set()
-        done: Set[Component] = set()
+        started: set[Component] = set()
+        doing: set[Component] = set()
+        finished: set[Component] = set()
+        done: set[Component] = set()
         while todo or doing:
             started.clear()
             for component in todo:
@@ -432,7 +432,7 @@ class ResourceAssignment:
         by_rank: List of OnNodeResources objects containing assigned resources,
         indexed by rank.
     """
-    def __init__(self, by_rank: List[OnNodeResources]) -> None:
+    def __init__(self, by_rank: list[OnNodeResources]) -> None:
         """Create a ResourceAssignment.
 
         Args:
@@ -481,13 +481,13 @@ class Planner:
                     for the planner to use.
         """
         self._all_resources = all_resources
-        self._allocations: Dict[Reference, Resources] = {}
-        self._oversubscribed: Dict[Reference, Resources] = {}
+        self._allocations: dict[Reference, Resources] = {}
+        self._oversubscribed: dict[Reference, Resources] = {}
         self._next_virtual_node = 1
 
     def allocate_all(
             self, configuration: Configuration, virtual: bool = False
-            ) -> Dict[Reference, ResourceAssignment]:
+            ) -> dict[Reference, ResourceAssignment]:
         """Allocates resources for the given components.
 
         Allocation can occur either on a fixed set of available
@@ -510,7 +510,7 @@ class Planner:
         Returns:
             Assigned resources for each instance required by the model.
         """
-        result: Dict[Reference, ResourceAssignment] = {}
+        result: dict[Reference, ResourceAssignment] = {}
 
         _logger.debug(f'Planning on resources {self._all_resources}')
 
@@ -532,7 +532,7 @@ class Planner:
         # Allocate
         unallocated_instances = [
                 i for c in model.components() for i in c.instances()]
-        leftover_instances: List[Reference] = []
+        leftover_instances: list[Reference] = []
         while unallocated_instances:
             leftover_instances.clear()
 
@@ -575,9 +575,9 @@ class Planner:
         return result
 
     def _sort_instances(
-            self, model_name: Reference, instances: List[Reference],
+            self, model_name: Reference, instances: list[Reference],
             requirements: Mapping[Reference, ResourceRequirements]
-            ) -> List[Reference]:
+            ) -> list[Reference]:
         """Return to be allocated components in optimal order.
 
         This is a heuristic, it's not actually optimal but it should
@@ -607,8 +607,8 @@ class Planner:
         return sorted_threaded_instances + sorted_mpi_instances
 
     def _conflicting_names(
-            self, model: ModelGraph, exclusive: Set[Reference],
-            component: Component, instance: Reference) -> Set[Reference]:
+            self, model: ModelGraph, exclusive: set[Reference],
+            component: Component, instance: Reference) -> set[Reference]:
         """Find conflicting components.
 
         This returns the names of instances that cannot share resources
@@ -617,7 +617,7 @@ class Planner:
 
         Args:
             model: Model to search
-            exclusive: List of instances that cannot share resources
+            exclusive: list of instances that cannot share resources
             component: Component to find conflicts for
             instance: Instance (of component) to find conflicts for
         """
@@ -628,7 +628,7 @@ class Planner:
             return idx1[:dims] == idx2[:dims]
 
         def matching_instances(
-                others: Set[Tuple[Component, int]]) -> Set[Reference]:
+                others: set[tuple[Component, int]]) -> set[Reference]:
             return {
                     i for c, d in others for i in c.instances()
                     if indices_match(i, instance, d)}
@@ -655,7 +655,7 @@ class Planner:
         """Adds an extra virtual node to the available resources."""
         taken = True
         while taken:
-            new_node_name = 'node{:06d}'.format(self._next_virtual_node)
+            new_node_name = f'node{self._next_virtual_node:06d}'
             taken = new_node_name in self._all_resources.nodes()
             self._next_virtual_node += 1
 
@@ -682,7 +682,7 @@ class Planner:
     def _assign_instance(
             self, instance: Reference, component: Component,
             requirements: ResourceRequirements,
-            simultaneous_instances: Set[Reference], virtual: bool
+            simultaneous_instances: set[Reference], virtual: bool
             ) -> ResourceAssignment:
         """Allocates resources for the given instance.
 
@@ -791,7 +791,7 @@ class Planner:
                 f'Instance {instance} requires more resources than are available in'
                 ' total. Oversubscribing this instance.')
 
-        res_by_rank: List[OnNodeResources] = list()
+        res_by_rank: list[OnNodeResources] = list()
 
         if isinstance(requirements, ThreadedResReq):
             res_by_rank.append(copy(next(iter(self._all_resources))))

--- a/libmuscle/python/libmuscle/planner/planner.py
+++ b/libmuscle/python/libmuscle/planner/planner.py
@@ -721,7 +721,7 @@ class Planner:
                     raise RuntimeError(
                             'Multiple threads per MPI process is not supported'
                             ' yet. Please make an issue on GitHub.')
-                for proc in range(requirements.mpi_processes):
+                for _ in range(requirements.mpi_processes):
                     block = self._assign_thread_block(
                                 free_resources, requirements.threads_per_mpi_process)
                     assignment.by_rank.append(block)
@@ -803,7 +803,7 @@ class Planner:
                         ' make an issue on GitHub.')
 
             free_resources = copy(self._all_resources)
-            for proc in range(requirements.mpi_processes):
+            for _ in range(requirements.mpi_processes):
                 if free_resources.total_cores() < requirements.threads_per_mpi_process:
                     free_resources = copy(self._all_resources)
 

--- a/libmuscle/python/libmuscle/planner/resources.py
+++ b/libmuscle/python/libmuscle/planner/resources.py
@@ -186,8 +186,9 @@ psutil      physical        counted by psutil.cpu_count(logical=False)
 ```
 
 """
+from collections.abc import Iterable, Iterator
 from copy import copy, deepcopy
-from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple
+from typing import Optional
 
 
 class Core:
@@ -224,7 +225,7 @@ class Core:
         cid: ID of this core, to be used to refer to it
         hwthreads: Ids of hwthreads (logical CPUs) belonging to this core
     """
-    def __init__(self, cid: int, hwthreads: Set[int]) -> None:
+    def __init__(self, cid: int, hwthreads: set[int]) -> None:
         """Create a Core"""
         self.cid = cid
         self.hwthreads = copy(hwthreads)
@@ -353,7 +354,7 @@ class CoreSet:
         return self
 
     def __str__(self) -> str:
-        def collapse_ranges(ids: List[int]) -> str:
+        def collapse_ranges(ids: list[int]) -> str:
             if len(ids) == 0:
                 return ''
 
@@ -372,8 +373,8 @@ class CoreSet:
                 i += 1
             return ','.join(result)
 
-        cores = sorted((c.cid for c in self._cores.values()))
-        hwthreads = sorted((t for c in self._cores.values() for t in c.hwthreads))
+        cores = sorted(c.cid for c in self._cores.values())
+        hwthreads = sorted(t for c in self._cores.values() for t in c.hwthreads)
 
         return f'{collapse_ranges(cores)}({collapse_ranges(hwthreads)})'
 
@@ -498,7 +499,7 @@ class Resources:
             nodes: OnNodeResourcess to be designated by this object.
         """
         if nodes is None:
-            self._nodes: Dict[str, OnNodeResources] = {}
+            self._nodes: dict[str, OnNodeResources] = {}
         else:
             self._nodes = {n.node_name: n for n in nodes}
 
@@ -529,7 +530,7 @@ class Resources:
 
     def __copy__(self) -> 'Resources':
         """Copy the object."""
-        return Resources((copy(n) for n in self._nodes.values()))
+        return Resources(copy(n) for n in self._nodes.values())
 
     def __ior__(self, other: object) -> 'Resources':
         """Add the resources in the argument to this object."""
@@ -574,15 +575,15 @@ class Resources:
 
     def total_cores(self) -> int:
         """Return the total number of cores (not hwthreads) designated."""
-        return sum((len(n.cpu_cores) for n in self._nodes.values()))
+        return sum(len(n.cpu_cores) for n in self._nodes.values())
 
-    def cores(self) -> Iterable[Tuple[str, int]]:
+    def cores(self) -> Iterable[tuple[str, int]]:
         """Return this resources as a list of node, core."""
         return (
                 (node.node_name, core.cid)
                 for node in self._nodes.values() for core in node.cpu_cores)
 
-    def hwthreads(self) -> Iterable[Tuple[str, int]]:
+    def hwthreads(self) -> Iterable[tuple[str, int]]:
         """Return this resources as a list of node, hwthread."""
         return (
                 (node.node_name, hwthread)

--- a/libmuscle/python/libmuscle/planner/test/test_planner.py
+++ b/libmuscle/python/libmuscle/planner/test/test_planner.py
@@ -1,5 +1,4 @@
 import pytest
-from typing import Dict, List
 
 from ymmsl.v0_2 import (
         Component, Conduit, Configuration, Model, MPICoresResReq, Ports, Program,
@@ -52,7 +51,7 @@ def model(init: Component, macro: Component, micro: Component) -> Model:
 
 
 @pytest.fixture
-def programs() -> List[Program]:
+def programs() -> list[Program]:
     return [
             Program(Ref('init'), script='init'),
             Program(Ref('macro'), script='macro'),
@@ -60,7 +59,7 @@ def programs() -> List[Program]:
 
 
 @pytest.fixture
-def requirements() -> Dict[Reference, ResourceRequirements]:
+def requirements() -> dict[Reference, ResourceRequirements]:
     res_list = [
             ThreadedResReq(Ref('test_model.init'), 4),
             ThreadedResReq(Ref('test_model.macro'), 4),
@@ -70,8 +69,8 @@ def requirements() -> Dict[Reference, ResourceRequirements]:
 
 @pytest.fixture
 def configuration(
-        model: Model, programs: List[Program],
-        requirements: Dict[Reference, ResourceRequirements]) -> Configuration:
+        model: Model, programs: list[Program],
+        requirements: dict[Reference, ResourceRequirements]) -> Configuration:
     return Configuration('config', [], [model], None, None, programs, requirements)
 
 
@@ -215,7 +214,7 @@ def test_oversubscribe(
 def test_oversubscribe_single_instance_threaded() -> None:
     model = Model('single_instance', None, '', None, [Component('x', Ports(), '', 'x')])
     programs = [Program(Ref('x'), script='x')]
-    reqs: Dict[Reference, ResourceRequirements] = {
+    reqs: dict[Reference, ResourceRequirements] = {
             Ref('single_instance.x'): ThreadedResReq(Ref('single_instance.x'), 24)}
     config = Configuration('config', [], [model], None, None, programs, reqs)
 
@@ -230,7 +229,7 @@ def test_oversubscribe_single_instance_threaded() -> None:
 def test_oversubscribe_single_instance_mpi() -> None:
     model = Model('single_instance', None, '', None, [Component('x', Ports(), '', 'x')])
     programs = [Program(Ref('x'), script='x')]
-    reqs: Dict[Reference, ResourceRequirements] = {
+    reqs: dict[Reference, ResourceRequirements] = {
             Ref('single_instance.x'): MPICoresResReq(Ref('single_instance.x'), 24)}
     config = Configuration('config', [], [model], None, None, programs, reqs)
 
@@ -248,7 +247,7 @@ def test_virtual_allocation() -> None:
     model = Model(
             'ensemble', None, '', None, [Component('x', Ports(), '', 'x', False, 9)])
     programs = [Program(Ref('x'), script='x')]
-    reqs: Dict[Ref, ResourceRequirements] = {
+    reqs: dict[Ref, ResourceRequirements] = {
             Ref('ensemble.x'): MPICoresResReq(Ref('ensemble.x'), 13)}
     config = Configuration('config', [], [model], None, None, programs, reqs)
 
@@ -268,7 +267,7 @@ def test_impossible_virtual_allocation() -> None:
     model = Model(
             'ensemble', None, '', None, [Component('x', Ports(), '', 'x', False, 9)])
     program = [Program(Ref('x'), script='x')]
-    reqs: Dict[Ref, ResourceRequirements] = {
+    reqs: dict[Ref, ResourceRequirements] = {
             Ref('ensemble.x'): ThreadedResReq(Ref('ensemble.x'), 13)}
     config = Configuration('config', [], [model], None, None, program, reqs)
 

--- a/libmuscle/python/libmuscle/planner/test/test_planner_scenarios.py
+++ b/libmuscle/python/libmuscle/planner/test/test_planner_scenarios.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from typing import Dict, Tuple
 
 import pytest
 from ymmsl.v0_2 import (
@@ -12,10 +11,10 @@ from libmuscle.planner.resources import Resources
 from libmuscle.test.conftest import core as c, on_node_resources as onr, resources
 
 
-_ResReqs = Dict[Reference, ResourceRequirements]
+_ResReqs = dict[Reference, ResourceRequirements]
 
 
-_Scenario = Tuple[Configuration, Resources]
+_Scenario = tuple[Configuration, Resources]
 
 
 s0_model = Model(

--- a/libmuscle/python/libmuscle/port.py
+++ b/libmuscle/python/libmuscle/port.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypeVar
+from typing import Optional, TypeVar
 
 from ymmsl.v0_2 import Identifier, Operator
 import ymmsl
@@ -7,7 +7,7 @@ import ymmsl
 _T = TypeVar("_T")
 
 
-def _extend_list_to_size(lst: List[_T], size: int, padding: _T) -> None:
+def _extend_list_to_size(lst: list[_T], size: int, padding: _T) -> None:
     """When lst is smaller than size, extend to size using padding as values
     """
     num_extend = size - len(lst)
@@ -32,7 +32,7 @@ class Port(ymmsl.v0_2.Port):
     """
 
     def __init__(self, name: str, operator: Operator, is_vector: bool,
-                 is_connected: bool, our_ndims: int, peer_dims: List[int]
+                 is_connected: bool, our_ndims: int, peer_dims: list[int]
                  ) -> None:
         """Create a Port.
 
@@ -54,33 +54,27 @@ class Port(ymmsl.v0_2.Port):
             elif our_ndims + 1 == len(peer_dims):
                 self._length = peer_dims[-1]
             elif our_ndims > len(peer_dims):
-                raise RuntimeError(('Vector port "{}" is connected to an'
-                                    ' instance set with fewer dimensions.'
-                                    ' It should be connected to a scalar'
-                                    ' port on a set with one more dimension,'
-                                    ' or to a vector port on a set with the'
-                                    ' same number of dimensions.').format(
-                                        name))
+                raise RuntimeError(
+                        f'Vector port "{name}" is connected to an instance set with'
+                        ' fewer dimensions. It should be connected to a scalar port on'
+                        ' a set with one more dimension, or to a vector port on a set'
+                        ' with the same number of dimensions.')
             else:
-                raise RuntimeError(('Port "{}" is connected to an instance set'
-                                    ' with more than one dimension more than'
-                                    ' its own, which is not possible.').format(
-                                        name))
+                raise RuntimeError(
+                        f'Port "{name}" is connected to an instance set with more than'
+                        ' one dimension more than its own, which is not possible.')
             self._is_open = [True] * self._length
         else:
             if our_ndims < len(peer_dims):
-                raise RuntimeError(('Scalar port "{}" is connected to an'
-                                    ' instance set with more dimensions.'
-                                    ' It should be connected to a scalar'
-                                    ' port on an instance set with the same'
-                                    ' dimensions, or to a vector port on an'
-                                    ' instance set with one less dimension.'
-                                    ).format(name))
+                raise RuntimeError(
+                        f'Scalar port "{name}" is connected to an instance set with'
+                        ' more dimensions. It should be connected to a scalar port on'
+                        ' an instance set with the same dimensions, or to a vector port'
+                        ' on an instance set with one less dimension.')
             elif our_ndims > len(peer_dims) + 1:
-                raise RuntimeError(('Scalar port "{}" is connected to an'
-                                    ' instance set with at least two fewer'
-                                    ' dimensions, which is not possible.'
-                                    ).format(name))
+                raise RuntimeError(
+                        f'Scalar port "{name}" is connected to an instance set with at'
+                        ' least two fewer dimensions, which is not possible.')
             self._length = None
             self._is_open = [True]
 
@@ -127,8 +121,7 @@ class Port(ymmsl.v0_2.Port):
             RuntimeError: If this port is a scalar port.
         """
         if self._length is None:
-            raise RuntimeError(('Tried to get length of scalar port {}'
-                                ).format(self.name))
+            raise RuntimeError(f'Tried to get length of scalar port {self.name}')
         return self._length
 
     def set_length(self, length: int) -> None:
@@ -143,8 +136,8 @@ class Port(ymmsl.v0_2.Port):
             RuntimeError: If the port is not resizable.
         """
         if not self._is_resizable:
-            raise RuntimeError(('Tried to resize port {}, but it is not'
-                                ' resizable.'.format(self.name)))
+            raise RuntimeError(
+                    f'Tried to resize port {self.name}, but it is not resizable.')
         if length != self._length:
             self._length = length
             self._is_open = [True] * self._length
@@ -162,7 +155,7 @@ class Port(ymmsl.v0_2.Port):
         else:
             self._is_open = [False]
 
-    def restore_message_counts(self, num_messages: List[int]) -> None:
+    def restore_message_counts(self, num_messages: list[int]) -> None:
         """Restore message counts from a snapshot
         """
         self._num_messages = num_messages
@@ -170,7 +163,7 @@ class Port(ymmsl.v0_2.Port):
         _extend_list_to_size(self._num_messages, self._length or 1, 0)
         _extend_list_to_size(self._is_resuming, self._length or 1, False)
 
-    def get_message_counts(self) -> List[int]:
+    def get_message_counts(self) -> list[int]:
         """Get a list of message counts for all slots in this port
         """
         return self._num_messages.copy()

--- a/libmuscle/python/libmuscle/port_manager.py
+++ b/libmuscle/python/libmuscle/port_manager.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from ymmsl.v0_2 import Identifier, Operator
 
@@ -9,7 +9,7 @@ from libmuscle.port import Port
 class PortManager:
     """Manages sending and receiving ports of the current instance."""
     def __init__(
-            self, index: List[int], declared_ports: Optional[Dict[Operator, List[str]]]
+            self, index: list[int], declared_ports: Optional[dict[Operator, list[str]]]
             ) -> None:
         """Create a PortManager.
 
@@ -19,7 +19,7 @@ class PortManager:
                     user when creating the Instance object.
         """
         self._index = index
-        self._ports: Dict[str, Port] = {}
+        self._ports: dict[str, Port] = {}
         self._declared_ports = declared_ports
 
     def connect_ports(self, peer_info: PeerInfo) -> None:
@@ -53,7 +53,7 @@ class PortManager:
         """Returns whether muscle_settings_in is connected."""
         return self._muscle_settings_in.is_connected()
 
-    def list_ports(self) -> Dict[Operator, List[str]]:
+    def list_ports(self) -> dict[Operator, list[str]]:
         """Returns a description of the ports this PortManager has.
 
         Returns:
@@ -61,7 +61,7 @@ class PortManager:
             port names. Operators with no associated ports are not
             included.
         """
-        result: Dict[Operator, List[str]] = {}
+        result: dict[Operator, list[str]] = {}
         for port_name, port in self._ports.items():
             if port.operator not in result:
                 result[port.operator] = list()
@@ -91,7 +91,7 @@ class PortManager:
         return self._ports[port_name]
 
     def restore_message_counts(
-            self, port_message_counts: Dict[str, List[int]]) -> None:
+            self, port_message_counts: dict[str, list[int]]) -> None:
         """Restore message counts on all ports.
 
         Args:
@@ -108,7 +108,7 @@ class PortManager:
                                    ' Have your port definitions changed since'
                                    ' the snapshot was taken?')
 
-    def get_message_counts(self) -> Dict[str, List[int]]:
+    def get_message_counts(self) -> dict[str, list[int]]:
         """Get message counts for all ports on the communicator.
 
         Returns:
@@ -137,7 +137,7 @@ class PortManager:
         return Port(
                 str(msi), Operator.F_INIT, False, False, len(self._index), [])
 
-    def _ports_from_declared(self, peer_info: PeerInfo) -> Dict[str, Port]:
+    def _ports_from_declared(self, peer_info: PeerInfo) -> dict[str, Port]:
         """Derives port definitions from supplied declaration.
 
         Args:
@@ -156,7 +156,7 @@ class PortManager:
                 if port_name.startswith('muscle_'):
                     raise RuntimeError(
                             'Port names starting with "muscle_" are reserved for'
-                            ' MUSCLE, please rename port "{}"'.format(port_name))
+                            f' MUSCLE, please rename port "{port_name}"')
                 port_id = Identifier(port_name)
                 is_connected = peer_info.is_connected(port_id)
                 peer_dims = peer_info.check_peer_dimensions(port_id)
@@ -165,7 +165,7 @@ class PortManager:
                         len(self._index), peer_dims)
         return ports
 
-    def _ports_from_conduits(self, peer_info: PeerInfo) -> Dict[str, Port]:
+    def _ports_from_conduits(self, peer_info: PeerInfo) -> dict[str, Port]:
         """Derives port definitions from the yMMSL configuration.
 
         Args:
@@ -183,7 +183,7 @@ class PortManager:
                 len(self._index), peer_dims)
         return ports
 
-    def _split_port_desc(self, port_desc: str) -> Tuple[str, bool]:
+    def _split_port_desc(self, port_desc: str) -> tuple[str, bool]:
         """Split a port description into its name and dimensionality.
 
         Expects a port description of the form port_name or
@@ -199,8 +199,8 @@ class PortManager:
             port_desc = port_desc[:-2]
 
         if port_desc.endswith('[]'):
-            raise ValueError(('Port description "{}" is invalid: ports can'
-                              ' have at most one dimension.').format(
-                                  port_desc))
+            raise ValueError(
+                    f'Port description "{port_desc}" is invalid: ports can have at most'
+                    ' one dimension.')
 
         return port_desc, is_vector

--- a/libmuscle/python/libmuscle/post_office.py
+++ b/libmuscle/python/libmuscle/post_office.py
@@ -1,6 +1,5 @@
 from threading import Lock
 import time
-from typing import Dict
 from typing_extensions import Buffer
 
 from ymmsl.v0_2 import Reference
@@ -17,7 +16,7 @@ class PostOffice:
     def __init__(self) -> None:
         """Create a PostOffice.
         """
-        self._outboxes: Dict[Reference, Outbox] = {}
+        self._outboxes: dict[Reference, Outbox] = {}
 
         self._outbox_lock = Lock()
 

--- a/libmuscle/python/libmuscle/profiler.py
+++ b/libmuscle/python/libmuscle/profiler.py
@@ -1,7 +1,6 @@
 from random import uniform
 from threading import Condition, Lock, Thread
 import time
-from typing import List
 
 from libmuscle.mmp_client import MMPClient
 from libmuscle.profiling import ProfileEvent, ProfileTimestamp
@@ -24,7 +23,7 @@ class Profiler:
 
         self._manager = manager
         self._enabled = True
-        self._events: List[ProfileEvent] = []
+        self._events: list[ProfileEvent] = []
         self._thread = Thread(target=self._communicate, daemon=True)
         self._done_cv = Condition(self._mutex)
         self._done = False

--- a/libmuscle/python/libmuscle/pytest/__init__.py
+++ b/libmuscle/python/libmuscle/pytest/__init__.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterator
 import pytest
-from typing import Iterator
 from pathlib import Path
 
 from libmuscle.pytest.implementation_tester import ImplementationTester

--- a/libmuscle/python/libmuscle/pytest/muscle_tester.py
+++ b/libmuscle/python/libmuscle/pytest/muscle_tester.py
@@ -1,10 +1,11 @@
+from collections.abc import Generator
 import os
 from contextlib import contextmanager
 from types import TracebackType
 from pathlib import Path
 import multiprocessing as mp
 from unittest.mock import patch
-from typing import Generator, Optional, Tuple, Union
+from typing import Optional, Union
 from multiprocessing.connection import Connection
 from contextlib import ExitStack
 
@@ -207,7 +208,7 @@ class MuscleTester:
         self.implementation_tester = None
 
 
-def start_mmp_server(control_pipe: Tuple[Connection, Connection],
+def start_mmp_server(control_pipe: tuple[Connection, Connection],
                      ymmsl_config: Configuration, run_dir: RunDir,
                      env: dict[str, str], start_instances: bool) -> None:
     if start_instances:

--- a/libmuscle/python/libmuscle/runner.py
+++ b/libmuscle/python/libmuscle/runner.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import sys
 from time import sleep
 import traceback
-from typing import Callable, Dict, List, Set, Tuple, cast
+from typing import Callable, cast
 from warnings import catch_warnings, filterwarnings
 
 from ymmsl import convert_to, Document
@@ -30,7 +30,7 @@ __all__ = ['run_simulation']
 _logger = logging.getLogger(__name__)
 
 
-Pipe = Tuple[mpc.Connection, mpc.Connection]
+Pipe = tuple[mpc.Connection, mpc.Connection]
 
 
 class MMPServerController:
@@ -103,8 +103,8 @@ def implementation_process(
         instance_id: str, manager_location: str,
         implementation: Callable) -> None:
     prefix_tag = '--muscle-prefix='
-    name_prefix = str()
-    index_prefix: List[int] = []
+    name_prefix = ''
+    index_prefix: list[int] = []
 
     instance = Reference(instance_id)
 
@@ -119,10 +119,10 @@ def implementation_process(
             index = index_prefix + index
 
             # replace it with the combined one
-            sys.argv[i] = '--muscle-instance={}'.format(str(name + index))
+            sys.argv[i] = f'--muscle-instance={name + index}'
             break
     else:
-        sys.argv.append('--muscle-instance={}'.format(instance_id))
+        sys.argv.append(f'--muscle-instance={instance_id}')
 
     for arg in sys.argv:
         if arg.startswith('--muscle-manager='):
@@ -147,7 +147,7 @@ def implementation_process(
         exit(1)
 
 
-def _parse_prefix(prefix: str) -> Tuple[str, List[int]]:
+def _parse_prefix(prefix: str) -> tuple[str, list[int]]:
     """Parse a --muscle-prefix argument.
 
     This is like a Reference, but not quite, because the
@@ -163,22 +163,22 @@ def _parse_prefix(prefix: str) -> Tuple[str, List[int]]:
     Returns:
         The identifier sequence and the list of ints.
     """
-    def parse_identifier(prefix: str, i: int) -> Tuple[str, int]:
-        name = str()
+    def parse_identifier(prefix: str, i: int) -> tuple[str, int]:
+        name = ''
         while i < len(prefix) and prefix[i] not in '[.':
             name += prefix[i]
             i += 1
         return name, i
 
-    def parse_number(prefix: str, i: int) -> Tuple[int, int]:
-        number = str()
+    def parse_number(prefix: str, i: int) -> tuple[int, int]:
+        number = ''
         while i < len(prefix) and prefix[i] in '0123456789':
             number += prefix[i]
             i += 1
         return int(number), i
 
-    name = str()
-    index: List[int] = []
+    name = ''
+    index: list[int] = []
     i = 0
 
     if i == len(prefix):
@@ -201,14 +201,14 @@ def _parse_prefix(prefix: str) -> Tuple[str, List[int]]:
         i += 1
 
     if i < len(prefix):
-        raise ValueError(('Found invalid extra character {} in'
-                          ' --muscle-prefix.').format(prefix[i]))
+        raise ValueError(
+                f'Found invalid extra character {prefix[i]} in --muscle-prefix.')
 
     return name, index
 
 
-def _split_reference(ref: Reference) -> Tuple[Reference, List[int]]:
-    index: List[int] = []
+def _split_reference(ref: Reference) -> tuple[Reference, list[int]]:
+    index: list[int] = []
     i = 0
     while i < len(ref) and isinstance(ref[i], Identifier):
         i += 1
@@ -222,7 +222,7 @@ def _split_reference(ref: Reference) -> Tuple[Reference, List[int]]:
 
 
 def run_instances(
-        instances: Dict[str, Callable], manager_location: str) -> None:
+        instances: dict[str, Callable], manager_location: str) -> None:
     """Runs the given instances and waits for them to finish.
 
     The instances are described in a dictionary with their instance
@@ -246,8 +246,8 @@ def run_instances(
         instance_processes.append(process)
 
     # wait for them to finish or one to fail
-    failed_processes: List[mp.Process] = list()
-    done_processes: Set[mp.Process] = set()
+    failed_processes: list[mp.Process] = list()
+    done_processes: set[mp.Process] = set()
     while len(done_processes) < len(instance_processes) and not failed_processes:
         sleep(0.5)
         for instance_process in instance_processes:
@@ -270,8 +270,8 @@ def run_instances(
         log_files = [Path(f'muscle3.{name}.log') for name in failed_names]
         outputs = [last_lines(log_file, 20) for log_file in log_files]
         msg = (
-                'Instance(s) {} failed to shut down cleanly. Here is the final'
-                ' bit of the output:').format(', '.join(failed_names))
+                f'Instance(s) {failed_names} failed to shut down cleanly. Here is the'
+                ' final bit of the output:')
         for name, output in zip(failed_names, outputs):
             msg += '\n ---------- ' + name + ' ----------\n'
             msg += output + '\n'
@@ -281,7 +281,7 @@ def run_instances(
 
 
 def run_simulation(
-        configuration: Document, implementations: Dict[str, Callable]
+        configuration: Document, implementations: dict[str, Callable]
         ) -> None:
     """Runs a simulation with the given configuration and instances.
 
@@ -317,9 +317,9 @@ def run_simulation(
     for ce in model.components.values():
         impl_name = str(ce.implementation)
         if impl_name not in implementations:
-            raise ValueError(('The model specifies an implementation named'
-                              ' "{}" but the given set of implementations does'
-                              ' not include it.').format(impl_name))
+            raise ValueError(
+                    f'The model specifies an implementation named "{impl_name}" but the'
+                    ' given set of implementations does not include it.')
 
         impl_fn = implementations[impl_name]
         if not ce.multiplicity:

--- a/libmuscle/python/libmuscle/settings_manager.py
+++ b/libmuscle/python/libmuscle/settings_manager.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set
+from typing import Optional
 
 from ymmsl.v0_2 import SettingValue, Reference, Settings
 
@@ -46,7 +46,7 @@ def has_setting_type(value: SettingValue, typ: str) -> bool:
                 # a full type check, so we just need to discriminate.
                 return True
         return False
-    raise ValueError('Invalid setting type specified: {}'.format(typ))
+    raise ValueError(f'Invalid setting type specified: {typ}')
 
 
 class SettingsManager:
@@ -70,7 +70,7 @@ class SettingsManager:
         self.base = Settings()
         self.overlay = Settings()
 
-    def list_settings(self, instance_id: Reference) -> List[str]:
+    def list_settings(self, instance_id: Reference) -> list[str]:
         """Returns the names of all the settings.
 
         This returns the names of all the settings, as the model would
@@ -95,8 +95,8 @@ class SettingsManager:
         Return:
             A list of setting names.
         """
-        def extract_names(settings: Settings) -> Set[str]:
-            result: Set[str] = set()
+        def extract_names(settings: Settings) -> set[str]:
+            result: set[str] = set()
             for name in settings:
                 if len(name) == 1:
                     result.add(str(name))
@@ -143,11 +143,11 @@ class SettingsManager:
                 value = self.base[name]
                 break
         else:
-            raise KeyError((f'Value for setting "{setting_name}" was not set.'))
+            raise KeyError(f'Value for setting "{setting_name}" was not set.')
 
         if typ is not None:
             if not has_setting_type(value, typ):
-                raise TypeError('Value for setting "{}" is of type {},'
-                                ' where {} was expected.'.format(
-                                    name, type(value), typ))
+                raise TypeError(
+                        f'Value for setting "{name}" is of type {type(value)}, where'
+                        f' {typ} was expected.')
         return value

--- a/libmuscle/python/libmuscle/snapshot.py
+++ b/libmuscle/python/libmuscle/snapshot.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Optional, cast
+from typing import Optional, cast
 from typing_extensions import Buffer
 
 import msgpack
@@ -18,9 +18,9 @@ class Snapshot(ABC):
     SNAPSHOT_VERSION_BYTE = b'\0'
 
     def __init__(self,
-                 triggers: List[str],
+                 triggers: list[str],
                  wallclock_time: float,
-                 port_message_counts: Dict[str, List[int]],
+                 port_message_counts: dict[str, list[int]],
                  is_final_snapshot: bool,
                  message: Optional['communicator.Message'],
                  settings_overlay: Settings) -> None:
@@ -110,11 +110,11 @@ class MsgPackSnapshot(Snapshot):
 class SnapshotMetadata:
     """Metadata of a snapshot for sending to the muscle_manager.
     """
-    triggers: List[str]
+    triggers: list[str]
     wallclock_time: float
     timestamp: float
     next_timestamp: Optional[float]
-    port_message_counts: Dict[str, List[int]]
+    port_message_counts: dict[str, list[int]]
     is_final_snapshot: bool
     # storing as str, because Path cannot be serialized by msgpack
     snapshot_filename: str

--- a/libmuscle/python/libmuscle/snapshot_manager.py
+++ b/libmuscle/python/libmuscle/snapshot_manager.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import cast, List, Optional
+from typing import cast, Optional
 
 from ymmsl.v0_2 import Reference, Operator, Settings
 
@@ -111,7 +111,7 @@ class SnapshotManager:
 
     def save_snapshot(
             self, msg: Optional[Message], final: bool,
-            triggers: List[str], wallclock_time: float,
+            triggers: list[str], wallclock_time: float,
             f_init_max_timestamp: Optional[float],
             settings_overlay: Settings
             ) -> float:

--- a/libmuscle/python/libmuscle/test/conftest.py
+++ b/libmuscle/python/libmuscle/test/conftest.py
@@ -1,6 +1,6 @@
 from copy import copy
 import pytest
-from typing import Dict, List, Set, Union
+from typing import Union
 from unittest.mock import patch
 
 from ymmsl.v0_2 import Operator, Reference, Settings
@@ -108,14 +108,14 @@ def core(hwthread_id: int) -> Core:
     return Core(hwthread_id, {hwthread_id})
 
 
-def on_node_resources(node_name: str, cores: Union[int, Set[int]]) -> OnNodeResources:
+def on_node_resources(node_name: str, cores: Union[int, set[int]]) -> OnNodeResources:
     """Helper that defines resources on a node from the name and a CPU core."""
     if isinstance(cores, int):
         cores = {cores}
     return OnNodeResources(node_name, CoreSet([Core(core, {core}) for core in cores]))
 
 
-def resources(node_resources: Dict[str, List[Core]]) -> Resources:
+def resources(node_resources: dict[str, list[Core]]) -> Resources:
     """Helper that defines a Resources from a dict."""
     return Resources([
         OnNodeResources(node_name, CoreSet(cores))

--- a/libmuscle/python/libmuscle/test/test_api_guard.py
+++ b/libmuscle/python/libmuscle/test/test_api_guard.py
@@ -1,4 +1,4 @@
-from typing import Callable, Set
+from typing import Callable
 
 import pytest
 
@@ -111,7 +111,7 @@ def run_until_before(guard: APIGuard, excluded: Callable) -> None:
         fun(guard, *args)
 
 
-def check_all_raise_except(guard: APIGuard, excluded: Set[Callable]) -> None:
+def check_all_raise_except(guard: APIGuard, excluded: set[Callable]) -> None:
     for fun, args in _api_guard_funs:
         if fun.__name__.startswith('verify_'):
             if fun not in excluded:

--- a/libmuscle/python/libmuscle/test/test_outbox.py
+++ b/libmuscle/python/libmuscle/test/test_outbox.py
@@ -18,9 +18,9 @@ def message():
     return MPPMessage(
             Ref('sender.out'), Ref('receiver.in'),
             None, 0.0, 1.0,
-            bytes(),
+            b'',
             0, 1.0,
-            'testing'.encode('utf-8'))
+            b'testing')
 
 
 def test_create_outbox():

--- a/libmuscle/python/libmuscle/test/test_port_manager.py
+++ b/libmuscle/python/libmuscle/test/test_port_manager.py
@@ -1,4 +1,3 @@
-from typing import List
 from libmuscle.peer_info import PeerInfo
 from libmuscle.port_manager import PortManager
 
@@ -8,7 +7,7 @@ import pytest
 
 
 @pytest.fixture
-def index() -> List[int]:
+def index() -> list[int]:
     return [13]
 
 
@@ -21,7 +20,7 @@ def port_manager(index) -> PortManager:
 
 
 @pytest.fixture
-def index2() -> List[int]:
+def index2() -> list[int]:
     return []
 
 

--- a/libmuscle/python/libmuscle/test/test_util.py
+++ b/libmuscle/python/libmuscle/test/test_util.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 from ymmsl.v0_2 import Reference
 
@@ -7,7 +5,7 @@ from libmuscle.util import instance_indices, instance_to_kernel
 
 
 @pytest.fixture
-def instances() -> List[Reference]:
+def instances() -> list[Reference]:
     return [
         Reference('test'),
         Reference('test.test'),
@@ -17,7 +15,7 @@ def instances() -> List[Reference]:
         Reference('test.test[1][2]')]
 
 
-def test_instance_to_kernel(instances: List[Reference]) -> None:
+def test_instance_to_kernel(instances: list[Reference]) -> None:
     assert instance_to_kernel(instances[0]) == 'test'
     assert instance_to_kernel(instances[1]) == 'test.test'
     assert instance_to_kernel(instances[2]) == 'test'
@@ -26,7 +24,7 @@ def test_instance_to_kernel(instances: List[Reference]) -> None:
     assert instance_to_kernel(instances[5]) == 'test.test'
 
 
-def test_instance_indices(instances: List[Reference]) -> None:
+def test_instance_indices(instances: list[Reference]) -> None:
     assert instance_indices(instances[0]) == []
     assert instance_indices(instances[1]) == []
     assert instance_indices(instances[2]) == [4]

--- a/libmuscle/python/libmuscle/timestamp.py
+++ b/libmuscle/python/libmuscle/timestamp.py
@@ -27,4 +27,5 @@ class Timestamp:
         """
         date_time = datetime.datetime.fromtimestamp(self.seconds)
         whole_part = date_time.strftime('%Y-%m-%d %H:%M:%S')
-        return '%s,%03d' % (whole_part, date_time.time().microsecond / 1000)
+        return '%s,%03d' % (    # noqa: UP031
+                whole_part, date_time.time().microsecond / 1000)

--- a/libmuscle/python/libmuscle/util.py
+++ b/libmuscle/python/libmuscle/util.py
@@ -1,8 +1,9 @@
+from collections.abc import Generator
 import itertools
 from pathlib import Path
 import sys
 import time
-from typing import Generator, List, Optional, cast
+from typing import Optional, cast
 
 from ymmsl.v0_2 import Reference
 
@@ -22,7 +23,7 @@ def instance_to_kernel(instance: Reference) -> Reference:
     return instance[:i]
 
 
-def instance_indices(instance: Reference) -> List[int]:
+def instance_indices(instance: Reference) -> list[int]:
     """Extracts the indices from an instance name.
 
     Args:
@@ -40,14 +41,14 @@ def instance_indices(instance: Reference) -> List[int]:
     return [cast(int, instance[j]) for j in range(i, len(instance))]
 
 
-def generate_indices(dims: List[int]) -> Generator[List[int], None, None]:
+def generate_indices(dims: list[int]) -> Generator[list[int], None, None]:
     """Generates all indices in a block of the given dimensions.
 
     Args:
         dims: The dimensions of the block.
 
     Yields:
-        Lists of indices, one for each point in the block.
+        lists of indices, one for each point in the block.
     """
     for index in itertools.product(*map(range, dims)):
         yield list(index)

--- a/muscle3/muscle3.py
+++ b/muscle3/muscle3.py
@@ -1,7 +1,7 @@
 import sys
 from collections import OrderedDict
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 import click
 import ymmsl
@@ -216,7 +216,7 @@ def _load_ymmsl_files(ymmsl_files: Sequence[str]) -> Configuration:
     """Loads and merges yMMSL files."""
     configuration = None
     for path in ymmsl_files:
-        with open(path, 'r') as f:
+        with open(path) as f:
             config = ymmsl.load_as(Configuration, f)
         if not configuration:
             configuration = config

--- a/muscle3/muscle_manager.py
+++ b/muscle3/muscle_manager.py
@@ -268,7 +268,7 @@ def create_run_dir(run_dir: Optional[str], model: v0_2.Model) -> RunDir:
         A RunDir object pointing to the created directory
     """
     if run_dir is None:
-        for i in range(10):
+        for _ in range(10):
             timestamp = datetime.now()
             timestr = timestamp.strftime('%Y%m%d_%H%M%S')
             run_dir_path = Path.cwd() / f'run_{model.name}_{timestr}'

--- a/muscle3/muscle_manager.py
+++ b/muscle3/muscle_manager.py
@@ -1,10 +1,11 @@
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 import sys
 import textwrap
 from time import sleep
 import traceback
-from typing import cast, List, Optional, Sequence
+from typing import cast, Optional
 from warnings import catch_warnings, filterwarnings
 
 import click
@@ -223,7 +224,7 @@ def load_configuration(paths: Sequence[str]) -> v0_2.Configuration:
         return config_v2
 
 
-def load_files(paths: Sequence[str]) -> List[Document]:
+def load_files(paths: Sequence[str]) -> list[Document]:
     """Load the given files and return a list of documents.
 
     This doesn't convert or merge anything, it just loads the files as they are. If an

--- a/muscle3/profiling.py
+++ b/muscle3/profiling.py
@@ -62,7 +62,7 @@ def plot_resources(performance_file: Path) -> None:
 
     palette = dict()
     next_color = 0
-    for core, data in stats.items():
+    for data in stats.values():
         for instance in data.keys():
             if instance not in palette:
                 palette[instance] = f'C{next_color}'

--- a/muscle3/profiling.py
+++ b/muscle3/profiling.py
@@ -1,6 +1,6 @@
 import sqlite3
 from pathlib import Path
-from typing import cast, List, Optional, Tuple
+from typing import cast, Optional
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -253,7 +253,7 @@ class TimelinePlot:
 
     def get_data(
             self, event_type: str, xmin: float, xmax: float
-            ) -> Tuple[List[int], List[float], List[float], Optional[float]]:
+            ) -> tuple[list[int], list[float], list[float], Optional[float]]:
         """Get events from the database
 
         Returns three lists with instance oid, start time and duration, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,11 +125,11 @@ select = [
   "E",
   # Pyflakes
   "F",
-  # TODO: enable these at some point?
   # pyupgrade
   "UP",
   # flake8-bugbear
-  #"B",
+  "B",
+  # TODO: enable these at some point?
   # flake8-simplify
   #"SIM",
   # isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ select = [
   "F",
   # TODO: enable these at some point?
   # pyupgrade
-  # "UP",
+  "UP",
   # flake8-bugbear
   #"B",
   # flake8-simplify

--- a/scripts/api_generator.py
+++ b/scripts/api_generator.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import abc
+from collections.abc import Sequence
 from copy import copy
 from textwrap import indent, dedent
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 
 error_codes = {
@@ -30,12 +31,9 @@ kinds = {
 def banner(comment_mark: str) -> str:
     """Generate a warning banner.
     """
-    result = ('{} This is generated code. If it\'s broken, then you'
-              ' should\n').format(comment_mark)
-    result += ('{} fix the generation script, not this file.\n'
-               ).format(comment_mark)
-    result += '\n\n'
-    return result
+    return (
+            f'{comment_mark} This is generated code. If it\'s broken, then you should\n'
+            f'{comment_mark} fix the generation script, not this file.\n\n\n')
 
 
 class Par(abc.ABC):
@@ -92,7 +90,7 @@ class Par(abc.ABC):
         self.class_name = ""
 
     def set_ns_prefix(
-            self, ns_for_name: Dict[str, Tuple[str, str]], c_ns: str, f_ns: str
+            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
             ) -> None:
         """Sets the namespace prefix correctly for all members.
 
@@ -121,25 +119,25 @@ class Par(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         """Format: [(C type, name_postfix), ...]
         """
         ...
 
     @abc.abstractmethod
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         """Format: [(C type, name_postfix), ...]
         """
         ...
 
     @abc.abstractmethod
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         """Format: [(F type, name_postfix), ...]
         """
         ...
 
     @abc.abstractmethod
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         """Format: (is_function, [(F type, name_postfix), ...])
 
         When is_function is True, the wrapper generates a Fortran function, otherwise a
@@ -147,11 +145,11 @@ class Par(abc.ABC):
         """
 
     @abc.abstractmethod
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         ...
 
     @abc.abstractmethod
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         ...
 
     @abc.abstractmethod
@@ -163,10 +161,10 @@ class Par(abc.ABC):
         ...
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    {} = {}\n'.format(result_name, call)
+        return f'    {result_name} = {call}\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return '    {} = {}\n'.format(return_name, result_name)
+        return f'    {return_name} = {result_name}\n'
 
     def fc_return_default(self) -> str:
         return 'return {};'
@@ -174,7 +172,7 @@ class Par(abc.ABC):
     def fc_convert_input(self) -> str:
         return ''
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return list()
 
     def f_chain_arg(self) -> str:
@@ -184,8 +182,8 @@ class Par(abc.ABC):
         return ''
 
     def _regular_type(self,
-                      short_type: Union[str, List[Union[str, Tuple[str, str]]]]
-                      ) -> List[Tuple[str, str]]:
+                      short_type: Union[str, list[Union[str, tuple[str, str]]]]
+                      ) -> list[tuple[str, str]]:
         """Converts brief type description to more regular format.
 
         This is a helper function for derived classes. Output is a list
@@ -206,14 +204,14 @@ class Par(abc.ABC):
         if isinstance(short_type, str):
             return [(short_type, '')]
         elif isinstance(short_type, list):
-            result = list()  # type: List[Tuple[str, str]]
+            result = list()  # type: list[tuple[str, str]]
             for st in short_type:
                 if isinstance(st, str):
                     result.append((st, ''))
                 else:
                     result.append(st)
             return result
-        raise ValueError('Invalid short type {}'.format(short_type))
+        raise ValueError(f'Invalid short type {short_type}')
 
 
 class Void(Par):
@@ -223,22 +221,22 @@ class Void(Par):
     def fc_cpp_type(self) -> str:
         return 'void'
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("Cannot use void as argument")
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('void')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("Cannot use void as argument")
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return []
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("Cannot use void as argument")
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, []
 
     def fc_cpp_arg(self) -> str:
@@ -251,7 +249,7 @@ class Void(Par):
         return '    return;\n'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n'.format(call)
+        return f'    call {call}\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ''
@@ -270,63 +268,62 @@ class String(Par):
     def fc_cpp_type(self) -> str:
         return 'std::string'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('character (len=*)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type('character(:), allocatable')
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return [('character (c_char), dimension(:), pointer', 'f_ret_ptr'),
                 ('integer', 'i_loop')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(len({}), c_size_t)'.format(self.name, self.name)
+        return f'{self.name}, int(len({self.name}), c_size_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                '    allocate (character(ret_val_size) :: {0})\n'
+                f'    allocate (character(ret_val_size) :: {return_name})\n'
                 '    do i_loop = 1, ret_val_size\n'
-                '        {0}(i_loop:i_loop) = f_ret_ptr(i_loop)\n'
-                '    end do\n').format(return_name)
+                f'        {return_name}(i_loop:i_loop) = f_ret_ptr(i_loop)\n'
+                '    end do\n')
 
     def f_return_dummy_result(self, return_name: str) -> str:
-        return '            allocate (character(0) :: {0})\n'.format(return_name)
+        return f'            allocate (character(0) :: {return_name})\n'
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['character',
                  ('integer (c_size_t), value', '_size')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_size_t)', '_size')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['char *', ('std::size_t', '_size')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['char **', ('std::size_t *', '_size')])
 
     def fc_convert_input(self) -> str:
-        return '    std::string {}_s({}, {}_size);\n'.format(
-                self.name, self.name, self.name)
+        return f'    std::string {self.name}_s({self.name}, {self.name}_size);\n'
 
     def fc_cpp_arg(self) -> str:
         return self.name + '_s'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
         return ('static std::string result;\n'
-                '    result = {}').format(cpp_chain_call)
+                f'    result = {cpp_chain_call}')
 
     def fc_return(self) -> str:
-        return ('    *{0} = const_cast<char*>(result.c_str());\n'
-                '    *{0}_size = result.size();\n'
-                '    return;\n').format(self.name)
+        return (f'    *{self.name} = const_cast<char*>(result.c_str());\n'
+                f'    *{self.name}_size = result.size();\n'
+                '    return;\n')
 
     def fc_return_default(self) -> str:
         return ''  # memfun has void signature
@@ -341,59 +338,59 @@ class VecInt64t(Par):
     def fc_cpp_type(self) -> str:
         return 'std::vector<int64_t>'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (selected_int_kind(18)), dimension(:)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
                 [('integer (selected_int_kind(18)), dimension(:)', self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return [(
             'integer (selected_int_kind(18)), pointer, dimension(:)',
             'f_ret_ptr')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(size({}), c_int64_t)'.format(self.name, self.name)
+        return f'{self.name}, int(size({self.name}), c_int64_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                '    {}(1:ret_val_size) = f_ret_ptr\n').format(return_name)
+                f'    {return_name}(1:ret_val_size) = f_ret_ptr\n')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['integer (c_int64_t), dimension(*)',
                  ('integer (c_int64_t), value', '_size')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_int64_t)', '_size')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['std::int64_t *', ('std::int64_t', '_size')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['std::int64_t **', ('std::size_t *', '_size')])
 
     def fc_convert_input(self) -> str:
-        return '    std::vector<std::int64_t> {}_v({}, {} + {}_size);\n'.format(
-                self.name, self.name, self.name, self.name)
+        return (f'    std::vector<std::int64_t> {self.name}_v({self.name}, {self.name}'
+                f' + {self.name}_size);\n')
 
     def fc_cpp_arg(self) -> str:
         return self.name + '_v'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
         return ('static std::vector<std::int64_t> result;\n'
-                '    result = {}').format(cpp_chain_call)
+                f'    result = {cpp_chain_call}')
 
     def fc_return(self) -> str:
-        return ('    *{0} = result.data();\n'
-                '    *{0}_size = result.size();\n'
-                '    return;\n').format(self.name)
+        return (f'    *{self.name} = result.data();\n'
+                f'    *{self.name}_size = result.size();\n'
+                '    return;\n')
 
     def fc_return_default(self) -> str:
         return ''  # memfun has void signature
@@ -408,61 +405,59 @@ class VecDbl(Par):
     def fc_cpp_type(self) -> str:
         return 'std::vector<double>'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                'real ({}_real8), dimension(:)'.format(self.f_prefix))
+                f'real ({self.f_prefix}_real8), dimension(:)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [('real ({}_real8), dimension(:)'.format(self.f_prefix),
-                  self.name)])
+                [(f'real ({self.f_prefix}_real8), dimension(:)', self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return [(
-            'real ({}_real8), pointer, dimension(:)'.format(self.f_prefix),
-            'f_ret_ptr')]
+            f'real ({self.f_prefix}_real8), pointer, dimension(:)', 'f_ret_ptr')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(size({}), c_size_t)'.format(self.name, self.name)
+        return f'{self.name}, int(size({self.name}), c_size_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                '    {} = f_ret_ptr\n').format(return_name)
+                f'    {return_name} = f_ret_ptr\n')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['real (c_double), dimension(*)',
                  ('integer (c_size_t), value', '_size')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_size_t)', '_size')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['double *', ('std::size_t', '_size')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['double **', ('std::size_t *', '_size')])
 
     def fc_convert_input(self) -> str:
-        return '    std::vector<double> {}_v({}, {} + {}_size);\n'.format(
-                self.name, self.name, self.name, self.name)
+        return (f'    std::vector<double> {self.name}_v({self.name}, {self.name} +'
+                f' {self.name}_size);\n')
 
     def fc_cpp_arg(self) -> str:
         return self.name + '_v'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
         return ('static std::vector<double> result;\n'
-                '    result = {}').format(cpp_chain_call)
+                f'    result = {cpp_chain_call}')
 
     def fc_return(self) -> str:
-        return ('    *{0} = result.data();\n'
-                '    *{0}_size = result.size();\n'
-                '    return;\n').format(self.name)
+        return (f'    *{self.name} = result.data();\n'
+                f'    *{self.name}_size = result.size();\n'
+                '    return;\n')
 
     def fc_return_default(self) -> str:
         return ''  # memfun has void signature
@@ -477,43 +472,40 @@ class Vec2Dbl(Par):
     def fc_cpp_type(self) -> str:
         return 'std::vector<std::vector<double>>'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type(
-                'real ({}_real8), dimension(:,:)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'real ({self.f_prefix}_real8), dimension(:,:)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [('real ({}_real8), dimension(:,:)'.format(self.f_prefix),
-                  self.name)])
+                [(f'real ({self.f_prefix}_real8), dimension(:,:)', self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
-        return [('real ({}_real8), pointer, dimension(:,:)'.format(
-                self.f_prefix), 'f_ret_ptr')]
+    def f_aux_variables(self) -> list[tuple[str, str]]:
+        return [(f'real ({self.f_prefix}_real8), pointer, dimension(:,:)', 'f_ret_ptr')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(shape({}), c_size_t)'.format(self.name, self.name)
+        return f'{self.name}, int(shape({self.name}), c_size_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)\n'
-                '    {} = f_ret_ptr\n').format(return_name)
+                f'    {return_name} = f_ret_ptr\n')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['real (c_double), dimension(*)',
                  ('integer (c_size_t), dimension(2)', '_shape')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_size_t), dimension(2)', '_shape')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['double *', ('std::size_t *', '_shape')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['double **', ('std::size_t *', '_shape')])
 
     def fc_convert_input(self) -> str:
@@ -531,8 +523,7 @@ class Vec2Dbl(Par):
         return self.name + '_v'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'std::vector<std::vector<double>> result = {}'.format(
-                cpp_chain_call)
+        return f'std::vector<std::vector<double>> result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         result = (
@@ -567,61 +558,58 @@ class VecSizet(Par):
     def fc_cpp_type(self) -> str:
         return 'std::vector<std::size_t>'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type(
-                'integer ({}_size), dimension(:)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'integer ({self.f_prefix}_size), dimension(:)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [('integer ({}_size), dimension(:)'.format(self.f_prefix),
-                  self.name)])
+                [(f'integer ({self.f_prefix}_size), dimension(:)', self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return [(
-            'integer ({}_size), pointer, dimension(:)'.format(self.f_prefix),
-            'f_ret_ptr')]
+            f'integer ({self.f_prefix}_size), pointer, dimension(:)', 'f_ret_ptr')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(size({}), c_size_t)'.format(self.name, self.name)
+        return f'{self.name}, int(size({self.name}), c_size_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                '    {}(1:ret_val_size) = f_ret_ptr\n').format(return_name)
+                f'    {return_name}(1:ret_val_size) = f_ret_ptr\n')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['integer (c_size_t), dimension(*)',
                  ('integer (c_size_t), value', '_size')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_size_t)', '_size')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['std::size_t *', ('std::size_t', '_size')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['std::size_t **', ('std::size_t *', '_size')])
 
     def fc_convert_input(self) -> str:
-        return '    std::vector<std::size_t> {}_v({}, {} + {}_size);\n'.format(
-                self.name, self.name, self.name, self.name)
+        return (f'    std::vector<std::size_t> {self.name}_v({self.name}, {self.name}'
+                f' + {self.name}_size);\n')
 
     def fc_cpp_arg(self) -> str:
         return self.name + '_v'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
         return ('static std::vector<std::size_t> result;\n'
-                '    result = {}').format(cpp_chain_call)
+                f'    result = {cpp_chain_call}')
 
     def fc_return(self) -> str:
-        return ('    *{0} = result.data();\n'
-                '    *{0}_size = result.size();\n'
-                '    return;\n').format(self.name)
+        return (f'    *{self.name} = result.data();\n'
+                f'    *{self.name}_size = result.size();\n'
+                '    return;\n')
 
     def fc_return_default(self) -> str:
         return ''  # memfun has void signature
@@ -636,49 +624,50 @@ class VecString(Par):
     def fc_cpp_type(self) -> str:
         return 'std::vector<std::string>'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('character, dimension(:,:)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type(
                 [('character(:), dimension(:), allocatable', self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return [('character, pointer, dimension(:,:)', 'f_ret_ptr'),
                 ('integer', 'i_loop, j_loop'),
                 ('character(:), allocatable', 'tmp_s')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(shape({}), c_size_t)'.format(self.name, self.name)
+        return f'{self.name}, int(shape({self.name}), c_size_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)\n'
-                '    allocate (character(ret_val_shape(2)) :: {0}(ret_val_shape(1)))\n'
+                '    allocate (character(ret_val_shape(2)) ::'
+                f' {return_name}(ret_val_shape(1)))\n'
                 '    allocate (character(ret_val_shape(2)) :: tmp_s)\n'
                 '    do i_loop = 1, ret_val_shape(1)\n'
                 '        do j_loop = 1, ret_val_shape(2)\n'
                 '            tmp_s(j_loop:j_loop) = f_ret_ptr(i_loop, j_loop)\n'
                 '        end do\n'
-                '        {0}(i_loop) = tmp_s\n'
-                '    end do\n').format(return_name)
+                f'        {return_name}(i_loop) = tmp_s\n'
+                '    end do\n')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['character, dimension(*)',
                  ('integer (c_size_t), dimension(2)', '_shape')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_size_t), dimension(2)', '_shape')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['char *', ('std::size_t *', '_shape')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['char **', ('std::size_t *', '_shape')])
 
     def fc_convert_input(self) -> str:
@@ -688,8 +677,7 @@ class VecString(Par):
         return self.name + '_s'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'std::vector<std::string> result = {}'.format(
-                cpp_chain_call)
+        return f'std::vector<std::string> result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         result = (
@@ -738,46 +726,46 @@ class Array(Par):
         self.ndims = ndims
 
     def set_ns_prefix(
-            self, ns_for_name: Dict[str, Tuple[str, str]], c_ns: str, f_ns: str
+            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
             ) -> None:
         self.c_prefix = c_ns
         self.f_prefix = f_ns
         self.elem_type.set_ns_prefix(ns_for_name, c_ns, f_ns)
 
     def tname(self) -> str:
-        return '{}array{}'.format(self.elem_type.tname(), self.ndims)
+        return f'{self.elem_type.tname()}array{self.ndims}'
 
     def fc_cpp_type(self) -> str:
-        return '{} const *'.format(self.elem_type.fc_cpp_type())
+        return f'{self.elem_type.fc_cpp_type()} const *'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                '{}, dimension({})'.format(
-                    self.elem_type.f_type()[0][0], self._f_dims()))
+                f'{self.elem_type.f_type()[0][0]}, dimension({self._f_dims()})')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [('{}, dimension({})'.format(self.elem_type.f_type()[0][0],
-                                             self._f_dims()),
+                [(f'{self.elem_type.f_type()[0][0]}, dimension({self._f_dims()})',
                   self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
-        return [('{}, pointer, dimension({})'.format(
-                    self.elem_type.fi_ret_type()[0][0], self._f_dims()), 'f_ret_ptr'),
-                ('{}, pointer, dimension(:)'.format(
-                    self.elem_type.fi_ret_type()[0][0]), 'f_ret_ptr_linear')]
+    def f_aux_variables(self) -> list[tuple[str, str]]:
+        return [(
+                    f'{self.elem_type.fi_ret_type()[0][0]}, pointer,'
+                    f' dimension({self._f_dims()})' , 'f_ret_ptr'),
+                (
+                    f'{self.elem_type.fi_ret_type()[0][0]}, pointer,'
+                    ' dimension(:)', 'f_ret_ptr_linear')]
 
     def f_chain_arg(self) -> str:
-        return '{0}, int(shape({0}), c_size_t), {1}_{2}_size'.format(
-                self.elem_type.f_chain_arg(), self.ndims, self.f_prefix)
+        tmpl = '{0}, int(shape({0}), c_size_t), {1}_{2}_size'
+        return tmpl.format(self.elem_type.f_chain_arg(), self.ndims, self.f_prefix)
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        c_order = '(/{}/)'.format(', '.join(
-            map(str, reversed(range(1, self.ndims+1)))))
-        return indent(dedent("""\
+        dims = ', '.join(map(str, reversed(range(1, self.ndims+1))))
+        c_order = f'f(/{dims}/)'
+        tmpl = indent(dedent("""\
             if (ret_val_format .eq. 0) then
                 call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)
                 {0} = f_ret_ptr
@@ -785,55 +773,50 @@ class Array(Par):
                 call c_f_pointer(ret_val, f_ret_ptr_linear, (/product(ret_val_shape)/))
                 {0} = reshape(f_ret_ptr_linear, ret_val_shape, (/ {2}:: /), {1})
             end if
-            """), 4*' ').format(
-                        return_name, c_order,
-                        self.elem_type.fi_ret_type()[0][0])
+            """), 4*' ')
+        return tmpl.format(return_name, c_order, self.elem_type.fi_ret_type()[0][0])
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         base_type = self.elem_type.fi_type()[0][0].split(',')[0]
         return self._regular_type(
-                ['{}, dimension(*)'.format(base_type),
-                 ('integer (c_size_t), dimension({})'.format(self.ndims),
-                     '_shape'),
+                [f'{base_type}, dimension(*)',
+                 (f'integer (c_size_t), dimension({self.ndims})', '_shape'),
                  ('integer (c_size_t), value', '_ndims')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
-                 ('integer (c_size_t), dimension({})'.format(self.ndims),
-                     '_shape'),
+                 (f'integer (c_size_t), dimension({self.ndims})', '_shape'),
                  ('integer (c_int)', '_format')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         elem_fc_type = self.elem_type.fc_type()[0][0]
         return self._regular_type(
-                ['{} *'.format(elem_fc_type),
+                [f'{elem_fc_type} *',
                     ('std::size_t *', '_shape'),
                     ('std::size_t', '_ndims')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         # TODO: add ndims
         return self._regular_type(
-            ['{} **'.format(self.elem_type.fc_cpp_type()),
+            [f'{self.elem_type.fc_cpp_type()} **',
              ('std::size_t *', '_shape'),
              ('int *', '_format')])
 
     def fc_convert_input(self) -> str:
-        result = (
+        tmpl = (
                 'std::vector<std::size_t> {0}_shape_v(\n'
                 '        {0}_shape, {0}_shape + {0}_ndims);\n'
                 'auto {0}_p = const_cast<{1} const *>({0});\n'
-                ).format(
-                        self.name, self.elem_type.fc_cpp_type())
-
+                )
+        result = tmpl.format(self.name, self.elem_type.fc_cpp_type())
         return indent(result, '    ')
 
     def fc_cpp_arg(self) -> str:
-        return '{0}_p, {0}_shape_v'.format(self.name)
+        return f'{self.name}_p, {self.name}_shape_v'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return '{} result = {}'.format(
-                self.fc_cpp_type(), cpp_chain_call)
+        return f'{self.fc_cpp_type()} result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         result = dedent("""\
@@ -850,8 +833,7 @@ class Array(Par):
             """)
 
         return indent(
-                result.format(self.name, self.elem_type.fc_cpp_type(),
-                              self.ndims),
+                result.format(self.name, self.elem_type.fc_cpp_type(), self.ndims),
                 '    ')
 
     def fc_return_default(self) -> str:
@@ -870,59 +852,60 @@ class Bytes(Par):
     def fc_cpp_type(self) -> str:
         return 'std::vector<char>'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 'character(len=1), dimension(:)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
                 [('character(len=1), dimension(:)', self.name)])
 
-    def f_aux_variables(self) -> List[Tuple[str, str]]:
+    def f_aux_variables(self) -> list[tuple[str, str]]:
         return [('character(len=1), pointer, dimension(:)',
                  'f_ret_ptr')]
 
     def f_chain_arg(self) -> str:
-        return '{}, int(size({}), c_size_t)'.format(self.name, self.name)
+        return f'{self.name}, int(size({self.name}), c_size_t)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    call {}\n\n'.format(call)
+        return f'    call {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
         return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                '    {} = f_ret_ptr\n').format(return_name)
+                f'    {return_name} = f_ret_ptr\n')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['character(len=1), dimension(*)',
                  ('integer (c_size_t), value', '_size')])
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
                 ['type (c_ptr)',
                  ('integer (c_size_t)', '_size')])
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['char *', ('std::size_t', '_size')])
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(['char **', ('std::size_t *', '_size')])
 
     def fc_convert_input(self) -> str:
-        return '    std::vector<char> {}_v({}, {} + {}_size);\n'.format(
-                self.name, self.name, self.name, self.name)
+        return (
+                f'    std::vector<char> {self.name}_v({self.name}, {self.name} +'
+                f' {self.name}_size);\n')
 
     def fc_cpp_arg(self) -> str:
         return self.name + '_v'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
         return ('static std::vector<char> result;\n'
-                'result = {}').format(cpp_chain_call)
+                f'result = {cpp_chain_call}')
 
     def fc_return(self) -> str:
-        return ('    *{0} = result.data();\n'
-                '    *{0}_size = result.size();\n'
-                '    return;\n').format(self.name)
+        return (f'    *{self.name} = result.data();\n'
+                f'    *{self.name}_size = result.size();\n'
+                '    return;\n')
 
     def fc_return_default(self) -> str:
         return ''  # memfun has void signature
@@ -937,7 +920,7 @@ class Obj(Par):
         self.class_name = class_name
 
     def set_ns_prefix(
-            self, ns_for_name: Dict[str, Tuple[str, str]], c_ns: str, f_ns: str
+            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
             ) -> None:
         self.c_prefix, self.f_prefix = ns_for_name[self.class_name]
 
@@ -947,48 +930,45 @@ class Obj(Par):
     def fc_cpp_type(self) -> str:
         return self.class_name
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('class({}_{})'.format(
-            self.f_prefix, self.class_name))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'class({self.f_prefix}_{self.class_name})')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('type({}_{})'.format(
-            self.f_prefix, self.class_name))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'type({self.f_prefix}_{self.class_name})')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_intptr_t), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_intptr_t)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('std::intptr_t')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('std::intptr_t')
 
     def fc_convert_input(self) -> str:
-        return '    {} * {}_p = reinterpret_cast<{} *>({});\n'.format(
-                self.class_name, self.name, self.class_name, self.name)
+        return (f'    {self.class_name} * {self.name}_p ='
+                f' reinterpret_cast<{self.class_name} *>({self.name});\n')
 
     def fc_cpp_arg(self) -> str:
-        return '*{}_p'.format(self.name)
+        return f'*{self.name}_p'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return '{0} * result = new {0}({1})'.format(
-                self.class_name, cpp_chain_call)
+        return f'{self.class_name} * result = new {self.class_name}({cpp_chain_call})'
 
     def fc_return(self) -> str:
         return '    return reinterpret_cast<std::intptr_t>(result);\n'
 
     def f_chain_arg(self) -> str:
-        return '{}%ptr'.format(self.name)
+        return f'{self.name}%ptr'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    {} = {}\n\n'.format(result_name, call)
+        return f'    {result_name} = {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return '    {}%ptr = {}\n'.format(return_name, result_name)
+        return f'    {return_name}%ptr = {result_name}\n'
 
     def fc_return_default(self) -> str:
         return '    return 0;\n'
@@ -1003,41 +983,41 @@ class Bool(Par):
     def fc_cpp_type(self) -> str:
         return 'bool'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('logical')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type('logical')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('logical (c_bool), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('logical (c_bool)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('bool')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('bool')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'bool result = {}'.format(cpp_chain_call)
+        return f'bool result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
 
     def f_chain_arg(self) -> str:
-        return 'logical({}, c_bool)'.format(self.name)
+        return f'logical({self.name}, c_bool)'
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return '    {} = {}\n\n'.format(result_name, call)
+        return f'    {result_name} = {call}\n\n'
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return '    {} = {}\n'.format(return_name, result_name)
+        return f'    {return_name} = {result_name}\n'
 
     def fc_return_default(self) -> str:
         return '    return false;\n'
@@ -1052,7 +1032,7 @@ class EnumVal(Par):
         self.class_name = class_name
 
     def set_ns_prefix(
-            self, ns_for_name: Dict[str, Tuple[str, str]], c_ns: str, f_ns: str
+            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
             ) -> None:
         self.c_prefix, self.f_prefix = ns_for_name[self.class_name]
 
@@ -1062,35 +1042,34 @@ class EnumVal(Par):
     def fc_cpp_type(self) -> str:
         return self.class_name
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('integer({}_{})'.format(
-            self.f_prefix, self.class_name))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'integer({self.f_prefix}_{self.class_name})')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('integer({}_{})'.format(
-            self.f_prefix, self.class_name))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'integer({self.f_prefix}_{self.class_name})')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int')
 
     def fc_convert_input(self) -> str:
-        return '    {} {}_e = static_cast<{}>({});\n'.format(
-                self.class_name, self.name, self.class_name, self.name)
+        return (
+                f'    {self.class_name} {self.name}_e ='
+                f' static_cast<{self.class_name}>({self.name});\n')
 
     def fc_cpp_arg(self) -> str:
         return self.name + '_e'
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return '{} result = {}'.format(self.class_name, cpp_chain_call)
+        return f'{self.class_name} result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return static_cast<int>(result);\n'
@@ -1108,29 +1087,29 @@ class Int(Par):
     def fc_cpp_type(self) -> str:
         return 'int'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type('integer')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'int result = {}'.format(cpp_chain_call)
+        return f'int result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1148,30 +1127,29 @@ class Char(Par):
     def fc_cpp_type(self) -> str:
         return 'char'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('integer ({}_int1)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'integer ({self.f_prefix}_int1)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('integer ({}_int1)'.format(
-                self.f_prefix))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'integer ({self.f_prefix}_int1)')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int8_t), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int8_t)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('char')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('char')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'char result = {}'.format(cpp_chain_call)
+        return f'char result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1189,29 +1167,29 @@ class Int16t(Par):
     def fc_cpp_type(self) -> str:
         return 'int16_t'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (selected_int_kind(4))')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type('integer (selected_int_kind(4))')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_short), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_short)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('short int')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('short int')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'short int result = {}'.format(cpp_chain_call)
+        return f'short int result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1229,30 +1207,29 @@ class Int32t(Par):
     def fc_cpp_type(self) -> str:
         return 'int32_t'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('integer ({}_int4)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'integer ({self.f_prefix}_int4)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('integer ({}_int4)'.format(
-                self.f_prefix))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'integer ({self.f_prefix}_int4)')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int32_t), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int32_t)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int32_t')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int32_t')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'int32_t result = {}'.format(cpp_chain_call)
+        return f'int32_t result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1270,29 +1247,29 @@ class Int64t(Par):
     def fc_cpp_type(self) -> str:
         return 'int64_t'
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (selected_int_kind(18))')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type('integer (selected_int_kind(18))')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int64_t), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_int64_t)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int64_t')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('int64_t')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'int64_t result = {}'.format(cpp_chain_call)
+        return f'int64_t result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1310,30 +1287,29 @@ class Sizet(Par):
     def fc_cpp_type(self) -> str:
         return 'std::size_t'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('integer ({}_size)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'integer ({self.f_prefix}_size)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('integer ({}_size)'.format(
-                self.f_prefix))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'integer ({self.f_prefix}_size)')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_size_t), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('integer (c_size_t)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('std::size_t')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('std::size_t')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'std::size_t result = {}'.format(cpp_chain_call)
+        return f'std::size_t result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1351,30 +1327,29 @@ class Float(Par):
     def fc_cpp_type(self) -> str:
         return 'float'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('real ({}_real4)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'real ({self.f_prefix}_real4)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('real ({}_real4)'.format(
-                self.f_prefix))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'real ({self.f_prefix}_real4)')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('real (c_float), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('real (c_float)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('float')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('float')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'float result = {}'.format(cpp_chain_call)
+        return f'float result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1392,30 +1367,29 @@ class Double(Par):
     def fc_cpp_type(self) -> str:
         return 'double'
 
-    def f_type(self) -> List[Tuple[str, str]]:
-        return self._regular_type('real ({}_real8)'.format(self.f_prefix))
+    def f_type(self) -> list[tuple[str, str]]:
+        return self._regular_type(f'real ({self.f_prefix}_real8)')
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
-        return True, self._regular_type('real ({}_real8)'.format(
-                self.f_prefix))
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
+        return True, self._regular_type(f'real ({self.f_prefix}_real8)')
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type('real (c_double), value')
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('real (c_double)')
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         return self._regular_type('double')
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type('double')
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return 'double result = {}'.format(cpp_chain_call)
+        return f'double result = {cpp_chain_call}'
 
     def fc_return(self) -> str:
         return '    return result;\n'
@@ -1430,25 +1404,25 @@ class T(Par):
     def tname(self) -> str:
         raise NotImplementedError("T is a dummy type")
 
-    def fc_type(self) -> List[Tuple[str, str]]:
+    def fc_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("T is a dummy type")
 
     def fc_cpp_type(self) -> str:
         raise NotImplementedError("T is a dummy type")
 
-    def fc_ret_type(self) -> List[Tuple[str, str]]:
+    def fc_ret_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("T is a dummy type")
 
-    def fi_type(self) -> List[Tuple[str, str]]:
+    def fi_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("T is a dummy type")
 
-    def fi_ret_type(self) -> List[Tuple[str, str]]:
+    def fi_ret_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("T is a dummy type")
 
-    def f_type(self) -> List[Tuple[str, str]]:
+    def f_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("T is a dummy type")
 
-    def f_ret_type(self) -> Tuple[bool, List[Tuple[str, str]]]:
+    def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         raise NotImplementedError("T is a dummy type")
 
     def fc_cpp_arg(self) -> str:
@@ -1474,7 +1448,7 @@ class Member(abc.ABC):
     def reset_class_name(self, class_name: str) -> None:
         self.class_name = class_name
 
-    def set_ns_prefix(self, ns_for_name: Dict[str, Tuple[str, str]]) -> None:
+    def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         self.c_prefix, self.f_prefix = ns_for_name[self.class_name]
 
     def set_public(self, public: Optional[bool]) -> None:
@@ -1505,7 +1479,7 @@ class MemFun(Member):
     def __init__(self,
                  ret_type: Par,
                  name: str,
-                 params: Optional[List[Par]] = None,
+                 params: Optional[list[Par]] = None,
                  may_throw: bool = False,
                  *,
                  cpp_func_name: Optional[str] = None,
@@ -1533,7 +1507,7 @@ class MemFun(Member):
         Args:
             ret_type: Description of the return value.
             name: Name of the member.
-            params: List of in/out parameters.
+            params: list of in/out parameters.
             may_throw: True iff this function can throw an exception.
             cpp_func_name: Name of C++ member function to call.
             cpp_chain_call: Function that produces the C++ chain call.
@@ -1543,7 +1517,7 @@ class MemFun(Member):
         """
         super().__init__(name)
         self.ret_type = ret_type
-        self.params: List[Par] = params if params else list()
+        self.params: list[Par] = params if params else list()
         self.may_throw = may_throw
         self.cpp_chain_call = cpp_chain_call or self._default_cpp_chain_call
         self.fc_override = fc_override
@@ -1575,7 +1549,7 @@ class MemFun(Member):
             if self.params[0].name == 'self':
                 self.params[0] = Obj(class_name, 'self')
 
-    def set_ns_prefix(self, ns_for_name: Dict[str, Tuple[str, str]]) -> None:
+    def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         """Sets the namespace prefix correctly for all members.
 
         Args:
@@ -1603,15 +1577,14 @@ class MemFun(Member):
             out_parameters.append('char ** err_msg')
             out_parameters.append('std::size_t * err_msg_len')
 
-        func_name = '{}_{}_{}_'.format(
-                self.c_prefix, self.class_name, self.name)
+        func_name = f'{self.c_prefix}_{self.class_name}_{self.name}_'
 
         par_str = ', '.join(in_parameters + out_parameters)
-        result += '{} {}({}) {{\n'.format(return_type, func_name, par_str)
+        result += f'{return_type} {func_name}({par_str}) {{\n'
 
         # convert input
         for par in self.params:
-            result += '{}'.format(par.fc_convert_input())
+            result += f'{par.fc_convert_input()}'
 
         # call C++ function and return result
         if self.may_throw:
@@ -1623,8 +1596,8 @@ class MemFun(Member):
             for exception, code in error_codes.items():
                 if code != 0:
                     catch = ''
-                    catch += 'catch (std::{} const & e) {{\n'.format(exception)
-                    catch += '    *err_code = {};\n'.format(code)
+                    catch += f'catch (std::{exception} const & e) {{\n'
+                    catch += f'    *err_code = {code};\n'
                     catch += '    static std::string msg;\n'
                     catch += '    msg = e.what();\n'
                     catch += '    *err_msg = const_cast<char*>(msg.data());\n'
@@ -1645,8 +1618,7 @@ class MemFun(Member):
         if self.fc_override == '':
             return result
 
-        func_name = '{}_{}_{}_'.format(
-                self.c_prefix, self.class_name, self.name)
+        func_name = f'{self.c_prefix}_{self.class_name}_{self.name}_'
 
         # declaration
         in_parameters = self._fi_in_parameters()
@@ -1663,26 +1635,24 @@ class MemFun(Member):
             arg_vlist = ', '.join(arg_list)
 
         if return_type != '':
-            result += '{} function {}({}) &\n'.format(
-                    return_type, func_name, arg_vlist)
+            result += f'{return_type} function {func_name}({arg_vlist}) &\n'
         else:
-            result += 'subroutine {}({}) &\n'.format(func_name, arg_vlist)
-        result += '        bind(C, name="{}")\n'.format(func_name)
+            result += f'subroutine {func_name}({arg_vlist}) &\n'
+        result += f'        bind(C, name="{func_name}")\n'
         result += '\n'
         result += '    use iso_c_binding\n'
 
         # parameter declarations
         for par_type, par_name in in_parameters:
-            result += '    {}, intent(in) :: {}\n'.format(
-                    par_type, par_name)
+            result += f'    {par_type}, intent(in) :: {par_name}\n'
         for par_type, par_name in out_parameters:
-            result += '    {}, intent(out) :: {}\n'.format(par_type, par_name)
+            result += f'    {par_type}, intent(out) :: {par_name}\n'
 
         # end
         if return_type != '':
-            result += 'end function {}\n\n'.format(func_name)
+            result += f'end function {func_name}\n\n'
         else:
-            result += 'end subroutine {}\n\n'.format(func_name)
+            result += f'end subroutine {func_name}\n\n'
         return indent(result, 8*' ')
 
     def fortran_function(self) -> str:
@@ -1698,8 +1668,7 @@ class MemFun(Member):
         result = ''
 
         # declaration
-        func_name = '{}_{}_{}'.format(
-                self.f_prefix, self.class_name, self.name)
+        func_name = f'{self.f_prefix}_{self.class_name}_{self.name}'
         in_parameters = self._f_in_parameters()
         return_type, out_parameters = self._f_out_parameters()
         if self.may_throw:
@@ -1711,29 +1680,28 @@ class MemFun(Member):
         arg_list = ', &\n'.join([par_name for _, par_name in all_parameters])
         arg_ilist = indent(arg_list, 8*' ')
         if return_type != '':
-            result += 'function {}( &\n{})\n'.format(func_name, arg_ilist)
+            result += f'function {func_name}( &\n{arg_ilist})\n'
         else:
-            result += 'subroutine {}( &\n{})\n'.format(func_name, arg_ilist)
+            result += f'subroutine {func_name}( &\n{arg_ilist})\n'
 
         # parameter declarations
         result += '    implicit none\n'
         for par_type, par_name in in_parameters:
-            result += '    {}, intent(in) :: {}\n'.format(
-                    par_type, par_name)
+            result += f'    {par_type}, intent(in) :: {par_name}\n'
         for par_type, par_name in out_parameters:
-            result += '    {}, intent(out) :: {}\n'.format(par_type, par_name)
+            result += f'    {par_type}, intent(out) :: {par_name}\n'
         if return_type != '':
-            result += '    {} :: {}\n'.format(return_type, func_name)
+            result += f'    {return_type} :: {func_name}\n'
         result += '\n'
 
         # variable declarations
         c_return_type, fi_out_parameters = self._fi_out_parameters()
         if c_return_type:
-            result += '    {} :: ret_val\n'.format(c_return_type)
+            result += f'    {c_return_type} :: ret_val\n'
         for par_type, par_name in fi_out_parameters:
-            result += '    {} :: {}\n'.format(par_type, par_name)
+            result += f'    {par_type} :: {par_name}\n'
         for par_type, par_name in self.ret_type.f_aux_variables():
-            result += '    {} :: {}\n'.format(par_type, par_name)
+            result += f'    {par_type} :: {par_name}\n'
         if self.may_throw:
             result += '    integer (c_int) :: err_code_v\n'
             result += '    type (c_ptr) :: err_msg_v\n'
@@ -1752,8 +1720,7 @@ class MemFun(Member):
         arg_str = ', &\n'.join([8*' ' + arg for arg in args])
 
         # call C function
-        fc_func_name = '{}_{}_{}_'.format(
-                self.c_prefix, self.class_name, self.name)
+        fc_func_name = f'{self.c_prefix}_{self.class_name}_{self.name}_'
         chain_call = self.fc_chain_call(
                 ns_prefix=self.c_prefix, class_name=self.class_name,
                 fc_func_name=fc_func_name, fc_args=arg_str)
@@ -1805,9 +1772,9 @@ class MemFun(Member):
 
         # end
         if return_type != '':
-            result += 'end function {}\n\n'.format(func_name)
+            result += f'end function {func_name}\n\n'
         else:
-            result += 'end subroutine {}\n\n'.format(func_name)
+            result += f'end subroutine {func_name}\n\n'
         return indent(result, 4*' ')
 
     def fortran_public_declaration(self) -> str:
@@ -1816,9 +1783,8 @@ class MemFun(Member):
         if self.f_override == '':
             return ''
 
-        func_name = '{}_{}_{}'.format(
-                self.f_prefix, self.class_name, self.name)
-        return '    public :: {}\n'.format(func_name)
+        func_name = f'{self.f_prefix}_{self.class_name}_{self.name}'
+        return f'    public :: {func_name}\n'
 
     def fortran_contains_definition(self) -> str:
         if self.f_override == '':
@@ -1842,7 +1808,7 @@ class MemFun(Member):
                 }
         cpp_chain_call = self.cpp_chain_call(**chain_args)
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return '    {};\n'.format(result)
+        return f'    {result};\n'
 
     def _fc_return(self) -> str:
         return self.ret_type.fc_return()
@@ -1850,19 +1816,19 @@ class MemFun(Member):
     def _fc_return_default(self) -> str:
         return self.ret_type.fc_return_default()
 
-    def _fc_in_parameters(self) -> List[str]:
+    def _fc_in_parameters(self) -> list[str]:
         """Create a list of input parameters.
         """
-        result = list()     # type: List[str]
+        result = list()     # type: list[str]
 
         for param in self.params:
             type_list = param.fc_type()
             for type_name, postfix in type_list:
-                result.append('{} {}'.format(type_name, param.name + postfix))
+                result.append(f'{type_name} {param.name + postfix}')
 
         return result
 
-    def _fc_out_parameters(self) -> Tuple[str, List[str]]:
+    def _fc_out_parameters(self) -> tuple[str, list[str]]:
         """Create return type and output parameters.
 
         Returns a tuple (ret_type, out_pars).
@@ -1871,25 +1837,24 @@ class MemFun(Member):
         if len(out_pars) == 1:
             return (out_pars[0][0], [])
 
-        out_par_strl = list()       # type: List[str]
+        out_par_strl = list()       # type: list[str]
         for type_name, postfix in out_pars:
-            out_par_strl.append('{} {}'.format(
-                type_name, self.ret_type.name + postfix))
+            out_par_strl.append(f'{type_name} {self.ret_type.name + postfix}')
         return ('void', out_par_strl)
 
-    def _fi_in_parameters(self) -> List[Tuple[str, str]]:
+    def _fi_in_parameters(self) -> list[tuple[str, str]]:
         """Returns Fortran interface input parameters.
 
         The result is a list of (type, name) tuples.
         """
-        result = list()     # type: List[Tuple[str, str]]
+        result = list()     # type: list[tuple[str, str]]
         for param in self.params:
             type_list = param.fi_type()
             for type_name, postfix in type_list:
                 result.append((type_name, param.name + postfix))
         return result
 
-    def _fi_out_parameters(self) -> Tuple[str, List[Tuple[str, str]]]:
+    def _fi_out_parameters(self) -> tuple[str, list[tuple[str, str]]]:
         """Returns Fortran interface output parameters.
 
         The result is a tuple (ret_type, [(out_type, out_name)]).
@@ -1898,25 +1863,25 @@ class MemFun(Member):
         if len(out_pars) == 1:
             return (out_pars[0][0], [])
 
-        out_par_list = list()       # type: List[Tuple[str, str]]
+        out_par_list = list()       # type: list[tuple[str, str]]
         for par_type, par_name in out_pars:
             out_par_list.append((par_type, 'ret_val' + par_name))
 
         return ('', out_par_list)
 
-    def _f_in_parameters(self) -> List[Tuple[str, str]]:
+    def _f_in_parameters(self) -> list[tuple[str, str]]:
         """Returns Fortran input parameters.
 
         The result is a list of (type, name) tuples.
         """
-        result = list()     # type: List[Tuple[str, str]]
+        result = list()     # type: list[tuple[str, str]]
         for param in self.params:
             type_list = param.f_type()
             for type_name, postfix in type_list:
                 result.append((type_name, param.name + postfix))
         return result
 
-    def _f_out_parameters(self) -> Tuple[str, List[Tuple[str, str]]]:
+    def _f_out_parameters(self) -> tuple[str, list[tuple[str, str]]]:
         """Returns Fortran output parameters.
 
         The result is a tuple (ret_type, [(out_type, out_name)]).
@@ -1925,7 +1890,7 @@ class MemFun(Member):
         if is_function:
             return (out_pars[0][0], [])
 
-        out_par_list = list()       # type: List[Tuple[str, str]]
+        out_par_list = list()       # type: list[tuple[str, str]]
         for par_type, par_name in out_pars:
             out_par_list.append((par_type, par_name))
 
@@ -1939,7 +1904,7 @@ class Constructor(MemFun):
     the default code.
     """
     def __init__(
-            self, params: Optional[List[Par]] = None, name: str = 'create',
+            self, params: Optional[list[Par]] = None, name: str = 'create',
             **args: Any) -> None:
         if params is None:
             params = list()
@@ -2017,9 +1982,9 @@ class EqualsOperator(MemFun):
     def _fc_cpp_call(self) -> str:
         # Call operator instead of function
         rhs = self.params[1].fc_cpp_arg()
-        cpp_chain_call = '((*self_p) == {})'.format(rhs)
+        cpp_chain_call = f'((*self_p) == {rhs})'
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return '    {};\n'.format(result)
+        return f'    {result};\n'
 
 
 class AssignmentOperator(MemFun):
@@ -2052,7 +2017,7 @@ class AssignmentOperator(MemFun):
     def _fc_cpp_call(self) -> str:
         # Create object instead of calling something
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return '    *self_p = {};\n'.format(cpp_args[1])
+        return f'    *self_p = {cpp_args[1]};\n'
 
 
 class IndexAssignmentOperator(MemFun):
@@ -2061,7 +2026,7 @@ class IndexAssignmentOperator(MemFun):
     This generates code suitable for assigning to a subobject accessed
     via the square brackets operator, i.e. self[key] = value.
     """
-    def __init__(self, name: str, params: List[Par], may_throw: bool = False
+    def __init__(self, name: str, params: list[Par], may_throw: bool = False
                  ) -> None:
         super().__init__(Void(), name, params, may_throw)
 
@@ -2082,7 +2047,7 @@ class IndexAssignmentOperator(MemFun):
     def _fc_cpp_call(self) -> str:
         # Call operator[] instead of a function
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return '    (*self_p)[{}] = {};\n'.format(cpp_args[1], cpp_args[2])
+        return f'    (*self_p)[{cpp_args[1]}] = {cpp_args[2]};\n'
 
 
 class ShiftedIndexAssignmentOperator(IndexAssignmentOperator):
@@ -2111,8 +2076,7 @@ class ShiftedIndexAssignmentOperator(IndexAssignmentOperator):
     def _fc_cpp_call(self) -> str:
         # Call operator[] instead of a function
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return '    (*self_p)[{} - 1u] = {};\n'.format(
-                cpp_args[1], cpp_args[2])
+        return f'    (*self_p)[{cpp_args[1]} - 1u] = {cpp_args[2]};\n'
 
 
 class NamedConstructor(Constructor):
@@ -2124,7 +2088,7 @@ class NamedConstructor(Constructor):
     For name, pass the name of the static function, the Fortran name
     will then be create_<name>.
     """
-    def __init__(self, params: List[Par], name: str, **args: Any) -> None:
+    def __init__(self, params: list[Par], name: str, **args: Any) -> None:
         if 'cpp_func_name' not in args:
             args['cpp_func_name'] = name
         super().__init__(params, 'create_' + name, **args)
@@ -2149,7 +2113,7 @@ class NamedConstructor(Constructor):
 
     @staticmethod
     def _default_cpp_chain_call(**kwargs: Any) -> str:
-        return '{0}::{1}({2})'.format(
+        return '{}::{}({})'.format(
                 kwargs['class_name'], kwargs['cpp_func_name'],
                 kwargs['cpp_args'])
 
@@ -2163,7 +2127,7 @@ class NamedConstructor(Constructor):
                 }
         cpp_chain_call = self.cpp_chain_call(**chain_args)
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return '    {};\n'.format(result)
+        return f'    {result};\n'
 
     def _fc_return(self) -> str:
         return '    return reinterpret_cast<std::intptr_t>(result);\n'
@@ -2228,7 +2192,7 @@ class MultiMemFun(Member):
     def __init__(self) -> None:
         """Create a MultiMemFun."""
         super().__init__("")
-        self.instances: List[Member] = list()
+        self.instances: list[Member] = list()
 
     def __copy__(self) -> 'MultiMemFun':
         result = MultiMemFun()
@@ -2247,7 +2211,7 @@ class MultiMemFun(Member):
         for instance in self.instances:
             instance.set_public(public)
 
-    def set_ns_prefix(self, ns_for_name: Dict[str, Tuple[str, str]]) -> None:
+    def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         """Sets the namespace prefix correctly for all members.
 
         Args:
@@ -2286,7 +2250,7 @@ class MemFunTmplInstance(MemFun):
                  ret_type: Par,
                  name: str,
                  targ: Par,
-                 params: Optional[List[Par]] = None,
+                 params: Optional[list[Par]] = None,
                  may_throw: bool = False,
                  **args: Any
                  ) -> None:
@@ -2308,13 +2272,13 @@ class MemFunTmplInstance(MemFun):
             ret_type: Description of the return value.
             name: Name of the template.
             targ: Template argument type.
-            params: List of parameters.
+            params: list of parameters.
             cpp_func_name: Name of C++ member function to call.
             cpp_chain_call: Function that produces the C++ chain call.
             fc_override: Custom Fortran-C wrapper function.
             f_override: Custom Fortran function.
         """
-        instance_name = '{}_{}'.format(name, targ.tname())
+        instance_name = f'{name}_{targ.tname()}'
         super().__init__(ret_type, instance_name, params, may_throw, **args)
 
         self.tpl_name = name
@@ -2350,15 +2314,15 @@ class MemFunTmplInstance(MemFun):
                 }
         cpp_chain_call = self.cpp_chain_call(**chain_args)
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return '    {};\n'.format(result)
+        return f'    {result};\n'
 
 
 class MemFunTmpl(MultiMemFun):
     def __init__(self,
-                 types: List[Par],
+                 types: list[Par],
                  ret_type: Par,
                  name: str,
-                 params: Optional[List[Par]] = None,
+                 params: Optional[list[Par]] = None,
                  may_throw: bool = False,
                  **args: Any
                  ) -> None:
@@ -2381,7 +2345,7 @@ class MemFunTmpl(MultiMemFun):
             types: Types for which this template can be instantiated.
             ret_type: Description of the return value.
             name: Name of the member.
-            params: List of in/out parameters.
+            params: list of in/out parameters.
             cpp_func_name: Name of C++ member function to call.
             cpp_chain_call: Function that produces the C++ chain call.
         """
@@ -2389,7 +2353,7 @@ class MemFunTmpl(MultiMemFun):
         self.types = types
         self.ret_type = ret_type
         self.name = name
-        self.params = params if params else list()  # type: List[Par]
+        self.params = params if params else list()  # type: list[Par]
         self.may_throw = may_throw
 
         # generate instances
@@ -2402,7 +2366,7 @@ class MemFunTmpl(MultiMemFun):
                     instance_ret_type = copy(instance_ret_type)
                     instance_ret_type.elem_type = typ
 
-            instance_params = list()    # type: List[Par]
+            instance_params = list()    # type: list[Par]
             for param in self.params:
                 if isinstance(param, T):
                     new_param = copy(typ)
@@ -2441,12 +2405,12 @@ class OverloadSet(Member):
     idea. This class specifies a set of member functions to aggregate
     under a single name.
     """
-    def __init__(self, name: str, names: List[str], is_constructor: bool) -> None:
+    def __init__(self, name: str, names: list[str], is_constructor: bool) -> None:
         """Create an OverloadSet.
 
         Args:
             name: Name of the overloaded function to generate.
-            names: List of function names to aggregate.
+            names: list of function names to aggregate.
             is_constructor: Whether this overload set is for a constructor.
         """
         super().__init__(name)
@@ -2471,7 +2435,7 @@ class OverloadSet(Member):
         return ''
 
     def fortran_overload(self) -> str:
-        prefix = '{}_{}'.format(self.f_prefix, self.class_name)
+        prefix = f'{self.f_prefix}_{self.class_name}'
         interfaces = [f'{prefix}_{self.name}']
         # do not generate a fortran constructor for named constructors like create_grid
         if self.is_constructor and self.name == 'create':
@@ -2479,7 +2443,7 @@ class OverloadSet(Member):
 
         result = ''
         for interface in interfaces:
-            result += '    interface {}\n'.format(interface)
+            result += f'    interface {interface}\n'
             result += '        module procedure &\n'
 
             names = ['{}{}_{}'.format(12*' ', prefix, name)
@@ -2494,8 +2458,7 @@ class OverloadSet(Member):
         """Create a Fortran statement declaring us public.
         """
         if self.public:
-            return '    public :: {}_{}_{}\n'.format(
-                    self.f_prefix, self.class_name, self.name)
+            return f'    public :: {self.f_prefix}_{self.class_name}_{self.name}\n'
         return ''
 
     def fortran_contains_definition(self) -> str:
@@ -2513,14 +2476,14 @@ class OverloadSetTmpl(MultiMemFun):
     value.
     """
     def __init__(
-            self, types: List[Par], name: str, names: List[str], is_constructor: bool
+            self, types: list[Par], name: str, names: list[str], is_constructor: bool
             ) -> None:
         """Create an OverloadSetTmpl.
 
         Args:
             types: Types for which this template can be instantiated.
             name: Name of the overloaded function to generate.
-            names: List of function names to aggregate.
+            names: list of function names to aggregate.
             is_constructor: Whether this overload set is for a constructor.
         """
         super().__init__()
@@ -2554,7 +2517,7 @@ class NamespaceMember(abc.ABC):
         self.public: Optional[bool] = None
         self.name = name
 
-    def set_ns_prefix(self, ns_for_name: Dict[str, Tuple[str, str]]) -> None:
+    def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         """Sets the namespace prefix correctly for all members.
 
         Args:
@@ -2607,13 +2570,13 @@ class Class(NamespaceMember):
     def __init__(
             self,
             name: str, parent: Optional['Class'],
-            members: List[Member]
+            members: list[Member]
             ) -> None:
         """Create a class description.
 
         Args:
             name: Name of the class.
-            members: List of member functions.
+            members: list of member functions.
         """
         super().__init__(name)
 
@@ -2635,7 +2598,7 @@ class Class(NamespaceMember):
                 else:
                     self.members.append(member)
 
-    def set_ns_prefix(self, ns_for_name: Dict[str, Tuple[str, str]]) -> None:
+    def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         super().set_ns_prefix(ns_for_name)
         for member in self.members:
             member.set_ns_prefix(ns_for_name)
@@ -2673,14 +2636,14 @@ class Class(NamespaceMember):
     def fortran_type_definition(self) -> str:
         """Create a Fortran type/handle definition for this class.
         """
-        result = 'type {}_{}\n'.format(self.f_prefix, self.name)
+        result = f'type {self.f_prefix}_{self.name}\n'
         result += '    integer (c_intptr_t) :: ptr = 0\n'
         ctn = ''.join(member.fortran_contains_definition() for member in self.members)
         if ctn:
             result += 'contains\n' + ctn
-        result += 'end type {}_{}\n'.format(self.f_prefix, self.name)
+        result += f'end type {self.f_prefix}_{self.name}\n'
         if self.public:
-            result += 'public :: {}_{}\n'.format(self.f_prefix, self.name)
+            result += f'public :: {self.f_prefix}_{self.name}\n'
         result += '\n'
         return indent(result, 4*' ')
 
@@ -2702,12 +2665,12 @@ class Class(NamespaceMember):
 
 
 class Enum(NamespaceMember):
-    def __init__(self, name: str, values: List[Tuple[str, int]]) -> None:
+    def __init__(self, name: str, values: list[tuple[str, int]]) -> None:
         """Create an enumeration description.
 
         Args:
             name: Name of the enum.
-            values: List of name, value pairs.
+            values: list of name, value pairs.
         """
         super().__init__(name)
         self.values = values
@@ -2720,15 +2683,18 @@ class Enum(NamespaceMember):
         if self.public:
             public = ', public'
         for val_name, val_value in self.values:
-            result += 'integer, parameter{} :: {}_{}_{} = {}\n'.format(
-                    public, self.f_prefix, self.name, val_name, val_value)
-        result += ('integer, parameter{0} :: {1}_{2} = selected_int_kind(9)\n\n'
-                   ).format(public, self.f_prefix, self.name)
+            result += (
+                    f'integer, parameter{public} ::'
+                    f' {self.f_prefix}_{self.name}_{val_name} = {val_value}\n')
+
+        result += (
+            f'integer, parameter{public} :: {self.f_prefix}_{self.name} ='
+            ' selected_int_kind(9)\n\n')
         return indent(result, 4*' ')
 
 
 class Flags(NamespaceMember):
-    def __init__(self, name: str, values: List[str]):
+    def __init__(self, name: str, values: list[str]):
         """Create a Flags description.
 
         Flags are an enum class in C++, but a custom derived type with boolean
@@ -2788,8 +2754,8 @@ class Namespace:
                     all (used for forward declarations).
             c_prefix: Short prefix to use in C function names.
             f_prefix: Short prefix to use in Fortran function names.
-            enums: List of enums in this namespace.
-            classes: List of classes in this namespace.
+            enums: list of enums in this namespace.
+            classes: list of classes in this namespace.
         """
         self.name = name
         self.public = public
@@ -2800,7 +2766,7 @@ class Namespace:
         for member in self.members:
             member.set_public(public)
 
-    def set_ns_prefix(self, ns_for_name: Dict[str, Tuple[str, str]]) -> None:
+    def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         """Sets the namespace prefix correctly for all members.
 
         Args:
@@ -2819,13 +2785,15 @@ class Namespace:
         if self.public:
             public = ', public'
         for err_name, err_code in error_codes.items():
-            result += '    integer, parameter{} :: {}_{} = {}\n'.format(
-                    public, self.f_prefix, err_name, err_code)
+            result += (
+                    f'    integer, parameter{public} :: {self.f_prefix}_{err_name} ='
+                    f' {err_code}\n')
         result += '\n'
 
         for kind_name, kind_def in kinds.items():
-            result += '    integer, parameter{} :: {}_{} = {}\n'.format(
-                    public, self.f_prefix, kind_name, kind_def)
+            result += (
+                    f'    integer, parameter{public} :: {self.f_prefix}_{kind_name} ='
+                    f' {kind_def}\n')
         result += '\n'
 
         for member in self.members:
@@ -2865,8 +2833,8 @@ class Namespace:
 
 class API:
     def __init__(
-            self, name: str, headers: List[str], uses: List[str],
-            namespaces: List[Namespace]) -> None:
+            self, name: str, headers: list[str], uses: list[str],
+            namespaces: list[Namespace]) -> None:
         """Create an API description.
 
         The API name will be used as module name in Fortran.
@@ -2874,7 +2842,7 @@ class API:
         Args:
             name: Name of the API.
             headers: Headers to include in the Fortran C wrapper file.
-            uses: List of Fortran modules used by this module.
+            uses: list of Fortran modules used by this module.
             namespaces: Namespaces making up the API.
         """
         self.name = name
@@ -2883,7 +2851,7 @@ class API:
         self.namespaces = namespaces
 
         # set ns_prefix throughout the description
-        ns_for_name: Dict[str, Tuple[str, str]] = dict()
+        ns_for_name: dict[str, tuple[str, str]] = dict()
         for namespace in self.namespaces:
             for member in namespace.members:
                 ns_for_name[member.name] = (namespace.c_prefix, namespace.f_prefix)
@@ -2910,10 +2878,10 @@ class API:
         created by fortran_c_wrapper(), and the public Fortran API.
         """
         result = banner('!')
-        result += 'module {}\n'.format(self.name)
+        result += f'module {self.name}\n'
         result += '    use iso_c_binding\n'
         for dep in self.uses:
-            result += '    use {}\n'.format(dep)
+            result += f'    use {dep}\n'
         result += '\n'
         result += '    private\n\n'
 
@@ -2929,7 +2897,7 @@ class API:
         for ns in self.namespaces:
             result += ns.fortran_functions()
             result += '\n'
-        result += 'end module {}\n'.format(self.name)
+        result += f'end module {self.name}\n'
         return result
 
     def _fc_includes(self) -> str:
@@ -2937,7 +2905,7 @@ class API:
         """
         result = ''
         for header in self.headers:
-            result += '#include <{}>\n'.format(header)
+            result += f'#include <{header}>\n'
         result += '\n\n'
         return result
 
@@ -2949,7 +2917,7 @@ class API:
         result = ''
         for namespace in self.namespaces:
             for member in namespace.members:
-                result += 'using {}::{};\n'.format(namespace.name, member.name)
+                result += f'using {namespace.name}::{member.name};\n'
         result += '\n\n'
         return result
 

--- a/scripts/convert_fortran_source.py
+++ b/scripts/convert_fortran_source.py
@@ -1,6 +1,5 @@
 import re
 import pathlib
-from typing import List
 
 import click
 
@@ -9,7 +8,7 @@ import click
 @click.argument("fortran_files", nargs=-1, required=True, type=click.Path(
             exists=True, file_okay=True, dir_okay=False, readable=True,
             allow_dash=True, resolve_path=True, path_type=pathlib.Path))
-def convert(fortran_files: List[pathlib.Path]) -> None:
+def convert(fortran_files: list[pathlib.Path]) -> None:
     """Convert a Fortran file using the old-style Fortran libmuscle API to the new
     object-oriented API.
     """

--- a/scripts/make_libmuscle_api.py
+++ b/scripts/make_libmuscle_api.py
@@ -3,7 +3,7 @@
 import argparse
 from copy import copy, deepcopy
 from textwrap import dedent
-from typing import List, cast
+from typing import cast
 
 from api_generator import (
         API, Array, AssignmentOperator, Bool, Bytes, Char, Class, Constructor,
@@ -50,23 +50,24 @@ class GridConstructor(MultiMemFun):
             typ.name = 'data_array'
             typ.set_ns_prefix({}, 'LIBMUSCLE', 'LIBMUSCLE')
 
-            instance_params: List[Par] = [Array(1, copy(typ), 'data_array')]
+            instance_params: list[Par] = [Array(1, copy(typ), 'data_array')]
             if not with_names:
-                instance_name = 'grid_{}_a'.format(typ.tname())
-                chain_call = lambda **kwargs: (  # noqa: E731
-                        '{}::grid(data_array_p,'
-                        ' data_array_shape_v, {{}},'
-                        ' libmuscle::StorageOrder::first_adjacent'
-                        ')').format(kwargs['class_name'])
+                instance_name = f'grid_{typ.tname()}_a'
+                def flex_chain_call(**kwargs: str) -> str:
+                    return (
+                        f'{kwargs["class_name"]}::grid(data_array_p,'
+                        ' data_array_shape_v, {},'
+                        ' libmuscle::StorageOrder::first_adjacent)')
                 self.instances.append(NamedConstructor(
                     instance_params, instance_name, cpp_func_name='grid',
-                    cpp_chain_call=chain_call, f_override=''))
+                    cpp_chain_call=flex_chain_call, f_override=''))
             else:
                 for i in range(1, 8):
-                    arg_name = 'index_name_{}'.format(i)
+                    arg_name = f'index_name_{i}'
                     instance_params.append(String(arg_name))
-                instance_name = 'grid_{}_n'.format(typ.tname())
-                fc_override = dedent("""\
+                instance_name = f'grid_{typ.tname()}_n'
+
+                tmpl = dedent("""\
                     std::intptr_t $C_PREFIX$_$CLASSNAME$_create_grid_{0}_n_(
                             {1} * data_array,
                             std::size_t * data_array_shape,
@@ -103,7 +104,9 @@ class GridConstructor(MultiMemFun):
                                 names_v, libmuscle::StorageOrder::first_adjacent));
                         return reinterpret_cast<std::intptr_t>(result);
                     }}\n
-                    """).format(typ.tname(), typ.fc_cpp_type())
+                    """)
+                fc_override = tmpl.format(typ.tname(), typ.fc_cpp_type())
+
                 self.instances.append(NamedConstructor(
                     instance_params, instance_name, fc_override=fc_override,
                     f_override=''))
@@ -114,23 +117,23 @@ class GridConstructor(MultiMemFun):
                 instance_params = [Array(ndims, copy(typ), 'data_array')]
                 if with_names:
                     for i in range(1, ndims+1):
-                        arg_name = 'index_name_{}'.format(i)
+                        arg_name = f'index_name_{i}'
                         instance_params.append(String(arg_name))
 
-                instance_name = 'grid_{}_{}_{}'.format(
-                        ndims, typ.tname(), 'n' if with_names else 'a')
+                instance_name = (
+                        f'grid_{ndims}_{typ.tname()}_{"n" if with_names else "a"}')
 
                 if with_names:
                     arg_list = [
-                            'index_name_{}'.format(i)
+                            f'index_name_{i}'
                             for i in range(1, ndims+1)]
                     name_args = ', &\n        '.join(arg_list)
                     name_types = ''.join([
-                            '    character (len=*), intent(in) :: {}\n'.format(arg)
+                            f'    character (len=*), intent(in) :: {arg}\n'
                             for arg in arg_list])
                     name_params = ', &\n'.join([(
-                        '            index_name_{0},'
-                        ' int(len(index_name_{0}), c_size_t)').format(dim)
+                        f'            index_name_{dim},'
+                        f' int(len(index_name_{dim}), c_size_t)')
                         for dim in range(1, ndims+1)])
                     if ndims < 7:
                         name_params += ', &\n'
@@ -141,7 +144,7 @@ class GridConstructor(MultiMemFun):
 
                     dim_list = ', '.join([':'] * ndims)
 
-                    f_override = dedent("""\
+                    tmpl = dedent("""\
                         function $F_PREFIX$_$CLASSNAME$_create_grid_{0}_{1}_n( &
                                 data_array, &
                                 {2})
@@ -163,7 +166,8 @@ class GridConstructor(MultiMemFun):
                             $F_PREFIX$_$CLASSNAME$_create_grid_{0}_{1}_n%ptr = ret_val
                         end function $F_PREFIX$_$CLASSNAME$_create_grid_{0}_{1}_n
 
-                        """).format(  # noqa: E501
+                        """)    # noqa: E501 Line too long
+                    f_override = tmpl.format(
                                 ndims, typ.tname(), name_args, name_types.strip(),
                                 name_params, filler_params,
                                 typ.f_type()[0][0], typ.f_chain_arg(),
@@ -173,14 +177,14 @@ class GridConstructor(MultiMemFun):
                         instance_params, instance_name,
                         f_override=f_override, fc_override=''))
                 else:
-                    chain_call = lambda tname=typ.tname(), **a: (  # noqa: E731
-                            '{}_{}_create_grid_{}_a_( &\n{})'.format(
-                                a['ns_prefix'], a['class_name'], tname,
-                                a['fc_args']))
+                    def inst_chain_call(tname: str = typ.tname(), **a: str) -> str:
+                        return (
+                            f'{a["ns_prefix"]}_{a["class_name"]}_create_grid_'
+                            f'{tname}_a_( &\n{a["fc_args"]})')
 
                     self.instances.append(NamedConstructor(
                         instance_params, instance_name, cpp_func_name='grid',
-                        fc_chain_call=chain_call, fc_override=''))
+                        fc_chain_call=inst_chain_call, fc_override=''))
 
     def __copy__(self) -> 'GridConstructor':
         result = GridConstructor(self.with_names)
@@ -214,8 +218,8 @@ class Elements(MultiMemFun):
             # The dict is only used by Obj, which we don't have.
             typ.name = 'elements'
             typ.set_ns_prefix({}, 'LIBMUSCLE', 'LIBMUSCLE')
-            func_name = 'elements_{}'.format(typ.tname())
-            fc_override = dedent("""\
+            func_name = f'elements_{typ.tname()}'
+            tmpl = dedent("""\
                     void $C_PREFIX$_$CLASSNAME$_elements_{0}_(
                             std::intptr_t self,
                             std::size_t ndims,
@@ -247,7 +251,8 @@ class Elements(MultiMemFun):
                         }}
                     }}
 
-                    """).format(typ.tname(), typ.fc_cpp_type())  # noqa: E501
+                    """)    # noqa: E501 Line too long
+            fc_override = tmpl.format(typ.tname(), typ.fc_cpp_type())
 
             self.instances.append(MemFun(
                     Array(1, copy(typ), 'elements'), func_name, [Sizet('ndims')],
@@ -256,10 +261,10 @@ class Elements(MultiMemFun):
         # Generate API
         for typ in self.types:
             for ndims in range(1, 8):
-                func_name = 'elements_{}_{}'.format(ndims, typ.tname())
+                func_name = f'elements_{ndims}_{typ.tname()}'
                 dims_list = ', '.join([':']*ndims)
                 rev_dims = ', '.join(map(str, reversed(range(1, ndims+1))))
-                f_override = dedent("""\
+                tmpl = dedent("""\
                     subroutine $F_PREFIX$_$CLASSNAME$_elements_{0}_{1}( &
                             self, &
                             elements, &
@@ -329,7 +334,8 @@ class Elements(MultiMemFun):
                         end if
                     end subroutine $F_PREFIX$_$CLASSNAME$_elements_{0}_{1}
 
-                    """).format(  # noqa: E501
+                    """)    # noqa: E501 Line too long
+                f_override = tmpl.format(
                         ndims, typ.tname(), typ.f_ret_type()[1][0][0],
                         dims_list, typ.fi_ret_type()[0][0], rev_dims)
 
@@ -353,7 +359,7 @@ class Elements(MultiMemFun):
 
 
 create_grid_overloads = [
-        'create_grid_{}_{}_{}'.format(ndims, typ, with_names_tag)
+        f'create_grid_{ndims}_{typ}_{with_names_tag}'
         for ndims in range(1, 8)
         for typ in ['logical', 'int4', 'int8', 'real4', 'real8']
         for with_names_tag in ['n', 'a']]
@@ -791,12 +797,10 @@ message_desc = Class('Message', None, [
         cpp_chain_call=lambda **kwargs: 'self_p->data()'),
     MemFun(
         Void(), 'set_data_d', [Obj('Data', 'data')],
-        cpp_chain_call=lambda **kwargs: 'self_p->set_data({})'.format(
-            kwargs['cpp_args'])),
+        cpp_chain_call=lambda **kwargs: f'self_p->set_data({kwargs["cpp_args"]})'),
     MemFun(
         Void(), 'set_data_dcr', [Obj('DataConstRef', 'data')],
-        cpp_chain_call=lambda **kwargs: 'self_p->set_data({})'.format(
-            kwargs['cpp_args'])),
+        cpp_chain_call=lambda **kwargs: f'self_p->set_data({kwargs["cpp_args"]})'),
     OverloadSet('set_data', ['set_data_d', 'set_data_dcr'], False),
     MemFun(Bool(), 'has_settings'),
     MemFun(
@@ -962,22 +966,21 @@ instance_members = [
         [String(), Int64t(), Double(), Bool(), VecInt64t('value'), VecDbl('value'),
          Vec2Dbl('value')],
         Bool(), 'is_setting_a', [String('name')], True,
-        cpp_chain_call=lambda **kwargs: 'self_p->get_setting({}).is_a<{}>()'.format(
-                kwargs['cpp_args'], kwargs['tpl_type'])
-        ),
+        cpp_chain_call=lambda **kwargs:\
+            f'self_p->get_setting({kwargs["cpp_args"]}).is_a<{kwargs["tpl_type"]}>()'),
     MemFunTmpl(
         [String(), Int64t(), Double(), Bool(), VecInt64t('value'), VecDbl('value'),
          Vec2Dbl('value')],
         T(), 'get_setting_as1', [String('name')], True,
-        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs: (
-            f'self_p->get_setting_as<{tpl_type}>({cpp_args})')),
+        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs:\
+            f'self_p->get_setting_as<{tpl_type}>({cpp_args})'),
     MemFunTmpl(
         [String(), Int64t(), Double(), Bool(), VecInt64t('value'),
          VecDbl('value'), Vec2Dbl('value')],
         T(), 'get_setting_as2',
         [String('name'), T('default_value')], True,
-        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs: (
-            f'self_p->get_setting_as<{tpl_type}>({cpp_args})')),
+        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs:\
+            f'self_p->get_setting_as<{tpl_type}>({cpp_args})'),
     OverloadSetTmpl(
         [String(), Int64t(), Double(), Bool(), VecInt64t('value'),
          VecDbl('value'), Vec2Dbl('value')],
@@ -992,54 +995,48 @@ instance_members = [
 
     MemFun(Void(), 'send_pm',
            [String('port_name'), Obj('Message', 'message')],
-           cpp_chain_call=lambda **kwargs: 'self_p->send({})'.format(
-               kwargs['cpp_args'])),
+           cpp_chain_call=lambda **kwargs: f'self_p->send({kwargs["cpp_args"]})'),
     MemFun(Void(), 'send_pms',
            [String('port_name'), Obj('Message', 'message'), Int('slot')],
-           cpp_chain_call=lambda **kwargs: 'self_p->send({})'.format(
-               kwargs['cpp_args'])),
+           cpp_chain_call=lambda **kwargs: f'self_p->send({kwargs["cpp_args"]})'),
     OverloadSet('send', ['send_pm', 'send_pms'], False),
 
     MemFun(Obj('Message'), 'receive_p', [String('port_name')], True,
-           cpp_chain_call=lambda **kwargs: 'self_p->receive({})'.format(
-               kwargs['cpp_args'])),
+           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
     MemFun(Obj('Message'), 'receive_pd',
            [String('port_name'), Obj('Message', 'default_msg')], True,
-           cpp_chain_call=lambda **kwargs: 'self_p->receive({})'.format(
-               kwargs['cpp_args'])),
+           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
     OverloadSet('receive', ['receive_p', 'receive_pd'], False),
 
     MemFun(Obj('Message'), 'receive_ps', [String('port_name'), Int('slot')],
            True,
-           cpp_chain_call=lambda **kwargs: 'self_p->receive({})'.format(
-               kwargs['cpp_args'])),
+           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
     MemFun(Obj('Message'), 'receive_psd',
            [String('port_name'), Int('slot'), Obj('Message', 'default_message')],
            True,
-           cpp_chain_call=lambda **kwargs: 'self_p->receive({})'.format(
-               kwargs['cpp_args'])),
+           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
     OverloadSet('receive_on_slot', ['receive_ps', 'receive_psd'], False),
 
     MemFun(Obj('Message'), 'receive_with_settings_p',
            [String('port_name')], True,
-           cpp_chain_call=lambda **kwargs: ('self_p->receive_with_settings({})'.format(
-               kwargs['cpp_args']))),
+           cpp_chain_call=lambda **kwargs:
+                f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
     MemFun(Obj('Message'), 'receive_with_settings_pd',
            [String('port_name'), Obj('Message', 'default_msg')], True,
-           cpp_chain_call=lambda **kwargs: ('self_p->receive_with_settings({})'.format(
-               kwargs['cpp_args']))),
+           cpp_chain_call=lambda **kwargs:
+               f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
     OverloadSet('receive_with_settings',
-                ['receive_with_settings_p', 'receive_with_settings_pd'], False),
+               ['receive_with_settings_p', 'receive_with_settings_pd'], False),
 
     MemFun(Obj('Message'), 'receive_with_settings_ps',
            [String('port_name'), Int('slot')], True,
-           cpp_chain_call=lambda **kwargs: ('self_p->receive_with_settings({})'.format(
-               kwargs['cpp_args']))),
+           cpp_chain_call=lambda **kwargs:
+               f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
     MemFun(Obj('Message'), 'receive_with_settings_psd',
            [String('port_name'), Int('slot'), Obj('Message', 'default_msg')],
            True,
-           cpp_chain_call=lambda **kwargs: ('self_p->receive_with_settings({})'.format(
-               kwargs['cpp_args']))),
+           cpp_chain_call=lambda **kwargs:
+               f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
     OverloadSet('receive_with_settings_on_slot',
                 ['receive_with_settings_ps', 'receive_with_settings_psd'], False),
     MemFun(Bool(), 'resuming'),


### PR DESCRIPTION
This enables the `UP` and `B` issue categories in ruff, after which it accuses us of a great many crimes. Being the most guilty developer of all, I went and fixed most of them, and successfully argued with the judge in the remaining ones.

An overview of the types of problems encountered:

### UP
- `Dict`, `List`, `Tuple`, `Set`, `Type` deprecated in favour of their lower-case counterparts
- Various imports from typing that should be from collections.abc
- Use of `.format()` on string literals where an f-string could be used
- Extraneous parentheses in generator expressions
- Extraneous `'r'` mode in `open()` calls
- `functools.cache` is more efficient than` lru_cache` and equivalent if size is infinite
- `%`-formatting is deprecated, but I left those in as they match the `logging` docs exactly

### B
- Unused loop variables
- `@cache` potential memory leak (pleaded innocence, no actual harm done)
- Better warnings by setting stacklevel
- Function call in argument default (`InstanceFlags(0)`)

I also tried to enable `SIM`, but disagreed with most of what it said, so I've left it off. I tried `I` (isort) as well, and like it well enough, but it uncovered a circular import, and I wanted to fix that by moving a class out of `snapshot.py` and then realised that I don't like the use of inheritance in there. So I'm leaving that off for now as well, maybe I'll do some refactoring when I get the time. (Note that I'm not sure why the circular import doesn't show up currently, but we'll take it for now :smile:)