### PR TITLE
Apply ruff format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ruff format
+21c7b67169ec1071b8bb0f67c32f606dc4f0ef71

--- a/integration_test/cluster_test/base_env.py
+++ b/integration_test/cluster_test/base_env.py
@@ -16,15 +16,15 @@ def component() -> None:
     """
     instance = Instance()
 
-    print(os.environ.get('PROFILE_LOADED', '0'))
-    print(os.environ.get('BASHRC_LOADED', '0'))
-    print(os.environ.get('MANAGER_SHELL', '0'))
-    print('1' if 'slurm' in os.environ['PATH'] else '0')
-    print(os.environ.get('VIRTUAL_ENV', ''))
+    print(os.environ.get("PROFILE_LOADED", "0"))
+    print(os.environ.get("BASHRC_LOADED", "0"))
+    print(os.environ.get("MANAGER_SHELL", "0"))
+    print("1" if "slurm" in os.environ["PATH"] else "0")
+    print(os.environ.get("VIRTUAL_ENV", ""))
 
     while instance.reuse_instance():
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     component()

--- a/integration_test/cluster_test/component.py
+++ b/integration_test/cluster_test/component.py
@@ -10,7 +10,7 @@ from libmuscle import Instance, Message
 def log_location() -> None:
     """Log where we are running so that the test can check for it."""
     print(socket.gethostname())
-    print(','.join(map(str, sorted(os.sched_getaffinity(0)))))
+    print(",".join(map(str, sorted(os.sched_getaffinity(0)))))
 
 
 def component() -> None:
@@ -19,30 +19,33 @@ def component() -> None:
     This sends and receives on all operators, allowing different coupling patterns
     with a single program.
     """
-    instance = Instance({
-            Operator.F_INIT: ['init_in'],
-            Operator.O_I: ['inter_out'],
-            Operator.S: ['inter_in'],
-            Operator.O_F: ['final_out']})
+    instance = Instance(
+        {
+            Operator.F_INIT: ["init_in"],
+            Operator.O_I: ["inter_out"],
+            Operator.S: ["inter_in"],
+            Operator.O_F: ["final_out"],
+        }
+    )
 
     while instance.reuse_instance():
         # F_INIT
-        steps = instance.get_setting('steps', 'int')
+        steps = instance.get_setting("steps", "int")
 
-        instance.receive('init_in', default=Message(0.0))
+        instance.receive("init_in", default=Message(0.0))
 
         for step in range(steps):
             # O_I
-            instance.send('inter_out', Message(step))
+            instance.send("inter_out", Message(step))
 
             # S
-            instance.receive('inter_in', default=Message(0.0))
+            instance.receive("inter_in", default=Message(0.0))
 
         # O_F
-        instance.send('final_out', Message(steps))
+        instance.send("final_out", Message(steps))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.basicConfig()
     logging.getLogger().setLevel(logging.INFO)
 

--- a/integration_test/cluster_test/conftest.py
+++ b/integration_test/cluster_test/conftest.py
@@ -148,17 +148,14 @@ def _start_nodes(local_term, slurm_version, net_name, shared_dir):
 
         image_name = _image_name(slurm_version)
 
-        run_cmd(
-            local_term,
-            60,
-            (
-                f"docker run -d --name={node_name}-{slurm_version} --hostname={hostname}"
-                f" --network={net_name} --cap-add=CAP_SYS_NICE"
-                f" --env SLURM_VERSION={slurm_version}"
-                f" --mount type=bind,source={shared_dir},target={REMOTE_SHARED}"
-                f" {image_name}"
-            ),
+        command = (
+            f"docker run -d --name={node_name}-{slurm_version} --hostname={hostname}"
+            f" --network={net_name} --cap-add=CAP_SYS_NICE"
+            f" --env SLURM_VERSION={slurm_version}"
+            f" --mount type=bind,source={shared_dir},target={REMOTE_SHARED}"
+            f" {image_name}"
         )
+        run_cmd(local_term, 60, command)
 
 
 def _start_headnode(local_term, slurm_version, net_name, shared_dir, headnode_port):

--- a/integration_test/cluster_test/conftest.py
+++ b/integration_test/cluster_test/conftest.py
@@ -10,22 +10,37 @@ import pytest
 _logger = logging.getLogger(__name__)
 
 
-IMAGE_NAME = 'muscle3_test_cluster'
+IMAGE_NAME = "muscle3_test_cluster"
 
-REMOTE_SHARED = '/home/cerulean/shared'
+REMOTE_SHARED = "/home/cerulean/shared"
 
-IDX_SLURM_VERSIONS = list(enumerate([
-    '17-02', '17-11', '18-08', '19-05', '20-02', '20-11', '21-08', '22-05', '23-02',
-    '23-11', '24-05', '24-11'
-    ]))
+IDX_SLURM_VERSIONS = list(
+    enumerate(
+        [
+            "17-02",
+            "17-11",
+            "18-08",
+            "19-05",
+            "20-02",
+            "20-11",
+            "21-08",
+            "22-05",
+            "23-02",
+            "23-11",
+            "24-05",
+            "24-11",
+        ]
+    )
+)
 
 # Shut down the containers after running the tests. Set to False to debug.
 CLEAN_UP_CONTAINERS = True
 
 
 skip_unless_cluster = pytest.mark.skipif(
-        'MUSCLE_TEST_CLUSTER' not in os.environ,
-        reason='Cluster tests were not explicitly enabled')
+    "MUSCLE_TEST_CLUSTER" not in os.environ,
+    reason="Cluster tests were not explicitly enabled",
+)
 
 
 def run_cmd(term, timeout, command):
@@ -36,50 +51,60 @@ def run_cmd(term, timeout, command):
     return out
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def local_term():
     return cerulean.LocalTerminal()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def local_fs():
     return cerulean.LocalFileSystem()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def repo_root(local_fs):
     root_dir = Path(__file__).parents[2]
     return local_fs / str(root_dir)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def fake_cluster_image(local_term):
-    run_cmd(local_term, 5400, (
-        f'docker buildx build -t {IMAGE_NAME}'
-        ' -f integration_test/fake_cluster/Dockerfile .'))
+    run_cmd(
+        local_term,
+        5400,
+        (
+            f"docker buildx build -t {IMAGE_NAME}"
+            " -f integration_test/fake_cluster/Dockerfile ."
+        ),
+    )
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def fake_cluster_image_old(local_term):
-    run_cmd(local_term, 5400, (
-        f'docker buildx build -t {IMAGE_NAME}_old'
-        ' -f integration_test/fake_cluster/old.Dockerfile .'))
+    run_cmd(
+        local_term,
+        5400,
+        (
+            f"docker buildx build -t {IMAGE_NAME}_old"
+            " -f integration_test/fake_cluster/old.Dockerfile ."
+        ),
+    )
 
 
 def _image_name(slurm_version):
-    if slurm_version <= '20-02':
-        return IMAGE_NAME + '_old'
+    if slurm_version <= "20-02":
+        return IMAGE_NAME + "_old"
     return IMAGE_NAME
 
 
 def _gcc_version(slurm_version):
-    if slurm_version <= '20-02':
-        return '7.5.0'
-    return '11.4.0'
+    if slurm_version <= "20-02":
+        return "7.5.0"
+    return "11.4.0"
 
 
 def ssh_term(port, timeout_msg):
-    cred = cerulean.PasswordCredential('cerulean', 'kingfisher')
+    cred = cerulean.PasswordCredential("cerulean", "kingfisher")
     ready = False
     start = time.monotonic()
     while not ready:
@@ -87,7 +112,7 @@ def ssh_term(port, timeout_msg):
             raise Exception(timeout_msg)
 
         try:
-            term = cerulean.SshTerminal('localhost', port, cred)
+            term = cerulean.SshTerminal("localhost", port, cred)
             ready = True
         except Exception:
             time.sleep(3.0)
@@ -95,7 +120,7 @@ def ssh_term(port, timeout_msg):
     return term
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def shared_dir():
     # Note that pytest's tmp_path is function-scoped, so cannot be used here
     with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
@@ -104,44 +129,54 @@ def shared_dir():
         yield path
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def cleanup_docker(local_term):
     for _, slurm_version in IDX_SLURM_VERSIONS:
         _clean_up_base_cluster(local_term, slurm_version)
 
 
 def _create_network(local_term, slurm_version):
-    name = f'muscle3-net-{slurm_version}'
-    run_cmd(local_term, 60, f'docker network create {name}')
+    name = f"muscle3-net-{slurm_version}"
+    run_cmd(local_term, 60, f"docker network create {name}")
     return name
 
 
 def _start_nodes(local_term, slurm_version, net_name, shared_dir):
     for i in range(5):
-        node_name = f'node-{i}'
-        hostname = f'{node_name}.example.org'
+        node_name = f"node-{i}"
+        hostname = f"{node_name}.example.org"
 
         image_name = _image_name(slurm_version)
 
-        run_cmd(local_term, 60, (
-            f'docker run -d --name={node_name}-{slurm_version} --hostname={hostname}'
-            f' --network={net_name} --cap-add=CAP_SYS_NICE'
-            f' --env SLURM_VERSION={slurm_version}'
-            f' --mount type=bind,source={shared_dir},target={REMOTE_SHARED}'
-            f' {image_name}'))
+        run_cmd(
+            local_term,
+            60,
+            (
+                f"docker run -d --name={node_name}-{slurm_version} --hostname={hostname}"
+                f" --network={net_name} --cap-add=CAP_SYS_NICE"
+                f" --env SLURM_VERSION={slurm_version}"
+                f" --mount type=bind,source={shared_dir},target={REMOTE_SHARED}"
+                f" {image_name}"
+            ),
+        )
 
 
 def _start_headnode(local_term, slurm_version, net_name, shared_dir, headnode_port):
     image_name = _image_name(slurm_version)
 
-    run_cmd(local_term, 60, (
-        f'docker run -d --name=headnode-{slurm_version} --hostname=headnode'
-        f' --network={net_name} -p {headnode_port}:22'
-        f' --env SLURM_VERSION={slurm_version}'
-        f' --mount type=bind,source={shared_dir},target={REMOTE_SHARED}'
-        f' {image_name}'))
+    run_cmd(
+        local_term,
+        60,
+        (
+            f"docker run -d --name=headnode-{slurm_version} --hostname=headnode"
+            f" --network={net_name} -p {headnode_port}:22"
+            f" --env SLURM_VERSION={slurm_version}"
+            f" --mount type=bind,source={shared_dir},target={REMOTE_SHARED}"
+            f" {image_name}"
+        ),
+    )
 
-    ssh_term(headnode_port, 'Virtual cluster container start timed out').close()
+    ssh_term(headnode_port, "Virtual cluster container start timed out").close()
 
 
 def _start_base_cluster(local_term, idx_slurm_version, shared_dir):
@@ -153,104 +188,146 @@ def _start_base_cluster(local_term, idx_slurm_version, shared_dir):
     _start_nodes(local_term, slurm_version, net_name, shared_dir)
     _start_headnode(local_term, slurm_version, net_name, shared_dir, headnode_port)
 
-    term = ssh_term(headnode_port, 'Connection to virtual cluster container timed out')
+    term = ssh_term(headnode_port, "Connection to virtual cluster container timed out")
     fs = cerulean.SftpFileSystem(term, False)
 
     return term, fs, headnode_port
 
 
 def _install_remote_source(local_term, repo_root, remote_fs, slurm_version):
-    muscle3_tgt = remote_fs / 'home' / 'cerulean' / 'muscle3'
+    muscle3_tgt = remote_fs / "home" / "cerulean" / "muscle3"
     muscle3_tgt.mkdir()
 
-    container = f'headnode-{slurm_version}'
+    container = f"headnode-{slurm_version}"
 
     for f in (
-            'muscle3', 'libmuscle', 'scripts', 'docs', 'setup.py', 'Makefile',
-            'MANIFEST.in', 'LICENSE', 'NOTICE', 'VERSION', 'README.rst'):
-        run_cmd(local_term, 60, (
-            f'docker cp {repo_root / f} {container}:{muscle3_tgt / f}'))
+        "muscle3",
+        "libmuscle",
+        "scripts",
+        "docs",
+        "setup.py",
+        "Makefile",
+        "MANIFEST.in",
+        "LICENSE",
+        "NOTICE",
+        "VERSION",
+        "README.rst",
+    ):
+        run_cmd(
+            local_term, 60, (f"docker cp {repo_root / f} {container}:{muscle3_tgt / f}")
+        )
 
     # needs to run as root, so not run through remote_term
-    run_cmd(local_term, 60, (
-        f'docker exec {container} /bin/bash -c'
-        f' "chown -R cerulean:cerulean {muscle3_tgt}"'))
+    run_cmd(
+        local_term,
+        60,
+        (
+            f"docker exec {container} /bin/bash -c"
+            f' "chown -R cerulean:cerulean {muscle3_tgt}"'
+        ),
+    )
 
     return muscle3_tgt
 
 
 def _create_muscle3_venv(remote_term, remote_source):
-    run_cmd(remote_term, 10, f'python3 -m venv {REMOTE_SHARED}/venv')
-    in_venv = f'source {REMOTE_SHARED}/venv/bin/activate && '
+    run_cmd(remote_term, 10, f"python3 -m venv {REMOTE_SHARED}/venv")
+    in_venv = f"source {REMOTE_SHARED}/venv/bin/activate && "
 
-    run_cmd(remote_term, 30, (
-        f'/bin/bash -c "{in_venv} python3 -m pip install pip wheel setuptools"'))
+    run_cmd(
+        remote_term,
+        30,
+        (f'/bin/bash -c "{in_venv} python3 -m pip install pip wheel setuptools"'),
+    )
 
     run_cmd(remote_term, 60, f'/bin/bash -c "{in_venv} pip install {remote_source}"')
 
 
 def _install_muscle3_native_openmpi(
-        remote_source, remote_term, remote_fs, slurm_version):
-    prefix = remote_fs / REMOTE_SHARED / 'muscle3-openmpi'
+    remote_source, remote_term, remote_fs, slurm_version
+):
+    prefix = remote_fs / REMOTE_SHARED / "muscle3-openmpi"
     prefix.mkdir()
 
-    openmpi_hash = run_cmd(remote_term, 600, (
-        '/bin/bash -c "'
-        'for phash in $(/opt/spack/bin/spack find --format \\"{hash}\\" openmpi'
-        '        | tr \'\\n\' \' \') ; do'
-        '    if /opt/spack/bin/spack find --deps /\\${phash} |'
-        f'                grep -q slurm@{slurm_version} ; then'
-        '        echo \\${phash} ;'
-        '     fi ;'
-        'done'
-        '"'))
+    openmpi_hash = run_cmd(
+        remote_term,
+        600,
+        (
+            '/bin/bash -c "'
+            'for phash in $(/opt/spack/bin/spack find --format \\"{hash}\\" openmpi'
+            "        | tr '\\n' ' ') ; do"
+            "    if /opt/spack/bin/spack find --deps /\\${phash} |"
+            f"                grep -q slurm@{slurm_version} ; then"
+            "        echo \\${phash} ;"
+            "     fi ;"
+            "done"
+            '"'
+        ),
+    )
 
-    openmpi_version = run_cmd(remote_term, 600, (
-        '/bin/bash -c "'
-        f'/opt/spack/bin/spack find --format \\"{{version}}\\" /{openmpi_hash}'
-        '"')).strip()
+    openmpi_version = run_cmd(
+        remote_term,
+        600,
+        (
+            '/bin/bash -c "'
+            f'/opt/spack/bin/spack find --format \\"{{version}}\\" /{openmpi_hash}'
+            '"'
+        ),
+    ).strip()
 
     gcc_version = _gcc_version(slurm_version)
 
-    module_name = f'openmpi/{openmpi_version}-gcc-{gcc_version}-{openmpi_hash[:7]}'
+    module_name = f"openmpi/{openmpi_version}-gcc-{gcc_version}-{openmpi_hash[:7]}"
 
-    _logger.info(f'Slurm {slurm_version} and module {module_name}')
+    _logger.info(f"Slurm {slurm_version} and module {module_name}")
 
-    run_cmd(remote_term, 600, (
-        f'/bin/bash -l -c "'
-        f'module load {module_name} && '
-        f'cd {remote_source} && '
-        f'make distclean >distclean.log 2>&1 && '
-        f'PREFIX={prefix} make install >make.log 2>&1 || cat make.log"'))
+    run_cmd(
+        remote_term,
+        600,
+        (
+            f'/bin/bash -l -c "'
+            f"module load {module_name} && "
+            f"cd {remote_source} && "
+            f"make distclean >distclean.log 2>&1 && "
+            f'PREFIX={prefix} make install >make.log 2>&1 || cat make.log"'
+        ),
+    )
 
-    return 'openmpi', prefix, module_name
+    return "openmpi", prefix, module_name
 
 
-def _install_muscle3_native_intelmpi(
-        remote_source, remote_term, remote_fs):
-    prefix = remote_fs / REMOTE_SHARED / 'muscle3-intelmpi'
+def _install_muscle3_native_intelmpi(remote_source, remote_term, remote_fs):
+    prefix = remote_fs / REMOTE_SHARED / "muscle3-intelmpi"
     prefix.mkdir()
 
-    module_name = 'intel-oneapi-mpi'
+    module_name = "intel-oneapi-mpi"
 
-    run_cmd(remote_term, 600, (
-        f'/bin/bash -l -c "'
-        f'module load {module_name} && '
-        f'cd {remote_source} && '
-        f'make distclean >distclean.log 2>&1 && '
-        f'PREFIX={prefix} make install >make.log 2>&1 || cat make.log"'))
+    run_cmd(
+        remote_term,
+        600,
+        (
+            f'/bin/bash -l -c "'
+            f"module load {module_name} && "
+            f"cd {remote_source} && "
+            f"make distclean >distclean.log 2>&1 && "
+            f'PREFIX={prefix} make install >make.log 2>&1 || cat make.log"'
+        ),
+    )
 
-    return 'intelmpi', prefix, module_name
+    return "intelmpi", prefix, module_name
 
 
 def _install_muscle3(local_term, repo_root, remote_term, remote_fs, slurm_version):
     remote_source = _install_remote_source(
-            local_term, repo_root, remote_fs, slurm_version)
+        local_term, repo_root, remote_fs, slurm_version
+    )
     _create_muscle3_venv(remote_term, remote_source)
     openmpi_install = _install_muscle3_native_openmpi(
-            remote_source, remote_term, remote_fs, slurm_version)
+        remote_source, remote_term, remote_fs, slurm_version
+    )
     intelmpi_install = _install_muscle3_native_intelmpi(
-            remote_source, remote_term, remote_fs)
+        remote_source, remote_term, remote_fs
+    )
     return openmpi_install, intelmpi_install
 
 
@@ -259,45 +336,69 @@ def _install_tests(repo_root, remote_term, remote_fs, remote_m3_installs):
 
     for mpi_type, remote_m3, mpi_module in remote_m3_installs:
         cerulean.copy(
-                repo_root / 'integration_test' / 'cluster_test', remote_home,
-                copy_permissions=True)
+            repo_root / "integration_test" / "cluster_test",
+            remote_home,
+            copy_permissions=True,
+        )
 
-        remote_source = remote_home / 'cluster_test'
+        remote_source = remote_home / "cluster_test"
 
-        if mpi_type == 'openmpi':
-            run_cmd(remote_term, 30, (
-                '/bin/bash -c "'
-                f'sed -i \\"s^modules: openmpi^modules: {mpi_module}^\\"'
-                f' {remote_source}/implementations_openmpi.ymmsl'
-                '"'))
+        if mpi_type == "openmpi":
+            run_cmd(
+                remote_term,
+                30,
+                (
+                    '/bin/bash -c "'
+                    f'sed -i \\"s^modules: openmpi^modules: {mpi_module}^\\"'
+                    f" {remote_source}/implementations_openmpi.ymmsl"
+                    '"'
+                ),
+            )
 
-            run_cmd(remote_term, 30, (
-                '/bin/bash -c "'
-                f'sed -i \\"s^modules: openmpi^modules: {mpi_module}^\\"'
-                f' {remote_source}/implementations_srunmpi.ymmsl'
-                '"'))
+            run_cmd(
+                remote_term,
+                30,
+                (
+                    '/bin/bash -c "'
+                    f'sed -i \\"s^modules: openmpi^modules: {mpi_module}^\\"'
+                    f" {remote_source}/implementations_srunmpi.ymmsl"
+                    '"'
+                ),
+            )
 
-        run_cmd(remote_term, 30, (
-            f'/bin/bash -l -c "'
-            f'module load {mpi_module} && '
-            f'. {remote_m3}/bin/muscle3.env && '
-            f'make -C {remote_source} MPI_TYPE={mpi_type}"'))
+        run_cmd(
+            remote_term,
+            30,
+            (
+                f'/bin/bash -l -c "'
+                f"module load {mpi_module} && "
+                f". {remote_m3}/bin/muscle3.env && "
+                f'make -C {remote_source} MPI_TYPE={mpi_type}"'
+            ),
+        )
 
 
 def _clean_up_base_cluster(local_term, slurm_version):
-    node_names = [f'node-{i}-{slurm_version}' for i in range(5)]
-    run_cmd(local_term, 60, f'docker rm -f {" ".join(node_names)}')
+    node_names = [f"node-{i}-{slurm_version}" for i in range(5)]
+    run_cmd(local_term, 60, f"docker rm -f {' '.join(node_names)}")
 
-    run_cmd(local_term, 60, f'docker rm -f headnode-{slurm_version}')
+    run_cmd(local_term, 60, f"docker rm -f headnode-{slurm_version}")
 
-    net_name = f'muscle3-net-{slurm_version}'
-    run_cmd(local_term, 60, f'docker network rm -f {net_name}')
+    net_name = f"muscle3-net-{slurm_version}"
+    run_cmd(local_term, 60, f"docker network rm -f {net_name}")
 
 
-@pytest.fixture(scope='session', params=IDX_SLURM_VERSIONS)
+@pytest.fixture(scope="session", params=IDX_SLURM_VERSIONS)
 def installed_cluster(
-        request, cleanup_docker, fake_cluster_image, fake_cluster_image_old, shared_dir,
-        repo_root, local_term, assert_no_threads_left):
+    request,
+    cleanup_docker,
+    fake_cluster_image,
+    fake_cluster_image_old,
+    shared_dir,
+    repo_root,
+    local_term,
+    assert_no_threads_left,
+):
 
     slurm_version = request.param[1]
     local_shared_dir = shared_dir / slurm_version
@@ -305,9 +406,11 @@ def installed_cluster(
     local_shared_dir.chmod(0o1777)
 
     remote_term, remote_fs, headnode_port = _start_base_cluster(
-            local_term, request.param, local_shared_dir)
+        local_term, request.param, local_shared_dir
+    )
     remote_m3_installs = _install_muscle3(
-            local_term, repo_root, remote_term, remote_fs, slurm_version)
+        local_term, repo_root, remote_term, remote_fs, slurm_version
+    )
     _install_tests(repo_root, remote_term, remote_fs, remote_m3_installs)
 
     yield headnode_port
@@ -316,7 +419,7 @@ def installed_cluster(
     # different owner than what we're running with on the host, and the host user cannot
     # remove the files. So we do it here from inside the container
     if CLEAN_UP_CONTAINERS:
-        run_cmd(remote_term, 60, f'rm -rf {REMOTE_SHARED}/*')
+        run_cmd(remote_term, 60, f"rm -rf {REMOTE_SHARED}/*")
 
     remote_fs.close()
     remote_term.close()
@@ -325,7 +428,7 @@ def installed_cluster(
         _clean_up_base_cluster(local_term, slurm_version)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def hwthread_to_core():
     """Translates hwthreads to core ids.
 
@@ -338,21 +441,23 @@ def hwthread_to_core():
     a function that takes a comma-separated list of hwthread ids and returns a list of
     corresponding core ids.
     """
-    with open('/proc/cpuinfo') as f:
+    with open("/proc/cpuinfo") as f:
         cpuinfo = f.readlines()
 
     def get_values(cpuinfo, field):
         return [
-                int(line.split(':')[1].strip())
-                for line in cpuinfo if line.startswith(field)]
+            int(line.split(":")[1].strip())
+            for line in cpuinfo
+            if line.startswith(field)
+        ]
 
-    hwthread_ids = get_values(cpuinfo, 'processor')
-    core_ids = get_values(cpuinfo, 'core id')
+    hwthread_ids = get_values(cpuinfo, "processor")
+    core_ids = get_values(cpuinfo, "core id")
 
     table = dict(zip(hwthread_ids, core_ids))
 
     def convert(aff_ids):
-        cores = {table[i] for i in map(int, aff_ids.split(','))}
+        cores = {table[i] for i in map(int, aff_ids.split(","))}
         return sorted(cores)
 
     return convert

--- a/integration_test/cluster_test/test_cluster.py
+++ b/integration_test/cluster_test/test_cluster.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 @pytest.fixture
 def fake_cluster(installed_cluster):
     headnode_port = installed_cluster
-    term = ssh_term(headnode_port, 'Connection to virtual cluster container timed out')
+    term = ssh_term(headnode_port, "Connection to virtual cluster container timed out")
     with cerulean.SftpFileSystem(term, True) as fs:
         local_sched = cerulean.DirectGnuScheduler(term)
         slurm_sched = cerulean.SlurmScheduler(term)
@@ -30,12 +30,12 @@ def remote_home(fake_cluster):
 
 @pytest.fixture
 def remote_test_files(remote_home):
-    return remote_home / 'cluster_test'
+    return remote_home / "cluster_test"
 
 
 @pytest.fixture
 def remote_out_dir(remote_home):
-    return remote_home / 'test_results'
+    return remote_home / "test_results"
 
 
 def _make_base_job(name, remote_out_dir, dir_name):
@@ -45,58 +45,58 @@ def _make_base_job(name, remote_out_dir, dir_name):
     job = cerulean.JobDescription()
     job.name = name
     job.working_directory = job_dir
-    job.stdout_file = job_dir / 'stdout.txt'
-    job.stderr_file = job_dir / 'stderr.txt'
-    job.queue_name = 'debug'
+    job.stdout_file = job_dir / "stdout.txt"
+    job.stderr_file = job_dir / "stderr.txt"
+    job.queue_name = "debug"
     job.time_reserved = 60
-    job.system_out_file = job_dir / 'sysout.txt'
-    job.system_err_file = job_dir / 'syserr.txt'
-    job.extra_scheduler_options = '--ntasks-per-node=4'
+    job.system_out_file = job_dir / "sysout.txt"
+    job.system_err_file = job_dir / "syserr.txt"
+    job.extra_scheduler_options = "--ntasks-per-node=4"
 
     return job
 
 
 def _make_job(name, mode, remote_test_files, remote_out_dir):
-    job = _make_base_job(name, remote_out_dir, f'test_{name}_{mode}')
-    job.command = str(remote_test_files / f'{name}.sh')
+    job = _make_base_job(name, remote_out_dir, f"test_{name}_{mode}")
+    job.command = str(remote_test_files / f"{name}.sh")
     return job
 
 
 def _make_mpi_job(name, mode, execution_model, remote_test_files, remote_out_dir):
-    job = _make_base_job(name, remote_out_dir, f'test_{name}_{mode}_{execution_model}')
-    job.command = str(remote_test_files / f'{name}_{execution_model}.sh')
+    job = _make_base_job(name, remote_out_dir, f"test_{name}_{mode}_{execution_model}")
+    job.command = str(remote_test_files / f"{name}_{execution_model}.sh")
     return job
 
 
 def _sched(fake_cluster, mode):
-    if mode == 'local':
+    if mode == "local":
         return fake_cluster[2]
     else:
         return fake_cluster[3]
 
 
 def _run_cmd_dir(remote_out_dir, testname, mode, execution_model=None):
-    results_name = f'test_{testname}_{mode}'
+    results_name = f"test_{testname}_{mode}"
     if execution_model is not None:
-        results_name += f'_{execution_model}'
+        results_name += f"_{execution_model}"
 
     for p in (remote_out_dir / results_name).iterdir():
-        if p.name.startswith('run_'):
+        if p.name.startswith("run_"):
             return p
 
 
 def _get_stdout(remote_out_dir, testname, mode, instance):
     run_dir = _run_cmd_dir(remote_out_dir, testname, mode)
-    stdout_file = run_dir / 'instances' / instance / 'stdout.txt'
-    assert stdout_file.exists()     # test output redirection
+    stdout_file = run_dir / "instances" / instance / "stdout.txt"
+    assert stdout_file.exists()  # test output redirection
     return stdout_file.read_text()
 
 
 def _get_outfile(remote_out_dir, testname, mode, execution_model, instance, rank):
     run_dir = _run_cmd_dir(remote_out_dir, testname, mode, execution_model)
-    work_dir = run_dir / 'instances' / instance / 'workdir'
-    out_file = work_dir / f'out_{rank}.txt'
-    assert out_file.exists()        # test working directory
+    work_dir = run_dir / "instances" / instance / "workdir"
+    out_file = work_dir / f"out_{rank}.txt"
+    assert out_file.exists()  # test working directory
     return out_file.read_text()
 
 
@@ -104,105 +104,114 @@ _SCHED_OVERHEAD = 60
 
 
 @skip_unless_cluster
-@pytest.mark.parametrize('mode', ['local', 'slurm'])
+@pytest.mark.parametrize("mode", ["local", "slurm"])
 def test_single(
-        fake_cluster, remote_test_files, remote_out_dir, mode, hwthread_to_core):
+    fake_cluster, remote_test_files, remote_out_dir, mode, hwthread_to_core
+):
     sched = _sched(fake_cluster, mode)
 
-    job = _make_job('single', mode, remote_test_files, remote_out_dir)
-    if mode == 'slurm':
+    job = _make_job("single", mode, remote_test_files, remote_out_dir)
+    if mode == "slurm":
         job.num_nodes = 1
         job.mpi_processes_per_node = 1
-        job.extra_scheduler_options += ' --nodelist=node-0'
+        job.extra_scheduler_options += " --nodelist=node-0"
 
     job_id = sched.submit(job)
     assert sched.wait(job_id, job.time_reserved + _SCHED_OVERHEAD) is not None
     assert sched.get_exit_code(job_id) == 0
 
-    output = _get_stdout(remote_out_dir, 'single', mode, 'c1')
+    output = _get_stdout(remote_out_dir, "single", mode, "c1")
 
-    if mode == 'local':
-        assert output.split('\n')[0] == 'headnode'
+    if mode == "local":
+        assert output.split("\n")[0] == "headnode"
     else:
-        node, hwthreads, _ = output.split('\n')
-        assert node == 'node-0.example.org'
+        node, hwthreads, _ = output.split("\n")
+        assert node == "node-0.example.org"
         assert hwthread_to_core(hwthreads) == [0]
 
 
 @skip_unless_cluster
-@pytest.mark.parametrize('mode', ['local', 'slurm'])
+@pytest.mark.parametrize("mode", ["local", "slurm"])
 def test_dispatch(
-        fake_cluster, remote_test_files, remote_out_dir, mode, hwthread_to_core):
+    fake_cluster, remote_test_files, remote_out_dir, mode, hwthread_to_core
+):
     sched = _sched(fake_cluster, mode)
 
-    job = _make_job('dispatch', mode, remote_test_files, remote_out_dir)
-    if mode == 'slurm':
+    job = _make_job("dispatch", mode, remote_test_files, remote_out_dir)
+    if mode == "slurm":
         job.num_nodes = 1
         job.mpi_processes_per_node = 1
-        job.extra_scheduler_options += ' --nodelist=node-1'
+        job.extra_scheduler_options += " --nodelist=node-1"
 
     job_id = sched.submit(job)
     assert sched.wait(job_id, job.time_reserved + _SCHED_OVERHEAD) is not None
     assert sched.get_exit_code(job_id) == 0
 
-    c1_out = _get_stdout(remote_out_dir, 'dispatch', mode, 'c1')
-    c2_out = _get_stdout(remote_out_dir, 'dispatch', mode, 'c2')
-    if mode == 'local':
-        assert c1_out.split('\n')[0] == 'headnode'
-        assert c2_out.split('\n')[0] == 'headnode'
+    c1_out = _get_stdout(remote_out_dir, "dispatch", mode, "c1")
+    c2_out = _get_stdout(remote_out_dir, "dispatch", mode, "c2")
+    if mode == "local":
+        assert c1_out.split("\n")[0] == "headnode"
+        assert c2_out.split("\n")[0] == "headnode"
     else:
-        node, hwthreads, _ = c1_out.split('\n')
-        assert node == 'node-1.example.org'
+        node, hwthreads, _ = c1_out.split("\n")
+        assert node == "node-1.example.org"
         assert hwthread_to_core(hwthreads) == [0]
 
-        node, hwthreads, _ = c2_out.split('\n')
-        assert node == 'node-1.example.org'
+        node, hwthreads, _ = c2_out.split("\n")
+        assert node == "node-1.example.org"
         assert hwthread_to_core(hwthreads) == [0]
 
 
 @skip_unless_cluster
-@pytest.mark.parametrize('mode', ['local', 'slurm'])
+@pytest.mark.parametrize("mode", ["local", "slurm"])
 def test_multiple(
-        fake_cluster, remote_test_files, remote_out_dir, mode, hwthread_to_core):
+    fake_cluster, remote_test_files, remote_out_dir, mode, hwthread_to_core
+):
     sched = _sched(fake_cluster, mode)
 
-    job = _make_job('multiple', mode, remote_test_files, remote_out_dir)
-    if mode == 'slurm':
+    job = _make_job("multiple", mode, remote_test_files, remote_out_dir)
+    if mode == "slurm":
         job.num_nodes = 3
-        job.extra_scheduler_options += ' --nodelist=node-[0-2]'
+        job.extra_scheduler_options += " --nodelist=node-[0-2]"
 
     job_id = sched.submit(job)
     assert sched.wait(job_id, job.time_reserved + _SCHED_OVERHEAD) is not None
     assert sched.get_exit_code(job_id) == 0
 
     for i in range(1, 7):
-        instance = f'c{i}'
-        out = _get_stdout(remote_out_dir, 'multiple', mode, instance)
-        if mode == 'local':
-            assert out.split('\n')[0] == 'headnode'
+        instance = f"c{i}"
+        out = _get_stdout(remote_out_dir, "multiple", mode, instance)
+        if mode == "local":
+            assert out.split("\n")[0] == "headnode"
         else:
-            node, hwthreads, _ = out.split('\n')
-            assert (instance, node) == (instance, f'node-{(i - 1) // 2}.example.org')
+            node, hwthreads, _ = out.split("\n")
+            assert (instance, node) == (instance, f"node-{(i - 1) // 2}.example.org")
             assert (instance, hwthread_to_core(hwthreads)) == (instance, [(i - 1) % 2])
 
 
 @skip_unless_cluster
-@pytest.mark.parametrize('mode', ['local', 'slurm'])
-@pytest.mark.parametrize('execution_model', ['openmpi', 'intelmpi', 'srunmpi'])
+@pytest.mark.parametrize("mode", ["local", "slurm"])
+@pytest.mark.parametrize("execution_model", ["openmpi", "intelmpi", "srunmpi"])
 def test_double(
-        fake_cluster, remote_test_files, remote_out_dir, hwthread_to_core,
-        mode, execution_model):
+    fake_cluster,
+    remote_test_files,
+    remote_out_dir,
+    hwthread_to_core,
+    mode,
+    execution_model,
+):
 
-    if mode == 'local' and execution_model == 'srunmpi':
-        pytest.skip('srun does not work without slurm')
+    if mode == "local" and execution_model == "srunmpi":
+        pytest.skip("srun does not work without slurm")
 
     sched = _sched(fake_cluster, mode)
 
     job = _make_mpi_job(
-            'double', mode, execution_model, remote_test_files, remote_out_dir)
-    if mode == 'slurm':
+        "double", mode, execution_model, remote_test_files, remote_out_dir
+    )
+    if mode == "slurm":
         job.num_nodes = 2
-        job.extra_scheduler_options += ' --nodelist=node-[3-4]'
+        job.extra_scheduler_options += " --nodelist=node-[3-4]"
 
     job_id = sched.submit(job)
     assert sched.wait(job_id, job.time_reserved + _SCHED_OVERHEAD) is not None
@@ -211,32 +220,39 @@ def test_double(
     for i in range(1, 3):
         for rank in range(2):
             out = _get_outfile(
-                    remote_out_dir, 'double', mode, execution_model, f'c{i}', rank)
-            if mode == 'local':
-                assert out.split('\n')[0] == 'headnode'
+                remote_out_dir, "double", mode, execution_model, f"c{i}", rank
+            )
+            if mode == "local":
+                assert out.split("\n")[0] == "headnode"
             else:
-                node, hwthreads, _ = out.split('\n')
-                assert node == f'node-{i + 2}.example.org'
+                node, hwthreads, _ = out.split("\n")
+                assert node == f"node-{i + 2}.example.org"
                 assert hwthread_to_core(hwthreads) == [rank]
 
 
 @skip_unless_cluster
-@pytest.mark.parametrize('mode', ['local', 'slurm'])
-@pytest.mark.parametrize('execution_model', ['openmpi', 'intelmpi', 'srunmpi'])
+@pytest.mark.parametrize("mode", ["local", "slurm"])
+@pytest.mark.parametrize("execution_model", ["openmpi", "intelmpi", "srunmpi"])
 def test_macro_micro(
-        fake_cluster, remote_test_files, remote_out_dir, hwthread_to_core,
-        mode, execution_model):
+    fake_cluster,
+    remote_test_files,
+    remote_out_dir,
+    hwthread_to_core,
+    mode,
+    execution_model,
+):
 
-    if mode == 'local' and execution_model == 'srunmpi':
-        pytest.skip('srun does not work without slurm')
+    if mode == "local" and execution_model == "srunmpi":
+        pytest.skip("srun does not work without slurm")
 
     sched = _sched(fake_cluster, mode)
 
     job = _make_mpi_job(
-            'macro_micro', mode, execution_model, remote_test_files, remote_out_dir)
-    if mode == 'slurm':
+        "macro_micro", mode, execution_model, remote_test_files, remote_out_dir
+    )
+    if mode == "slurm":
         job.num_nodes = 1
-        job.extra_scheduler_options += ' --nodelist=node-4'
+        job.extra_scheduler_options += " --nodelist=node-4"
 
     job_id = sched.submit(job)
     assert sched.wait(job_id, job.time_reserved + _SCHED_OVERHEAD) is not None
@@ -245,23 +261,23 @@ def test_macro_micro(
     for i in range(1, 3):
         for rank in range(2):
             out = _get_outfile(
-                    remote_out_dir, 'macro_micro', mode, execution_model, f'c{i}', rank)
-            if mode == 'local':
-                assert out.split('\n')[0] == 'headnode'
+                remote_out_dir, "macro_micro", mode, execution_model, f"c{i}", rank
+            )
+            if mode == "local":
+                assert out.split("\n")[0] == "headnode"
             else:
-                node, hwthreads, _ = out.split('\n')
-                assert node == 'node-4.example.org'
+                node, hwthreads, _ = out.split("\n")
+                assert node == "node-4.example.org"
                 assert hwthread_to_core(hwthreads) == [rank]
 
 
 @skip_unless_cluster
-@pytest.mark.parametrize('mode', ['local', 'slurm'])
-def test_base_env(
-        fake_cluster, remote_test_files, remote_out_dir, mode):
+@pytest.mark.parametrize("mode", ["local", "slurm"])
+def test_base_env(fake_cluster, remote_test_files, remote_out_dir, mode):
     sched = _sched(fake_cluster, mode)
 
-    job = _make_job('base_env', mode, remote_test_files, remote_out_dir)
-    if mode == 'slurm':
+    job = _make_job("base_env", mode, remote_test_files, remote_out_dir)
+    if mode == "slurm":
         job.num_nodes = 2
         job.mpi_processes_per_node = 2
 
@@ -269,24 +285,24 @@ def test_base_env(
     assert sched.wait(job_id, job.time_reserved + _SCHED_OVERHEAD) is not None
     assert sched.get_exit_code(job_id) == 0
 
-    login_out = _get_stdout(remote_out_dir, 'base_env', mode, 'login')
-    clean_out = _get_stdout(remote_out_dir, 'base_env', mode, 'clean')
-    manager_out = _get_stdout(remote_out_dir, 'base_env', mode, 'manager')
+    login_out = _get_stdout(remote_out_dir, "base_env", mode, "login")
+    clean_out = _get_stdout(remote_out_dir, "base_env", mode, "clean")
+    manager_out = _get_stdout(remote_out_dir, "base_env", mode, "manager")
 
-    assert login_out.split('\n')[0] == '1'     # .profile loaded
-    assert login_out.split('\n')[1] == '0'     # .bashrc loaded
-    assert login_out.split('\n')[2] == '0'     # manager shell
-    assert login_out.split('\n')[3] == '1'     # modules loaded
-    assert login_out.split('\n')[4] == ''      # venv active
+    assert login_out.split("\n")[0] == "1"  # .profile loaded
+    assert login_out.split("\n")[1] == "0"  # .bashrc loaded
+    assert login_out.split("\n")[2] == "0"  # manager shell
+    assert login_out.split("\n")[3] == "1"  # modules loaded
+    assert login_out.split("\n")[4] == ""  # venv active
 
-    assert clean_out.split('\n')[0] == '0'     # .profile loaded
-    assert clean_out.split('\n')[1] == '0'     # .bashrc loaded
-    assert clean_out.split('\n')[2] == '1'     # manager shell
-    assert clean_out.split('\n')[3] == '0'     # modules loaded
-    assert clean_out.split('\n')[4] == ''      # venv active
+    assert clean_out.split("\n")[0] == "0"  # .profile loaded
+    assert clean_out.split("\n")[1] == "0"  # .bashrc loaded
+    assert clean_out.split("\n")[2] == "1"  # manager shell
+    assert clean_out.split("\n")[3] == "0"  # modules loaded
+    assert clean_out.split("\n")[4] == ""  # venv active
 
-    assert manager_out.split('\n')[0] == '0'   # .profile loaded
-    assert manager_out.split('\n')[1] == '0'   # .bashrc loaded
-    assert manager_out.split('\n')[2] == '1'   # manager shell
-    assert manager_out.split('\n')[3] == '1'   # modules loaded
-    assert manager_out.split('\n')[4] == '/home/cerulean/shared/venv'
+    assert manager_out.split("\n")[0] == "0"  # .profile loaded
+    assert manager_out.split("\n")[1] == "0"  # .bashrc loaded
+    assert manager_out.split("\n")[2] == "1"  # manager shell
+    assert manager_out.split("\n")[3] == "1"  # modules loaded
+    assert manager_out.split("\n")[4] == "/home/cerulean/shared/venv"

--- a/integration_test/codes/macro/__main__.py
+++ b/integration_test/codes/macro/__main__.py
@@ -2,16 +2,14 @@ from ymmsl import Operator
 
 from libmuscle import Instance, Message
 
-instance = Instance({
-        Operator.O_I: ['out'],
-        Operator.S: ['in']})
+instance = Instance({Operator.O_I: ["out"], Operator.S: ["in"]})
 
 while instance.reuse_instance():
     # f_init
     for i in range(2):
         # o_i
-        instance.send('out', Message(i * 10.0, (i + 1) * 10.0, i))
+        instance.send("out", Message(i * 10.0, (i + 1) * 10.0, i))
 
         # s/b
-        msg = instance.receive('in')
+        msg = instance.receive("in")
         assert msg.data == i

--- a/integration_test/codes/micro/__main__.py
+++ b/integration_test/codes/micro/__main__.py
@@ -2,13 +2,11 @@ from ymmsl import Operator
 
 from libmuscle import Instance, Message
 
-instance = Instance({
-        Operator.F_INIT: ['init'],
-        Operator.O_F: ['final']})
+instance = Instance({Operator.F_INIT: ["init"], Operator.O_F: ["final"]})
 
 while instance.reuse_instance():
     # f_init
-    msg = instance.receive('init')
+    msg = instance.receive("init")
 
     # o_f
-    instance.send('final', Message(msg.timestamp, msg.next_timestamp, msg.data))
+    instance.send("final", Message(msg.timestamp, msg.next_timestamp, msg.data))

--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -13,16 +13,16 @@ from libmuscle.manager.manager import Manager
 from libmuscle.pytest.muscle_tester import make_server_process
 
 skip_if_python_only = pytest.mark.skipif(
-        'MUSCLE_TEST_PYTHON_ONLY' in os.environ,
-        reason='Python-only tests requested')
+    "MUSCLE_TEST_PYTHON_ONLY" in os.environ, reason="Python-only tests requested"
+)
 
 skip_if_no_fortran = pytest.mark.skipif(
-        'MUSCLE_DISABLE_FORTRAN' in os.environ,
-        reason='No Fortran compiler available')
+    "MUSCLE_DISABLE_FORTRAN" in os.environ, reason="No Fortran compiler available"
+)
 
 skip_if_no_mpi_cpp = pytest.mark.skipif(
-        'MUSCLE_ENABLE_CPP_MPI' not in os.environ,
-        reason='MPI support was not detected')
+    "MUSCLE_ENABLE_CPP_MPI" not in os.environ, reason="MPI support was not detected"
+)
 
 
 @pytest.fixture
@@ -32,33 +32,38 @@ def yatiml_log_warning():
 
 @pytest.fixture
 def ymmsl_path() -> str:
-    return str(Path(__file__).parent / 'ymmsl')
+    return str(Path(__file__).parent / "ymmsl")
 
 
 @pytest.fixture
 def codes_path() -> str:
-    return str(Path(__file__).parent / 'codes')
+    return str(Path(__file__).parent / "codes")
 
 
 def ls_snapshots(run_dir, instance=None):
     """List all snapshots of the instance or workflow"""
-    return sorted(run_dir.snapshot_dir(instance).iterdir(),
-                  key=lambda path: tuple(map(int, path.stem.split("_")[1:])))
+    return sorted(
+        run_dir.snapshot_dir(instance).iterdir(),
+        key=lambda path: tuple(map(int, path.stem.split("_")[1:])),
+    )
 
 
 def _python_wrapper(tmpdir, instance_name, muscle_manager, callable):
-    sys.argv.append(f'--muscle-instance={instance_name}')
-    sys.argv.append(f'--muscle-manager={muscle_manager}')
+    sys.argv.append(f"--muscle-instance={instance_name}")
+    sys.argv.append(f"--muscle-manager={muscle_manager}")
 
-    with open(tmpdir / f'{instance_name}_stdout.txt', 'w') as f_out:
-        with open(tmpdir / f'{instance_name}_stderr.txt', 'w') as f_err:
+    with open(tmpdir / f"{instance_name}_stdout.txt", "w") as f_out:
+        with open(tmpdir / f"{instance_name}_stderr.txt", "w") as f_err:
             sys.stdout = f_out
             sys.stderr = f_err
 
             root_logger = logging.getLogger()
             handler = logging.StreamHandler()
-            handler.setFormatter(logging.Formatter(
-                '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'))
+            handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s"
+                )
+            )
             root_logger.addHandler(handler)
             root_logger.setLevel(logging.DEBUG)
 
@@ -100,19 +105,19 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
     """
     env = os.environ.copy()
     ymmsl_doc = ymmsl.load(ymmsl_text)
-    libmuscle_dir = Path(__file__).parents[1] / 'libmuscle'
-    cpp_build_dir = libmuscle_dir / 'cpp' / 'build' / 'libmuscle' / 'tests'
-    fortran_build_dir = libmuscle_dir / 'fortran' / 'build' / 'libmuscle' / 'tests'
+    libmuscle_dir = Path(__file__).parents[1] / "libmuscle"
+    cpp_build_dir = libmuscle_dir / "cpp" / "build" / "libmuscle" / "tests"
+    fortran_build_dir = libmuscle_dir / "fortran" / "build" / "libmuscle" / "tests"
 
     with ExitStack() as stack:
         ctx = make_server_process(ymmsl_doc, Path(tmpdir), False)
-        env['MUSCLE_MANAGER'] = stack.enter_context(ctx)
+        env["MUSCLE_MANAGER"] = stack.enter_context(ctx)
 
-        lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-        if 'LD_LIBRARY_PATH' in env:
-            env['LD_LIBRARY_PATH'] += ':' + ':'.join(map(str, lib_paths))
+        lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+        if "LD_LIBRARY_PATH" in env:
+            env["LD_LIBRARY_PATH"] += ":" + ":".join(map(str, lib_paths))
         else:
-            env['LD_LIBRARY_PATH'] = ':'.join(map(str, lib_paths))
+            env["LD_LIBRARY_PATH"] = ":".join(map(str, lib_paths))
 
         native_processes = []
         python_processes = []
@@ -121,9 +126,10 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
             if language == "python":
                 # start python actor
                 proc = mp.Process(
-                        target=_python_wrapper,
-                        args=(tmpdir, instance_name, env['MUSCLE_MANAGER'], actor),
-                        name=instance_name)
+                    target=_python_wrapper,
+                    args=(tmpdir, instance_name, env["MUSCLE_MANAGER"], actor),
+                    name=instance_name,
+                )
                 proc.start()
                 python_processes.append(proc)
                 continue
@@ -131,22 +137,35 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
                 executable = cpp_build_dir / actor
             elif language == "mpicpp":
                 assert len(args) > 0, "must provide at least number of mpi instances"
-                executable = 'mpirun'
-                out_file = tmpdir / f'mpi_{instance_name}.log'
-                args = ('-np', args[0], mpirun_outfile_arg(), str(out_file),
-                        str(cpp_build_dir / actor), *args[1:])
+                executable = "mpirun"
+                out_file = tmpdir / f"mpi_{instance_name}.log"
+                args = (
+                    "-np",
+                    args[0],
+                    mpirun_outfile_arg(),
+                    str(out_file),
+                    str(cpp_build_dir / actor),
+                    *args[1:],
+                )
             elif language == "fortran":
                 executable = fortran_build_dir / actor
             else:
                 raise ValueError(f"Unknown language: {language}")
             # start native code actor
             f_out = stack.enter_context(
-                    (tmpdir / f'{instance_name}_stdout.txt').open('w'))
+                (tmpdir / f"{instance_name}_stdout.txt").open("w")
+            )
             f_err = stack.enter_context(
-                    (tmpdir / f'{instance_name}_stderr.txt').open('w'))
-            native_processes.append(subprocess.Popen(
-                    [str(executable), *args, f'--muscle-instance={instance_name}'],
-                    env=env, stdout=f_out, stderr=f_err))
+                (tmpdir / f"{instance_name}_stderr.txt").open("w")
+            )
+            native_processes.append(
+                subprocess.Popen(
+                    [str(executable), *args, f"--muscle-instance={instance_name}"],
+                    env=env,
+                    stdout=f_out,
+                    stderr=f_err,
+                )
+            )
 
         # check results
         for proc in native_processes:
@@ -159,53 +178,53 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
                 assert proc.exitcode == 0
         if not expect_success:
             # Check that at least one process has failed
-            assert (
-                    any(proc.returncode != 0 for proc in native_processes) or
-                    any(proc.exitcode != 0 for proc in python_processes))
+            assert any(proc.returncode != 0 for proc in native_processes) or any(
+                proc.exitcode != 0 for proc in python_processes
+            )
 
 
 @pytest.fixture
 def mmp_server_config(yatiml_log_warning):
     return (
-            'ymmsl_version: v0.2\n'
-            'description: A less simple configuration for integration tests\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: A model for testing\n'
-            '  components:\n'
-            '    macro:\n'
-            '      description: The macro model\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      implementation: macro_implementation\n'
-            '    micro:\n'
-            '      description: The micro model, many of them\n'
-            '      ports:\n'
-            '        f_init: in\n'
-            '        o_f: out\n'
-            '      implementation: micro_implementation\n'
-            '      multiplicity: [10]\n'
-            '  conduits:\n'
-            '    macro.out: micro.in\n'
-            '    micro.out: macro.in\n'
-            'settings:\n'
-            '  test1: 13\n'
-            '  test2: 13.3\n'
-            '  test3: testing\n'
-            '  test4: True\n'
-            '  test5: [2.3, 5.6]\n'
-            '  test6:\n'
-            '    - [1.0, 2.0]\n'
-            '    - [3.0, 1.0]\n'
-            'programs:\n'
-            '  macro_implementation:\n'
-            '    description: Program implementing macro\n'
-            '    executable: macro.py\n'
-            '  micro_implementation:\n'
-            '    description: Program implementing micro\n'
-            '    executable: micro.py\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: A less simple configuration for integration tests\n"
+        "models:\n"
+        "- name: test_model\n"
+        "  description: A model for testing\n"
+        "  components:\n"
+        "    macro:\n"
+        "      description: The macro model\n"
+        "      ports:\n"
+        "        o_i: out\n"
+        "        s: in\n"
+        "      implementation: macro_implementation\n"
+        "    micro:\n"
+        "      description: The micro model, many of them\n"
+        "      ports:\n"
+        "        f_init: in\n"
+        "        o_f: out\n"
+        "      implementation: micro_implementation\n"
+        "      multiplicity: [10]\n"
+        "  conduits:\n"
+        "    macro.out: micro.in\n"
+        "    micro.out: macro.in\n"
+        "settings:\n"
+        "  test1: 13\n"
+        "  test2: 13.3\n"
+        "  test3: testing\n"
+        "  test4: True\n"
+        "  test5: [2.3, 5.6]\n"
+        "  test6:\n"
+        "    - [1.0, 2.0]\n"
+        "    - [3.0, 1.0]\n"
+        "programs:\n"
+        "  macro_implementation:\n"
+        "    description: Program implementing macro\n"
+        "    executable: macro.py\n"
+        "  micro_implementation:\n"
+        "    description: Program implementing micro\n"
+        "    executable: micro.py\n"
+    )
 
 
 @pytest.fixture
@@ -218,48 +237,48 @@ def mmp_server_process(mmp_server_config, tmpdir):
 @pytest.fixture
 def mmp_server_config_simple(yatiml_log_warning):
     return (
-            'ymmsl_version: v0.2\n'
-            'description: A simple configuration for integration tests\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: A model for testing\n'
-            '  components:\n'
-            '    macro:\n'
-            '      description: The macro model\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      implementation: macro_implementation\n'
-            '    micro:\n'
-            '      description: The micro model\n'
-            '      ports:\n'
-            '        f_init: in\n'
-            '        o_f: out\n'
-            '      implementation: micro_implementation\n'
-            '  conduits:\n'
-            '    macro.out: micro.in\n'
-            '    micro.out: macro.in\n'
-            'settings:\n'
-            '  test1: 13\n'
-            '  test2: 13.3\n'
-            '  test3: testing\n'
-            '  test4: True\n'
-            '  test5: [2.3, 5.6]\n'
-            '  test6:\n'
-            '    - [1.0, 2.0]\n'
-            '    - [3.0, 1.0]\n'
-            '  test_with_a_longer_name: 1\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: A simple configuration for integration tests\n"
+        "models:\n"
+        "- name: test_model\n"
+        "  description: A model for testing\n"
+        "  components:\n"
+        "    macro:\n"
+        "      description: The macro model\n"
+        "      ports:\n"
+        "        o_i: out\n"
+        "        s: in\n"
+        "      implementation: macro_implementation\n"
+        "    micro:\n"
+        "      description: The micro model\n"
+        "      ports:\n"
+        "        f_init: in\n"
+        "        o_f: out\n"
+        "      implementation: micro_implementation\n"
+        "  conduits:\n"
+        "    macro.out: micro.in\n"
+        "    micro.out: macro.in\n"
+        "settings:\n"
+        "  test1: 13\n"
+        "  test2: 13.3\n"
+        "  test3: testing\n"
+        "  test4: True\n"
+        "  test5: [2.3, 5.6]\n"
+        "  test6:\n"
+        "    - [1.0, 2.0]\n"
+        "    - [3.0, 1.0]\n"
+        "  test_with_a_longer_name: 1\n"
+    )
 
 
 @pytest.fixture
 def mmp_server_config_simple_nopython(mmp_server_config_simple):
-    return mmp_server_config_simple + '  python_compat: false\n'
+    return mmp_server_config_simple + "  python_compat: false\n"
 
 
 @pytest.fixture
 def mmp_server_config_simple_python(mmp_server_config_simple):
-    return mmp_server_config_simple + '  python_compat: true\n'
+    return mmp_server_config_simple + "  python_compat: true\n"
 
 
 @pytest.fixture
@@ -289,24 +308,23 @@ def log_file_in_tmpdir(tmpdir):
 
 
 def mpi_is_intel():
-    if 'MUSCLE_ENABLE_CPP_MPI' not in os.environ:
+    if "MUSCLE_ENABLE_CPP_MPI" not in os.environ:
         return None
 
-    result = subprocess.run(
-            ['mpirun', '--version'], capture_output=True, check=True)
-    return 'Intel' in result.stdout.decode('utf-8')
+    result = subprocess.run(["mpirun", "--version"], capture_output=True, check=True)
+    return "Intel" in result.stdout.decode("utf-8")
 
 
 def mpirun_outfile_arg():
     if mpi_is_intel():
-        return '-outfile-pattern'
+        return "-outfile-pattern"
     else:
-        return '--output-filename'
+        return "--output-filename"
 
 
 @pytest.fixture
 def mpi_exec_model():
     if mpi_is_intel():
-        return 'intelmpi'
+        return "intelmpi"
     else:
-        return 'openmpi'
+        return "openmpi"

--- a/integration_test/test_all.py
+++ b/integration_test/test_all.py
@@ -19,73 +19,68 @@ NUM_MICROS = 10
 
 
 def macro():
-    """Macro model implementation.
-    """
-    instance = Instance({
-            Operator.O_I: ['out[]'],
-            Operator.S: ['in[]']})
+    """Macro model implementation."""
+    instance = Instance({Operator.O_I: ["out[]"], Operator.S: ["in[]"]})
 
     while instance.reuse_instance():
         # f_init
-        assert instance.get_setting('test1') == 13
+        assert instance.get_setting("test1") == 13
 
         # o_i
-        assert instance.is_vector_port('out')
+        assert instance.is_vector_port("out")
         for slot in range(NUM_MICROS):
-            instance.send('out', Message(0.0, 10.0, 'testing'), slot)
+            instance.send("out", Message(0.0, 10.0, "testing"), slot)
 
         # s/b
         for slot in range(NUM_MICROS):
-            msg = instance.receive('in', slot)
-            assert msg.data['string'] == 'testing back'
-            assert msg.data['int'] == 42
-            assert msg.data['float'] == 3.1416
-            assert msg.data['grid'].array.dtype == np.float64
-            assert msg.data['grid'].array[0, 1] == 34.0
+            msg = instance.receive("in", slot)
+            assert msg.data["string"] == "testing back"
+            assert msg.data["int"] == 42
+            assert msg.data["float"] == 3.1416
+            assert msg.data["grid"].array.dtype == np.float64
+            assert msg.data["grid"].array[0, 1] == 34.0
 
 
 def micro():
-    """Micro model implementation.
-    """
-    instance = Instance({
-            Operator.F_INIT: ['in'],
-            Operator.O_F: ['out']})
+    """Micro model implementation."""
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_F: ["out"]})
 
     while instance.reuse_instance():
         # f_init
-        assert instance.get_setting('test3', 'str') == 'testing'
-        assert instance.get_setting('test4', 'bool') is True
-        assert instance.get_setting('test6', '[[float]]')[0][1] == 2.0
+        assert instance.get_setting("test3", "str") == "testing"
+        assert instance.get_setting("test4", "bool") is True
+        assert instance.get_setting("test6", "[[float]]")[0][1] == 2.0
 
-        msg = instance.receive('in')
-        assert msg.data == 'testing'
+        msg = instance.receive("in")
+        assert msg.data == "testing"
 
         # o_f
         result = {
-                'string': 'testing back',
-                'int': 42,
-                'float': 3.1416,
-                'grid': Grid(np.array([[12.0, 34.0, 56.0], [1.0, 2.0, 3.0]]))}
-        instance.send('out', Message(0.1, data=result))
+            "string": "testing back",
+            "int": 42,
+            "float": 3.1416,
+            "grid": Grid(np.array([[12.0, 34.0, 56.0], [1.0, 2.0, 3.0]])),
+        }
+        instance.send("out", Message(0.1, data=result))
 
 
 def check_profile_output(tmp_path):
-    conn = sqlite3.connect(tmp_path / 'performance.sqlite')
+    conn = sqlite3.connect(tmp_path / "performance.sqlite")
     cur = conn.cursor()
 
-    for typ in ('SEND', 'RECEIVE_TRANSFER'):
+    for typ in ("SEND", "RECEIVE_TRANSFER"):
         cur.execute(
-                "SELECT * FROM all_events"
-                "    WHERE instance = 'macro' AND type = ?", (typ,))
+            "SELECT * FROM all_events    WHERE instance = 'macro' AND type = ?", (typ,)
+        )
         res = cur.fetchall()
         assert len(res) == NUM_MICROS
 
     cur.execute(
-            "SELECT * FROM all_events"
-            "    WHERE instance = 'micro[5]' AND type = 'RECEIVE'")
+        "SELECT * FROM all_events    WHERE instance = 'micro[5]' AND type = 'RECEIVE'"
+    )
     res = cur.fetchall()
     assert len(res) == 1
-    assert res[0][4:8] == ('in', 'F_INIT', None, None)
+    assert res[0][4:8] == ("in", "F_INIT", None, None)
     assert res[0][8] == 0
     assert res[0][9] > 0
     assert res[0][10] == 0.0
@@ -95,29 +90,33 @@ def check_profile_output(tmp_path):
 
 
 def test_all(log_file_in_tmpdir, tmp_path):
-    """A positive all-up test of everything.
-    """
+    """A positive all-up test of everything."""
     components = [
-            Component('macro', Ports(o_i='out', s='in'), '', 'macro_impl'),
-            Component(
-                'micro', Ports('in', o_f='out'), '', 'micro_impl', False, [NUM_MICROS])]
+        Component("macro", Ports(o_i="out", s="in"), "", "macro_impl"),
+        Component(
+            "micro", Ports("in", o_f="out"), "", "micro_impl", False, [NUM_MICROS]
+        ),
+    ]
 
-    conduits = [
-            Conduit('macro.out', 'micro.in'),
-            Conduit('micro.out', 'macro.in')]
+    conduits = [Conduit("macro.out", "micro.in"), Conduit("micro.out", "macro.in")]
 
-    model = Model('test_model', None, '', None, components, conduits)
-    settings = Settings(OrderedDict([
-                ('test1', 13),
-                ('test2', 13.3),
-                ('test3', 'testing'),
-                ('test4', True),
-                ('test5', [2.3, 5.6]),
-                ('test6', [[1.0, 2.0], [3.0, 1.0]])]))
+    model = Model("test_model", None, "", None, components, conduits)
+    settings = Settings(
+        OrderedDict(
+            [
+                ("test1", 13),
+                ("test2", 13.3),
+                ("test3", "testing"),
+                ("test4", True),
+                ("test5", [2.3, 5.6]),
+                ("test6", [[1.0, 2.0], [3.0, 1.0]]),
+            ]
+        )
+    )
 
-    configuration = Configuration('test_all', None, [model], None, settings)
+    configuration = Configuration("test_all", None, [model], None, settings)
 
-    implementations = {'macro_impl': macro, 'micro_impl': micro}
+    implementations = {"macro_impl": macro, "micro_impl": micro}
     run_simulation(configuration, implementations)
 
     check_profile_output(tmp_path)

--- a/integration_test/test_base_env.py
+++ b/integration_test/test_base_env.py
@@ -12,15 +12,15 @@ def test_base_env(tmpdir):
     tmppath = Path(str(tmpdir))
 
     # find our test component and its requirements
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    ld_lib_path = ':'.join(map(str, lib_paths))
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    ld_lib_path = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    test_component = cpp_test_dir / 'component_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    test_component = cpp_test_dir / "component_test"
 
     # make config
-    ymmsl_text = (f"""
+    ymmsl_text = f"""
 ymmsl_version: v0.2
 description: Testing base_env option
 models:
@@ -57,15 +57,15 @@ resources:
     threads: 1
   test_model.micro:
     threads: 1
-""")
+"""
 
     config = ymmsl.load(ymmsl_text)
 
     # set up
-    run_dir = RunDir(tmppath / 'run')
+    run_dir = RunDir(tmppath / "run")
 
     # launch MUSCLE Manager with simulation
-    manager = Manager(config, run_dir, 'DEBUG')
+    manager = Manager(config, run_dir, "DEBUG")
     manager.start_instances()
     success = manager.wait()
 

--- a/integration_test/test_cpp_mmp_client.py
+++ b/integration_test/test_cpp_mmp_client.py
@@ -14,42 +14,42 @@ from .conftest import skip_if_python_only
 
 def do_mmp_client_test(tmpdir, caplog):
     ymmsl_text = (
-            'ymmsl_version: v0.2\n'
-            'description: Configuration for testing MMP clients\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: A model for testing the MMP client\n'
-            '  components:\n'
-            '    macro:\n'
-            '      description: Macro model\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      implementation: macro_implementation\n'
-            '    micro:\n'
-            '      description: Micro model\n'
-            '      ports:\n'
-            '        f_init: in\n'
-            '        o_f: out\n'
-            '      implementation: micro_implementation\n'
-            '      multiplicity: [10]\n'
-            '  conduits:\n'
-            '    macro.out: micro.in\n'
-            '    micro.out: macro.in\n'
-            'settings:\n'
-            '  test1: 13\n'
-            '  test2: 13.3\n'
-            '  test3: testing\n'
-            '  test4: True\n'
-            '  test5: [2.3, 5.6]\n'
-            '  test6:\n'
-            '    - [1.0, 2.0]\n'
-            '    - [3.0, 1.0]\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Configuration for testing MMP clients\n"
+        "models:\n"
+        "- name: test_model\n"
+        "  description: A model for testing the MMP client\n"
+        "  components:\n"
+        "    macro:\n"
+        "      description: Macro model\n"
+        "      ports:\n"
+        "        o_i: out\n"
+        "        s: in\n"
+        "      implementation: macro_implementation\n"
+        "    micro:\n"
+        "      description: Micro model\n"
+        "      ports:\n"
+        "        f_init: in\n"
+        "        o_f: out\n"
+        "      implementation: micro_implementation\n"
+        "      multiplicity: [10]\n"
+        "  conduits:\n"
+        "    macro.out: micro.in\n"
+        "    micro.out: macro.in\n"
+        "settings:\n"
+        "  test1: 13\n"
+        "  test2: 13.3\n"
+        "  test3: testing\n"
+        "  test4: True\n"
+        "  test5: [2.3, 5.6]\n"
+        "  test6:\n"
+        "    - [1.0, 2.0]\n"
+        "    - [3.0, 1.0]\n"
+    )
 
     # create server
     ymmsl_doc = ymmsl.load(ymmsl_text)
-    manager = Manager(ymmsl_doc, RunDir(Path(tmpdir)), 'DEBUG')
+    manager = Manager(ymmsl_doc, RunDir(Path(tmpdir)), "DEBUG")
 
     # mock the deregistration
     removed_instance = None
@@ -62,24 +62,27 @@ def do_mmp_client_test(tmpdir, caplog):
 
     # add some peers
     manager._instance_registry.add(
-            Reference('macro'), ['tcp:test3', 'tcp:test4'],
-            [Port('out', Operator.O_I), Port('in', Operator.S)])
+        Reference("macro"),
+        ["tcp:test3", "tcp:test4"],
+        [Port("out", Operator.O_I), Port("in", Operator.S)],
+    )
 
     # create C++ client
     # it runs through the various RPC calls
     # see libmuscle/cpp/src/libmuscle/tests/mmp_client_test.cpp
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
     env = os.environ.copy()
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    if 'LD_LIBRARY_PATH' in env:
-        env['LD_LIBRARY_PATH'] += ':' + ':'.join(map(str, lib_paths))
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    if "LD_LIBRARY_PATH" in env:
+        env["LD_LIBRARY_PATH"] += ":" + ":".join(map(str, lib_paths))
     else:
-        env['LD_LIBRARY_PATH'] = ':'.join(map(str, lib_paths))
+        env["LD_LIBRARY_PATH"] = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    cpp_test_client = cpp_test_dir / 'mmp_client_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    cpp_test_client = cpp_test_dir / "mmp_client_test"
     result = subprocess.run(
-            [str(cpp_test_client), manager.get_server_location()], env=env)
+        [str(cpp_test_client), manager.get_server_location()], env=env
+    )
 
     # check that C++-side checks were successful
     assert result.returncode == 0
@@ -87,26 +90,28 @@ def do_mmp_client_test(tmpdir, caplog):
     # check submit_log_message (if supported, see below)
     if caplog is not None:
         for rec in caplog.records:
-            if rec.name == 'test_logging':
+            if rec.name == "test_logging":
                 # N.B. string representation of iasctime depends on timezone settings
                 assert rec.iasctime == Timestamp(2).to_asctime()
-                assert rec.levelname == 'CRITICAL'
-                assert rec.message == 'Integration testing'
+                assert rec.levelname == "CRITICAL"
+                assert rec.message == "Integration testing"
                 break
         else:
             raise RuntimeError(f"No log message for 'test_logging' in {caplog.records}")
 
     # check instance registry
-    assert (manager._instance_registry.get_locations('micro[3]') ==
-            ['tcp:test1', 'tcp:test2'])
-    ports = manager._instance_registry.get_ports('micro[3]')
-    assert ports[0].name == 'out'
+    assert manager._instance_registry.get_locations("micro[3]") == [
+        "tcp:test1",
+        "tcp:test2",
+    ]
+    ports = manager._instance_registry.get_ports("micro[3]")
+    assert ports[0].name == "out"
     assert ports[0].operator == Operator.O_F
-    assert ports[1].name == 'in'
+    assert ports[1].name == "in"
     assert ports[1].operator == Operator.F_INIT
 
     # check deregister_instance
-    assert removed_instance == 'micro[3]'
+    assert removed_instance == "micro[3]"
 
     manager.stop()
 
@@ -116,7 +121,7 @@ def test_mmp_client(log_file_in_tmpdir, tmpdir, caplog):
     # caplog cannot be pickled, causing a crash if we try to pass it to the
     # process on platforms that don't fork. In this case, don't pass it and skip
     # the output check, if it works on one platform it'll work everywhere.
-    pass_caplog = caplog if mp.get_start_method() != 'spawn' else None
+    pass_caplog = caplog if mp.get_start_method() != "spawn" else None
 
     if mp.get_start_method() == "forkserver":
         # Python 3.14+ defaults to the forkserver start method, but we want to

--- a/integration_test/test_cpp_mpp_client.py
+++ b/integration_test/test_cpp_mpp_client.py
@@ -15,18 +15,25 @@ from .conftest import skip_if_python_only
 
 def tcp_server_process(control_pipe):
     control_pipe[0].close()
-    settings = Settings({'test_setting': 42})
-    data = {'test1': 10, 'test2': [None, True, 'testing']}
-    receiver = Reference('test_receiver.test_port2')
+    settings = Settings({"test_setting": 42})
+    data = {"test1": 10, "test2": [None, True, "testing"]}
+    receiver = Reference("test_receiver.test_port2")
     message = MPPMessage(
-            Reference('test_sender.test_port'),
-            receiver,
-            10, 1.0, 2.0, settings, 0, 1.0, data).encoded()
+        Reference("test_sender.test_port"),
+        receiver,
+        10,
+        1.0,
+        2.0,
+        settings,
+        0,
+        1.0,
+        data,
+    ).encoded()
 
     def handle_request(request_bytes):
         request = msgpack.unpackb(request_bytes, raw=False)
         assert request[0] == RequestType.GET_NEXT_MESSAGE.value
-        assert request[1] == 'test_receiver.test_port2'
+        assert request[1] == "test_receiver.test_port2"
         return message
 
     post_office = MagicMock()
@@ -52,16 +59,16 @@ def test_cpp_tcp_client(log_file_in_tmpdir):
     # create C++ client
     # it receives and checks settings, and sends a log message
     # see libmuscle/cpp/src/libmuscle/tests/mpp_client_test.cpp
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
     env = os.environ.copy()
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    if 'LD_LIBRARY_PATH' in env:
-        env['LD_LIBRARY_PATH'] += ':' + ':'.join(map(str, lib_paths))
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    if "LD_LIBRARY_PATH" in env:
+        env["LD_LIBRARY_PATH"] += ":" + ":".join(map(str, lib_paths))
     else:
-        env['LD_LIBRARY_PATH'] = ':'.join(map(str, lib_paths))
+        env["LD_LIBRARY_PATH"] = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    cpp_test_client = cpp_test_dir / 'mpp_client_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    cpp_test_client = cpp_test_dir / "mpp_client_test"
     result = subprocess.run([str(cpp_test_client), server_loc], env=env)
 
     server_pipe[0].send(None)

--- a/integration_test/test_cpp_tcp_reconnect.py
+++ b/integration_test/test_cpp_tcp_reconnect.py
@@ -33,7 +33,10 @@ def test_cpp_tcp_reconnect(tmp_path):
     # create C++ macro/micro model
     # see libmuscle/cpp/src/libmuscle/tests/tcp_reconnect_test.cpp
     run_manager_with_actors(
-            CONFIG,
-            tmp_path,
-            {'macro': ('cpp', 'tcp_reconnect_test'),
-             'micro': ('cpp', 'tcp_reconnect_test')})
+        CONFIG,
+        tmp_path,
+        {
+            "macro": ("cpp", "tcp_reconnect_test"),
+            "micro": ("cpp", "tcp_reconnect_test"),
+        },
+    )

--- a/integration_test/test_cpp_tcp_server.py
+++ b/integration_test/test_cpp_tcp_server.py
@@ -15,20 +15,25 @@ def test_cpp_tcp_server(log_file_in_tmpdir):
     # create C++ server
     # it serves a message for us to receive
     # see libmuscle/cpp/src/libmuscle/tests/mpp_server_test.cpp
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
     env = os.environ.copy()
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    if 'LD_LIBRARY_PATH' in env:
-        env['LD_LIBRARY_PATH'] += ':' + ':'.join(map(str, lib_paths))
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    if "LD_LIBRARY_PATH" in env:
+        env["LD_LIBRARY_PATH"] += ":" + ":".join(map(str, lib_paths))
     else:
-        env['LD_LIBRARY_PATH'] = ':'.join(map(str, lib_paths))
+        env["LD_LIBRARY_PATH"] = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    cpp_test_server = cpp_test_dir / 'tcp_transport_server_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    cpp_test_server = cpp_test_dir / "tcp_transport_server_test"
     server = subprocess.Popen(
-            [str(cpp_test_server)], env=env, stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            universal_newlines=True, bufsize=1, close_fds=True)
+        [str(cpp_test_server)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        bufsize=1,
+        close_fds=True,
+    )
 
     # get server location
     location = server.stdout.readline()
@@ -36,17 +41,17 @@ def test_cpp_tcp_server(log_file_in_tmpdir):
     assert TcpTransportClient.can_connect_to(location)
 
     client = MPPClient([location])
-    msg_bytes, _ = client.receive(Reference('test_receiver.port'), None)
+    msg_bytes, _ = client.receive(Reference("test_receiver.port"), None)
     msg = MPPMessage.from_bytes(msg_bytes)
     client.close()
 
     # assert stuff
-    assert msg.sender == 'test_sender.port'
-    assert msg.receiver == 'test_receiver.port'
+    assert msg.sender == "test_sender.port"
+    assert msg.receiver == "test_receiver.port"
     assert msg.timestamp == 0.0
     assert msg.next_timestamp == 1.0
-    assert msg.settings_overlay == Settings({'par1': 13})
-    assert msg.data == {'var1': 1, 'var2': 2.0, 'var3': '3'}
+    assert msg.settings_overlay == Settings({"par1": 13})
+    assert msg.data == {"var1": 1, "var2": 2.0, "var3": "3"}
 
     server.stdout.close()
     server.wait()

--- a/integration_test/test_crash_cleanup.py
+++ b/integration_test/test_crash_cleanup.py
@@ -12,13 +12,13 @@ def test_crash_cleanup(tmpdir):
     tmppath = Path(str(tmpdir))
 
     # find our test component and its requirements
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    ld_lib_path = ':'.join(map(str, lib_paths))
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    ld_lib_path = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    test_component = cpp_test_dir / 'component_test'
-    crash_component = cpp_test_dir / 'crashing_component_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    test_component = cpp_test_dir / "component_test"
+    crash_component = cpp_test_dir / "crashing_component_test"
 
     # make config
     ymmsl_text = f"""
@@ -62,10 +62,10 @@ resources:
     config = ymmsl.load(ymmsl_text)
 
     # set up
-    run_dir = RunDir(tmppath / 'run')
+    run_dir = RunDir(tmppath / "run")
 
     # launch MUSCLE Manager with simulation
-    manager = Manager(config, run_dir, 'DEBUG')
+    manager = Manager(config, run_dir, "DEBUG")
     try:
         manager.start_instances()
     except:  # noqa

--- a/integration_test/test_deadlock_detection.py
+++ b/integration_test/test_deadlock_detection.py
@@ -18,6 +18,7 @@ def suppress_deadlock_exception_output(func):
             if "deadlock" not in exc_str and "did the peer crash?" not in exc_str:
                 raise
             sys.exit(1)
+
     return wrapper
 
 
@@ -136,79 +137,100 @@ settings:
 
 def test_no_deadlock(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_CONFIG, tmp_path,
-        {"macro": ("python", macro),
-         "micro": ("python", micro)})
+        MACRO_MICRO_CONFIG,
+        tmp_path,
+        {"macro": ("python", macro), "micro": ("python", micro)},
+    )
 
 
 def test_deadlock1(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_CONFIG, tmp_path,
-        {"macro": ("python", macro),
-         "micro": ("python", deadlocking_micro)},
-        expect_success=False)
+        MACRO_MICRO_CONFIG,
+        tmp_path,
+        {"macro": ("python", macro), "micro": ("python", deadlocking_micro)},
+        expect_success=False,
+    )
 
 
 def test_deadlock2(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_CONFIG, tmp_path,
-        {"macro": ("python", deadlocking_macro),
-         "micro": ("python", micro)},
-        expect_success=False)
+        MACRO_MICRO_CONFIG,
+        tmp_path,
+        {"macro": ("python", deadlocking_macro), "micro": ("python", micro)},
+        expect_success=False,
+    )
 
 
 def test_no_deadlock_with_dispatch(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_WITH_DISPATCH_CONFIG, tmp_path,
-        {"macro": ("python", macro),
-         "micro1": ("python", micro),
-         "micro2": ("python", micro),
-         "micro3": ("python", micro)})
+        MACRO_MICRO_WITH_DISPATCH_CONFIG,
+        tmp_path,
+        {
+            "macro": ("python", macro),
+            "micro1": ("python", micro),
+            "micro2": ("python", micro),
+            "micro3": ("python", micro),
+        },
+    )
 
 
 def test_deadlock1_with_dispatch(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_WITH_DISPATCH_CONFIG, tmp_path,
-        {"macro": ("python", macro),
-         "micro1": ("python", micro),
-         "micro2": ("python", deadlocking_micro),
-         "micro3": ("python", micro)},
-        expect_success=False)
+        MACRO_MICRO_WITH_DISPATCH_CONFIG,
+        tmp_path,
+        {
+            "macro": ("python", macro),
+            "micro1": ("python", micro),
+            "micro2": ("python", deadlocking_micro),
+            "micro3": ("python", micro),
+        },
+        expect_success=False,
+    )
 
 
 def test_deadlock2_with_dispatch(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_WITH_DISPATCH_CONFIG, tmp_path,
-        {"macro": ("python", deadlocking_macro),
-         "micro1": ("python", micro),
-         "micro2": ("python", micro),
-         "micro3": ("python", micro)},
-        expect_success=False)
+        MACRO_MICRO_WITH_DISPATCH_CONFIG,
+        tmp_path,
+        {
+            "macro": ("python", deadlocking_macro),
+            "micro1": ("python", micro),
+            "micro2": ("python", micro),
+            "micro3": ("python", micro),
+        },
+        expect_success=False,
+    )
 
 
 @skip_if_python_only
 def test_no_deadlock_cpp(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_CONFIG, tmp_path,
-        {"macro": ("cpp", "component_test"),
-         "micro": ("python", micro)})
+        MACRO_MICRO_CONFIG,
+        tmp_path,
+        {"macro": ("cpp", "component_test"), "micro": ("python", micro)},
+    )
 
 
 @skip_if_python_only
 def test_deadlock1_cpp(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_CONFIG, tmp_path,
-        {"macro": ("cpp", "component_test"),
-         "micro": ("python", deadlocking_micro)},
-        expect_success=False)
+        MACRO_MICRO_CONFIG,
+        tmp_path,
+        {"macro": ("cpp", "component_test"), "micro": ("python", deadlocking_micro)},
+        expect_success=False,
+    )
 
 
 @skip_if_python_only
 def test_deadlock2_cpp(tmp_path):
     run_manager_with_actors(
-        MACRO_MICRO_WITH_DISPATCH_CONFIG, tmp_path,
-        {"macro": ("cpp", "component_test"),
-         "micro1": ("python", micro),
-         "micro2": ("python", deadlocking_micro),
-         "micro3": ("cpp", "component_test")},
-        expect_success=False)
+        MACRO_MICRO_WITH_DISPATCH_CONFIG,
+        tmp_path,
+        {
+            "macro": ("cpp", "component_test"),
+            "micro1": ("python", micro),
+            "micro2": ("python", deadlocking_micro),
+            "micro3": ("cpp", "component_test"),
+        },
+        expect_success=False,
+    )

--- a/integration_test/test_duplication_mapper.py
+++ b/integration_test/test_duplication_mapper.py
@@ -13,28 +13,26 @@ from libmuscle import Instance, Message
 
 
 def duplication_mapper():
-    """Duplication mapper implementation.
-    """
+    """Duplication mapper implementation."""
     instance = Instance()
 
     while instance.reuse_instance():
         # o_f
         out_ports = instance.list_ports()[Operator.O_F]
 
-        message = Message(0.0, data='testing')
+        message = Message(0.0, data="testing")
         for out_port in out_ports:
             instance.send(out_port, message)
 
 
 def receiver():
-    """Receiver for messages from dm.
-    """
-    instance = Instance({Operator.F_INIT: ['in']})
+    """Receiver for messages from dm."""
+    instance = Instance({Operator.F_INIT: ["in"]})
 
     while instance.reuse_instance():
         # f_init
-        msg = instance.receive('in')
-        assert msg.data == 'testing'
+        msg = instance.receive("in")
+        assert msg.data == "testing"
 
 
 def test_duplication_mapper(log_file_in_tmpdir):
@@ -43,23 +41,20 @@ def test_duplication_mapper(log_file_in_tmpdir):
     This is an acyclic workflow.
     """
     components = [
-            Component(
-                'dm', Ports(o_f='out out2'), '', 'muscle.duplication_mapper'),
-            Component(
-                'first', Ports('in'), '', 'receiver'),
-            Component(
-                'second', Ports('in'), '', 'receiver')]
+        Component("dm", Ports(o_f="out out2"), "", "muscle.duplication_mapper"),
+        Component("first", Ports("in"), "", "receiver"),
+        Component("second", Ports("in"), "", "receiver"),
+    ]
 
-    conduits = [
-                Conduit('dm.out', 'first.in'),
-                Conduit('dm.out2', 'second.in')]
+    conduits = [Conduit("dm.out", "first.in"), Conduit("dm.out2", "second.in")]
 
-    model = Model('test_model', None, '', None, components, conduits)
+    model = Model("test_model", None, "", None, components, conduits)
     settings = Settings()
 
-    configuration = Configuration('test_dm', None, [model], None, settings)
+    configuration = Configuration("test_dm", None, [model], None, settings)
 
     implementations = {
-            'muscle.duplication_mapper': duplication_mapper,
-            'receiver': receiver}
+        "muscle.duplication_mapper": duplication_mapper,
+        "receiver": receiver,
+    }
     run_simulation(configuration, implementations)

--- a/integration_test/test_logging.py
+++ b/integration_test/test_logging.py
@@ -7,59 +7,60 @@ from ymmsl.v0_2 import Reference
 
 def test_logging(log_file_in_tmpdir, caplog):
     ymmsl_text = (
-            'ymmsl_version: v0.2\n'
-            'description: A log test configuration\n'
-            'models:\n'
-            '- name: test_model\n'
-            '  description: Macro-micro ensemble model\n'
-            '  components:\n'
-            '    macro:\n'
-            '      ports:\n'
-            '        o_i: out\n'
-            '        s: in\n'
-            '      description: The macro model\n'
-            '      implementation: macro_implementation\n'
-            '    micro:\n'
-            '      ports:\n'
-            '        f_init: in\n'
-            '        o_f: out\n'
-            '      description: The micro model\n'
-            '      implementation: micro_implementation\n'
-            '      multiplicity: [10]\n'
-            '  conduits:\n'
-            '    macro.out: micro.in\n'
-            '    micro.out: macro.in\n'
-            'settings:\n'
-            '  test1: 13\n'
-            '  test2: 13.3\n'
-            '  test3: testing\n'
-            '  test4: True\n'
-            '  test5: [2.3, 5.6]\n'
-            '  test6:\n'
-            '    - [1.0, 2.0]\n'
-            '    - [3.0, 1.0]\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: A log test configuration\n"
+        "models:\n"
+        "- name: test_model\n"
+        "  description: Macro-micro ensemble model\n"
+        "  components:\n"
+        "    macro:\n"
+        "      ports:\n"
+        "        o_i: out\n"
+        "        s: in\n"
+        "      description: The macro model\n"
+        "      implementation: macro_implementation\n"
+        "    micro:\n"
+        "      ports:\n"
+        "        f_init: in\n"
+        "        o_f: out\n"
+        "      description: The micro model\n"
+        "      implementation: micro_implementation\n"
+        "      multiplicity: [10]\n"
+        "  conduits:\n"
+        "    macro.out: micro.in\n"
+        "    micro.out: macro.in\n"
+        "settings:\n"
+        "  test1: 13\n"
+        "  test2: 13.3\n"
+        "  test3: testing\n"
+        "  test4: True\n"
+        "  test5: [2.3, 5.6]\n"
+        "  test6:\n"
+        "    - [1.0, 2.0]\n"
+        "    - [3.0, 1.0]\n"
+    )
 
     # create server
     ymmsl_doc = ymmsl.load(ymmsl_text)
     manager = Manager(ymmsl_doc)
 
     # create client
-    instance_id = Reference('test_logging')
+    instance_id = Reference("test_logging")
     client = MMPClient(instance_id, manager.get_server_location())
     message = LogMessage(
-            instance_id=str(instance_id),
-            timestamp=Timestamp(2.0),
-            level=LogLevel.DEBUG,
-            text='Integration testing')
+        instance_id=str(instance_id),
+        timestamp=Timestamp(2.0),
+        level=LogLevel.DEBUG,
+        text="Integration testing",
+    )
 
     # log and check
     client.submit_log_message(message)
     for rec in caplog.records:
-        if rec.name == 'instances.test_logging':
-            assert rec.time_stamp == '1970-01-01T00:00:02Z'
-            assert rec.levelname == 'DEBUG'
-            assert rec.message == 'Integration testing'
+        if rec.name == "instances.test_logging":
+            assert rec.time_stamp == "1970-01-01T00:00:02Z"
+            assert rec.levelname == "DEBUG"
+            assert rec.message == "Integration testing"
             break
 
     client.close()

--- a/integration_test/test_macro_micro.py
+++ b/integration_test/test_macro_micro.py
@@ -11,73 +11,73 @@ from .conftest import run_manager_with_actors, skip_if_no_fortran, skip_if_pytho
 def check_settings(instance):
     settings = instance.list_settings()
 
-    assert len(settings) == 8   # test1-6, test_with_a_longer_name, python_compat
+    assert len(settings) == 8  # test1-6, test_with_a_longer_name, python_compat
     setting_seen = [False] * 8
     for setting in settings:
-        if setting == 'test1':
+        if setting == "test1":
             setting_seen[0] = True
-        elif setting == 'test2':
+        elif setting == "test2":
             setting_seen[1] = True
-        elif setting == 'test3':
+        elif setting == "test3":
             setting_seen[2] = True
-        elif setting == 'test4':
+        elif setting == "test4":
             setting_seen[3] = True
-        elif setting == 'test5':
+        elif setting == "test5":
             setting_seen[4] = True
-        elif setting == 'test6':
+        elif setting == "test6":
             setting_seen[5] = True
-        elif setting == 'test_with_a_longer_name':
+        elif setting == "test_with_a_longer_name":
             setting_seen[6] = True
-        elif setting == 'python_compat':
+        elif setting == "python_compat":
             setting_seen[7] = True
         else:
-            raise RuntimeError('Unexpected setting name ' + setting)
+            raise RuntimeError("Unexpected setting name " + setting)
 
     assert all(setting_seen)
 
-    assert isinstance(instance.get_setting('test1'), int)
-    assert not isinstance(instance.get_setting('test1'), bool)
+    assert isinstance(instance.get_setting("test1"), int)
+    assert not isinstance(instance.get_setting("test1"), bool)
     try:
-        instance.get_setting('does_not_exist')
+        instance.get_setting("does_not_exist")
     except KeyError:
         pass
 
-    assert instance.get_setting('test1', 'int') == 13
-    assert instance.get_setting('test4', 'bool') is True
+    assert instance.get_setting("test1", "int") == 13
+    assert instance.get_setting("test4", "bool") is True
 
     # Test get_setting_as with default (scalar types only)
-    assert instance.get_setting('test1', 'int', default=99) == 13
-    assert instance.get_setting('does_not_exist', 'int', default=99) == 99
+    assert instance.get_setting("test1", "int", default=99) == 13
+    assert instance.get_setting("does_not_exist", "int", default=99) == 99
 
-    assert instance.get_setting('test4', 'bool', default=False) is True
-    assert instance.get_setting('does_not_exist', 'bool', default=False) is False
+    assert instance.get_setting("test4", "bool", default=False) is True
+    assert instance.get_setting("does_not_exist", "bool", default=False) is False
 
-    assert instance.get_setting('test2', 'float', default=99.0) == 13.3
-    assert instance.get_setting('does_not_exist', 'float', default=99.0) == 99.0
+    assert instance.get_setting("test2", "float", default=99.0) == 13.3
+    assert instance.get_setting("does_not_exist", "float", default=99.0) == 99.0
 
-    assert instance.get_setting('test3', 'str', default='default') == 'testing'
-    assert instance.get_setting('does_not_exist', 'str', default='default') == 'default'
+    assert instance.get_setting("test3", "str", default="default") == "testing"
+    assert instance.get_setting("does_not_exist", "str", default="default") == "default"
 
 
 def check_data(data, python_compat):
-    assert data['bool'] is True
-    assert data['char'] == 23
-    assert data['short int'] == 4097
-    assert data['int'] == 1234567
-    assert data['long int'] == 1234568
-    assert data['long long int'] == 6001002003
+    assert data["bool"] is True
+    assert data["char"] == 23
+    assert data["short int"] == 4097
+    assert data["int"] == 1234567
+    assert data["long int"] == 1234568
+    assert data["long long int"] == 6001002003
     if not python_compat:
-        assert data['float'] == 1.23456
-    assert data['double'] == 1.2345678901234
-    assert data['message'] == 'testing'
+        assert data["float"] == 1.23456
+    assert data["double"] == 1.2345678901234
+    assert data["message"] == "testing"
 
-    r_list = data['list']
+    r_list = data["list"]
     assert r_list[0] == 1
-    assert r_list[1] == 'two'
+    assert r_list[1] == "two"
     if not python_compat:
         assert data[2] == 3.0
 
-    r_test_grid = data['test_grid']
+    r_test_grid = data["test_grid"]
     assert isinstance(r_test_grid, Grid)
     assert r_test_grid.array.dtype.type == np.float64
     assert r_test_grid.array.shape == (2, 3)
@@ -90,65 +90,64 @@ def make_data():
     assert test_array.shape == (2, 3)
     assert test_array.flags.c_contiguous
     return {
-            'bool': True,
-            'char': 23,
-            'short int': 4097,
-            'int': 1234567,
-            'long int': 1234568,
-            'long long int': 6001002003,
-            'double': 1.2345678901234,
-            'message': 'testing',
-            'list': [1, 'two'],
-            'test_grid': test_array}
+        "bool": True,
+        "char": 23,
+        "short int": 4097,
+        "int": 1234567,
+        "long int": 1234568,
+        "long long int": 6001002003,
+        "double": 1.2345678901234,
+        "message": "testing",
+        "list": [1, "two"],
+        "test_grid": test_array,
+    }
 
 
 def macro():
-    instance = Instance({
-            Operator.O_I: ['out'],
-            Operator.S: ['in']})
+    instance = Instance({Operator.O_I: ["out"], Operator.S: ["in"]})
 
     while instance.reuse_instance():
         # f_init
-        python_compat = instance.get_setting('python_compat')
-        assert instance.get_setting('test1') == 13
+        python_compat = instance.get_setting("python_compat")
+        assert instance.get_setting("test1") == 13
 
         for i in range(2):
             # o_i
             data = make_data()
-            instance.send('out', Message(i * 10.0, (i + 1) * 10.0, data))
+            instance.send("out", Message(i * 10.0, (i + 1) * 10.0, data))
 
             # s/b
-            msg = instance.receive('in')
+            msg = instance.receive("in")
             check_data(msg.data, python_compat)
 
 
 def micro():
-    instance = Instance({
-        Operator.F_INIT: ['in'],
-        Operator.O_F: ['out']})
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_F: ["out"]})
 
     while instance.reuse_instance():
         # f_init
         check_settings(instance)
-        python_compat = instance.get_setting('python_compat')
+        python_compat = instance.get_setting("python_compat")
 
-        msg = instance.receive('in')
+        msg = instance.receive("in")
         check_data(msg.data, python_compat)
 
         # o_f
         reply = make_data()
-        instance.send('out', Message(msg.timestamp, None, reply))
+        instance.send("out", Message(msg.timestamp, None, reply))
 
 
 def check_profile_output(tmp_path):
-    conn = sqlite3.connect(tmp_path / 'performance.sqlite')
+    conn = sqlite3.connect(tmp_path / "performance.sqlite")
     cur = conn.cursor()
 
     def check(instance: str, typ: str, port: str, operator: str) -> None:
         cur.execute(
-                "SELECT * FROM all_events"
-                "    WHERE instance = ? AND type = ?"
-                "    ORDER BY start_time", (instance, typ))
+            "SELECT * FROM all_events"
+            "    WHERE instance = ? AND type = ?"
+            "    ORDER BY start_time",
+            (instance, typ),
+        )
         res = cur.fetchall()
         assert len(res) == 2
         assert res[0][4:8] == (port, operator, None, None)
@@ -161,10 +160,10 @@ def check_profile_output(tmp_path):
         assert res[1][9] > 0
         assert res[1][10] == 10.0
 
-    check('macro', 'SEND', 'out', 'O_I')
-    check('micro', 'RECEIVE_TRANSFER', 'in', 'F_INIT')
-    check('micro', 'SEND', 'out', 'O_F')
-    check('macro', 'RECEIVE_DECODE', 'in', 'S')
+    check("macro", "SEND", "out", "O_I")
+    check("micro", "RECEIVE_TRANSFER", "in", "F_INIT")
+    check("micro", "SEND", "out", "O_F")
+    check("macro", "RECEIVE_DECODE", "in", "S")
 
     cur.close()
     conn.close()
@@ -172,10 +171,10 @@ def check_profile_output(tmp_path):
 
 def test_python_macro_micro(mmp_server_config_simple_python, tmp_path):
     run_manager_with_actors(
-            mmp_server_config_simple_python,
-            tmp_path,
-            {'micro': ('python', micro),
-             'macro': ('python', macro)})
+        mmp_server_config_simple_python,
+        tmp_path,
+        {"micro": ("python", micro), "macro": ("python", macro)},
+    )
 
     check_profile_output(tmp_path)
 
@@ -185,10 +184,10 @@ def test_python_cpp_macro_micro(mmp_server_config_simple_python, tmp_path):
     # create C++ micro model
     # see libmuscle/cpp/src/libmuscle/tests/micro_model_test.cpp
     run_manager_with_actors(
-            mmp_server_config_simple_python,
-            tmp_path,
-            {'micro': ('cpp', 'micro_model_test'),
-             'macro': ('python', macro)})
+        mmp_server_config_simple_python,
+        tmp_path,
+        {"micro": ("cpp", "micro_model_test"), "macro": ("python", macro)},
+    )
 
     check_profile_output(tmp_path)
 
@@ -199,10 +198,10 @@ def test_cpp_macro_micro(mmp_server_config_simple_nopython, tmp_path):
     # see libmuscle/cpp/src/libmuscle/tests/micro_model_test.cpp
     # and libmuscle/cpp/src/libmuscle/tests/macro_model_test.cpp
     run_manager_with_actors(
-            mmp_server_config_simple_nopython,
-            tmp_path,
-            {'micro': ('cpp', 'micro_model_test'),
-             'macro': ('cpp', 'macro_model_test')})
+        mmp_server_config_simple_nopython,
+        tmp_path,
+        {"micro": ("cpp", "micro_model_test"), "macro": ("cpp", "macro_model_test")},
+    )
 
     check_profile_output(tmp_path)
 
@@ -213,10 +212,10 @@ def test_python_fortran_macro_micro(mmp_server_config_simple_python, tmp_path):
     # create Fortran micro model
     # see libmuscle/fortran/src/libmuscle/tests/fortran_micro_model_test.f90
     run_manager_with_actors(
-            mmp_server_config_simple_python,
-            tmp_path,
-            {'micro': ('fortran', 'fortran_micro_model_test'),
-             'macro': ('python', macro)})
+        mmp_server_config_simple_python,
+        tmp_path,
+        {"micro": ("fortran", "fortran_micro_model_test"), "macro": ("python", macro)},
+    )
 
 
 @skip_if_python_only
@@ -225,7 +224,10 @@ def test_fortran_macro_micro(mmp_server_config_simple_nopython, tmp_path):
     # create Fortran micro model
     # see libmuscle/fortran/src/libmuscle/tests/fortran_micro_model_test.f90
     run_manager_with_actors(
-            mmp_server_config_simple_nopython,
-            tmp_path,
-            {'micro': ('fortran', 'fortran_micro_model_test'),
-             'macro': ('cpp', 'macro_model_test')})
+        mmp_server_config_simple_nopython,
+        tmp_path,
+        {
+            "micro": ("fortran", "fortran_micro_model_test"),
+            "macro": ("cpp", "macro_model_test"),
+        },
+    )

--- a/integration_test/test_model_imports.py
+++ b/integration_test/test_model_imports.py
@@ -7,23 +7,26 @@ from muscle3.muscle_manager import _manage_simulation
 
 
 def manage_simulation(
-        ymmsl_path: str, codes_path: str, ymmsl_files: Sequence[str]) -> None:
+    ymmsl_path: str, codes_path: str, ymmsl_files: Sequence[str]
+) -> None:
     """Set environment and run the simulation.
 
     Note that the environment needs to be set within the subprocess for this to work on
     platforms that don't use fork, which includes POSIX on Python 3.14 and up.
     """
-    os.environ['YMMSL_PATH'] = ymmsl_path
-    os.environ['PYTHONPATH'] = ':'.join([codes_path, os.environ.get('PYTHONPATH', '')])
+    os.environ["YMMSL_PATH"] = ymmsl_path
+    os.environ["PYTHONPATH"] = ":".join([codes_path, os.environ.get("PYTHONPATH", "")])
     _manage_simulation(ymmsl_files, True, None, None, None, None)
 
 
 def test_model_imports(ymmsl_path, codes_path, log_file_in_tmpdir) -> None:
     this_dir = Path(__file__).parent
-    ymmsl_files = [str(this_dir / 'ymmsl' / 'models' / 'macro_micro_import.ymmsl')]
+    ymmsl_files = [str(this_dir / "ymmsl" / "models" / "macro_micro_import.ymmsl")]
     proc = Process(
-            target=manage_simulation, args=(ymmsl_path, codes_path, ymmsl_files),
-            name='test_model_imports')
+        target=manage_simulation,
+        args=(ymmsl_path, codes_path, ymmsl_files),
+        name="test_model_imports",
+    )
     proc.start()
     proc.join()
     assert proc.exitcode == 0

--- a/integration_test/test_mpi_macro_micro.py
+++ b/integration_test/test_mpi_macro_micro.py
@@ -6,21 +6,19 @@ from .conftest import run_manager_with_actors, skip_if_no_mpi_cpp, skip_if_pytho
 
 
 def macro():
-    instance = Instance({
-            Operator.O_I: ['out'],
-            Operator.S: ['in']})
+    instance = Instance({Operator.O_I: ["out"], Operator.S: ["in"]})
 
     while instance.reuse_instance():
         # f_init
-        assert instance.get_setting('test1') == 13
+        assert instance.get_setting("test1") == 13
 
         for i in range(2):
             # o_i
-            instance.send('out', Message(i * 10.0, (i + 1) * 10.0, 'testing'))
+            instance.send("out", Message(i * 10.0, (i + 1) * 10.0, "testing"))
 
             # s/b
-            msg = instance.receive('in')
-            assert msg.data == f'testing back {i}'
+            msg = instance.receive("in")
+            assert msg.data == f"testing back {i}"
             assert msg.timestamp == i * 10.0
 
 
@@ -28,6 +26,7 @@ def macro():
 @skip_if_no_mpi_cpp
 def test_mpi_macro_micro(tmpdir, mmp_server_config_simple):
     actors = {
-            'macro': ('python', macro),
-            'micro': ('mpicpp', 'mpi_micro_model_test', '2')}  # 2 processes
+        "macro": ("python", macro),
+        "micro": ("mpicpp", "mpi_micro_model_test", "2"),
+    }  # 2 processes
     run_manager_with_actors(mmp_server_config_simple, tmpdir, actors)

--- a/integration_test/test_multicast.py
+++ b/integration_test/test_multicast.py
@@ -13,39 +13,39 @@ from libmuscle import Instance, Message
 
 
 def multicaster():
-    instance = Instance({Operator.O_F: ['out']})
+    instance = Instance({Operator.O_F: ["out"]})
 
     while instance.reuse_instance():
         # o_f
-        message = Message(0.0, data='testing')
-        instance.send('out', message)
+        message = Message(0.0, data="testing")
+        instance.send("out", message)
 
 
 def receiver():
-    instance = Instance({Operator.F_INIT: ['in']})
+    instance = Instance({Operator.F_INIT: ["in"]})
 
     while instance.reuse_instance():
         # f_init
-        msg = instance.receive('in')
-        assert msg.data == 'testing'
+        msg = instance.receive("in")
+        assert msg.data == "testing"
 
 
 def test_multicast(log_file_in_tmpdir):
     elements = [
-            Component('broadcast', Ports(o_f='out'), '', 'broadcaster'),
-            Component('first', Ports('in'), '', 'receiver'),
-            Component('second', Ports('in'), '', 'receiver')]
+        Component("broadcast", Ports(o_f="out"), "", "broadcaster"),
+        Component("first", Ports("in"), "", "receiver"),
+        Component("second", Ports("in"), "", "receiver"),
+    ]
 
     conduits = [
-                Conduit('broadcast.out', 'first.in'),
-                Conduit('broadcast.out', 'second.in')]
+        Conduit("broadcast.out", "first.in"),
+        Conduit("broadcast.out", "second.in"),
+    ]
 
-    model = Model('test_model', None, '', None, elements, conduits)
+    model = Model("test_model", None, "", None, elements, conduits)
     settings = Settings()
 
-    configuration = Configuration('multicast', None, [model], None, settings)
+    configuration = Configuration("multicast", None, [model], None, settings)
 
-    implementations = {
-            'broadcaster': multicaster,
-            'receiver': receiver}
+    implementations = {"broadcaster": multicaster, "receiver": receiver}
     run_simulation(configuration, implementations)

--- a/integration_test/test_multicast_cpp.py
+++ b/integration_test/test_multicast_cpp.py
@@ -6,12 +6,12 @@ from .conftest import run_manager_with_actors, skip_if_python_only
 
 
 def receiver():
-    instance = Instance({Operator.F_INIT: ['in']})
+    instance = Instance({Operator.F_INIT: ["in"]})
 
     i = 0
     while instance.reuse_instance():
         # f_init
-        msg = instance.receive('in')
+        msg = instance.receive("in")
         assert msg.data == i
         assert isinstance(msg.data, int)
         i += 1
@@ -47,6 +47,9 @@ models:
     - receiver1.in
     - receiver2.in""",
         tmp_path,
-        {'multicast': ('cpp', 'component_test'),
-         'receiver1': ('python', receiver),
-         'receiver2': ('python', receiver)})
+        {
+            "multicast": ("cpp", "component_test"),
+            "receiver1": ("python", receiver),
+            "receiver2": ("python", receiver),
+        },
+    )

--- a/integration_test/test_muscle_tester_macro_micro.py
+++ b/integration_test/test_muscle_tester_macro_micro.py
@@ -8,14 +8,14 @@ from libmuscle.pytest import MuscleTester
 
 from libmuscle import Message
 
-YMMSL_CODES_DIR = Path(__file__).parent / 'ymmsl' / 'codes'
-CODES_DIR = Path(__file__).parent / 'codes'
+YMMSL_CODES_DIR = Path(__file__).parent / "ymmsl" / "codes"
+CODES_DIR = Path(__file__).parent / "codes"
 
 
 @pytest.fixture(autouse=True)
 def set_pythonpath(monkeypatch):
     """Ensure the codes directory is on PYTHONPATH so 'python3 -m micro' works."""
-    monkeypatch.setenv("PYTHONPATH", str(CODES_DIR),  prepend=":")
+    monkeypatch.setenv("PYTHONPATH", str(CODES_DIR), prepend=":")
 
 
 def test_micro_model_with_tester(muscle3_tester: MuscleTester) -> None:
@@ -30,14 +30,14 @@ def test_micro_model_with_tester(muscle3_tester: MuscleTester) -> None:
       - Expects to receive the same integers back on 'final'
     """
     tester = muscle3_tester.start_implementation(
-        YMMSL_CODES_DIR / 'micro1.ymmsl','micro1'
-        )
+        YMMSL_CODES_DIR / "micro1.ymmsl", "micro1"
+    )
 
     for i in range(2):
         msg = Message(float(i) * 10.0, float(i + 1) * 10.0, i)
 
-        tester.send('init', msg)
-        reply = tester.receive('final')
+        tester.send("init", msg)
+        reply = tester.receive("final")
 
         assert reply.data == i, (
             f"Iteration {i}: expected micro to echo back {i}, got {reply.data}"
@@ -60,17 +60,17 @@ def test_macro_model_with_tester(muscle3_tester: MuscleTester) -> None:
       - Sends the same value back on 'in'
     """
     tester = muscle3_tester.start_implementation(
-        YMMSL_CODES_DIR / 'macro.ymmsl', 'macro'
-        )
+        YMMSL_CODES_DIR / "macro.ymmsl", "macro"
+    )
 
     for i in range(2):
-        msg = tester.receive('out')
+        msg = tester.receive("out")
         assert msg.data == i, (
             f"Iteration {i}: expected macro to send {i}, got {msg.data}"
         )
 
         reply = Message(msg.timestamp, msg.next_timestamp, msg.data)
-        tester.send('in', reply)
+        tester.send("in", reply)
 
 
 def test_receive_timeout_raises_error(muscle3_tester: MuscleTester) -> None:
@@ -81,18 +81,19 @@ def test_receive_timeout_raises_error(muscle3_tester: MuscleTester) -> None:
     the tester's receive will time out and raise a RuntimeError.
     """
     tester = muscle3_tester.start_implementation(
-        YMMSL_CODES_DIR / 'micro1.ymmsl', 'micro1', default_timeout=2.0
+        YMMSL_CODES_DIR / "micro1.ymmsl", "micro1", default_timeout=2.0
     )
 
     with pytest.raises(RuntimeError):
-        tester.receive('final')
+        tester.receive("final")
+
 
 def test_failing_actor(muscle3_tester: MuscleTester) -> None:
     """Test that a RuntimeError is raised when the actor crashes after registering.
 
     The test_program registers with MUSCLE3 using start_implementation, then crashes.
     Any subsequent communication attempt should raise a RuntimeError. This RuntimeError
-    should be raised in at least min(RECONNECT_TIMEOUT, default_timeout) seconds. 
+    should be raised in at least min(RECONNECT_TIMEOUT, default_timeout) seconds.
     """
     default_timeout = 1.0
     tester = muscle3_tester.start_implementation(
@@ -111,7 +112,7 @@ def test_failing_actor(muscle3_tester: MuscleTester) -> None:
 
     start = time.monotonic()
     with pytest.raises(RuntimeError):
-        tester.receive('output')
+        tester.receive("output")
     elapsed = time.monotonic() - start
 
     eps = 5
@@ -120,6 +121,7 @@ def test_failing_actor(muscle3_tester: MuscleTester) -> None:
         f"Expected reconnection retries to take at most {max_allowed_time:.1f} s "
         f"(including {eps}s eps), but it took {elapsed:.1f} s"
     )
+
 
 def test_failing_executable(muscle3_tester: MuscleTester) -> None:
     """Test that a RuntimeError is raised within default_timeout seconds when the
@@ -153,4 +155,3 @@ def test_failing_executable(muscle3_tester: MuscleTester) -> None:
         f"Expected start_implementation to raise within {max_allowed_time:.1f} s "
         f"(including {eps}s eps), but it took {elapsed:.1f} s"
     )
-

--- a/integration_test/test_nested.py
+++ b/integration_test/test_nested.py
@@ -6,56 +6,56 @@ from integration_test.test_all import NUM_MICROS, macro, micro
 
 def test_nested(log_file_in_tmpdir, tmp_path):
     yaml_text = (
-            'ymmsl_version: v0.2\n'
-            'description: Simple nested test configuration\n'
-            'models:\n'
-            '  outer:\n'
-            '    description: Model containing a submodel\n'
-            '    components:\n'
-            '      macro:\n'
-            '        ports:\n'
-            '          o_i: out\n'
-            '          s: in\n'
-            '        description: Macro model\n'
-            '        implementation: macro_impl\n'
-            '      sim:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out\n'
-            '        description: Simulates stuff\n'
-            '        implementation: inner\n'
-            '    conduits:\n'
-            '      macro.out: sim.in\n'
-            '      sim.out: macro.in\n'
-            '  inner:\n'
-            '    ports:\n'
-            '      f_init: in\n'
-            '      o_f: out\n'
-            '    description: Nested simulation model\n'
-            '    components:\n'
-            '      simulate:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out\n'
-            '        description: Micro model\n'
-            '        implementation: micro_impl\n'
-            '    conduits:\n'
-            '      in: simulate.in\n'
-            '      simulate.out: out\n'
-            'settings:\n'
-            '  muscle_local_log_level: DEBUG\n'
-            '  test1: 13\n'
-            '  test2: 13.3\n'
-            '  test3: testing\n'
-            '  test4: true\n'
-            '  test5: [2.3, 5.6]\n'
-            '  test6:\n'
-            '  - [1.0, 2.0]\n'
-            '  - [3.0, 1.0]\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Simple nested test configuration\n"
+        "models:\n"
+        "  outer:\n"
+        "    description: Model containing a submodel\n"
+        "    components:\n"
+        "      macro:\n"
+        "        ports:\n"
+        "          o_i: out\n"
+        "          s: in\n"
+        "        description: Macro model\n"
+        "        implementation: macro_impl\n"
+        "      sim:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "          o_f: out\n"
+        "        description: Simulates stuff\n"
+        "        implementation: inner\n"
+        "    conduits:\n"
+        "      macro.out: sim.in\n"
+        "      sim.out: macro.in\n"
+        "  inner:\n"
+        "    ports:\n"
+        "      f_init: in\n"
+        "      o_f: out\n"
+        "    description: Nested simulation model\n"
+        "    components:\n"
+        "      simulate:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "          o_f: out\n"
+        "        description: Micro model\n"
+        "        implementation: micro_impl\n"
+        "    conduits:\n"
+        "      in: simulate.in\n"
+        "      simulate.out: out\n"
+        "settings:\n"
+        "  muscle_local_log_level: DEBUG\n"
+        "  test1: 13\n"
+        "  test2: 13.3\n"
+        "  test3: testing\n"
+        "  test4: true\n"
+        "  test5: [2.3, 5.6]\n"
+        "  test6:\n"
+        "  - [1.0, 2.0]\n"
+        "  - [3.0, 1.0]\n"
+    )
 
     configuration = load(yaml_text)
-    configuration.models['outer'].components['sim'].multiplicity = [NUM_MICROS]
+    configuration.models["outer"].components["sim"].multiplicity = [NUM_MICROS]
 
-    implementations = {'macro_impl': macro, 'micro_impl': micro}
+    implementations = {"macro_impl": macro, "micro_impl": micro}
     run_simulation(configuration, implementations)

--- a/integration_test/test_parameter_overlays.py
+++ b/integration_test/test_parameter_overlays.py
@@ -17,37 +17,34 @@ _ENSEMBLE_SIZE = 2
 
 
 def qmc():
-    """qMC implementation.
-    """
-    instance = Instance({Operator.O_F: ['settings_out[]']})
+    """qMC implementation."""
+    instance = Instance({Operator.O_F: ["settings_out[]"]})
 
     while instance.reuse_instance():
         # o_f
-        settings0 = Settings({'test2': 14.4})
+        settings0 = Settings({"test2": 14.4})
 
-        assert instance.is_connected('settings_out')
-        assert instance.is_vector_port('settings_out')
-        assert not instance.is_resizable('settings_out')
-        length = instance.get_port_length('settings_out')
+        assert instance.is_connected("settings_out")
+        assert instance.is_vector_port("settings_out")
+        assert not instance.is_resizable("settings_out")
+        length = instance.get_port_length("settings_out")
         assert length == _ENSEMBLE_SIZE
         for slot in range(length):
-            instance.send('settings_out', Message(0.0, data=settings0), slot)
+            instance.send("settings_out", Message(0.0, data=settings0), slot)
 
 
 def macro():
-    """Macro model implementation.
-    """
-    instance = Instance({
-            Operator.O_I: ['out'], Operator.S: ['in']})
+    """Macro model implementation."""
+    instance = Instance({Operator.O_I: ["out"], Operator.S: ["in"]})
 
     while instance.reuse_instance():
         # f_init
-        assert instance.get_setting('test2') == 14.4
+        assert instance.get_setting("test2") == 14.4
         # o_i
-        instance.send('out', Message(0.0, 10.0, 'testing'))
+        instance.send("out", Message(0.0, 10.0, "testing"))
         # s/b
-        msg = instance.receive('in')
-        assert msg.data == 'testing back'
+        msg = instance.receive("in")
+        assert msg.data == "testing back"
 
 
 def explicit_relay():
@@ -56,85 +53,91 @@ def explicit_relay():
     Sends and receives overlay settings explicitly, rather than
     having MUSCLE handle them. This just passes all information on.
     """
-    instance = Instance({
-            Operator.F_INIT: ['in[]'], Operator.O_F: ['out[]']},
-            DONT_APPLY_OVERLAY)
+    instance = Instance(
+        {Operator.F_INIT: ["in[]"], Operator.O_F: ["out[]"]}, DONT_APPLY_OVERLAY
+    )
 
     while instance.reuse_instance():
         # f_init
-        assert instance.get_setting('test2', 'float') == 13.3
-        assert instance.get_port_length('in') == instance.get_port_length(
-                'out')
+        assert instance.get_setting("test2", "float") == 13.3
+        assert instance.get_port_length("in") == instance.get_port_length("out")
 
         msgs = list()
-        for slot in range(instance.get_port_length('in')):
-            msg = instance.receive_with_settings('in', slot)
-            assert msg.data.startswith('testing')
-            assert msg.settings['test2'] == 14.4
+        for slot in range(instance.get_port_length("in")):
+            msg = instance.receive_with_settings("in", slot)
+            assert msg.data.startswith("testing")
+            assert msg.settings["test2"] == 14.4
             msgs.append(msg)
 
-        assert instance.get_setting('test2') == 13.3
+        assert instance.get_setting("test2") == 13.3
 
         # o_f
-        for slot in range(instance.get_port_length('out')):
-            instance.send('out', msgs[slot], slot)
+        for slot in range(instance.get_port_length("out")):
+            instance.send("out", msgs[slot], slot)
 
 
 def micro():
-    """Micro model implementation.
-    """
-    instance = Instance({Operator.F_INIT: ['in'], Operator.O_F: ['out']})
+    """Micro model implementation."""
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_F: ["out"]})
 
-    assert instance.get_setting('test2') == 13.3
+    assert instance.get_setting("test2") == 13.3
     while instance.reuse_instance():
         # f_init
-        assert instance.get_setting('test2', 'float') == 14.4
-        msg = instance.receive('in')
-        assert msg.data == 'testing'
+        assert instance.get_setting("test2", "float") == 14.4
+        msg = instance.receive("in")
+        assert msg.data == "testing"
 
         # with pytest.raises(RuntimeError):
         #     instance.receive_with_settings('in')
 
         # o_f
-        instance.send('out', Message(0.1, data='testing back'))
+        instance.send("out", Message(0.1, data="testing back"))
 
 
 def test_settings_overlays(log_file_in_tmpdir):
-    """A positive all-up test of settings overlays.
-    """
+    """A positive all-up test of settings overlays."""
     components = [
-            Component('qmc', Ports(o_f='settings_out'), '', 'qmc'),
-            Component(
-                'macro', Ports(o_i='out', s='in'), '', 'macro', False, [_ENSEMBLE_SIZE]
-                ),
-            Component('relay', Ports('in', o_f='out'), '', 'explicit_relay'),
-            Component('relay2', Ports('in', o_f='out'), '', 'explicit_relay'),
-            Component(
-                'micro', Ports('in', o_f='out'), '', 'micro', False, [_ENSEMBLE_SIZE])]
+        Component("qmc", Ports(o_f="settings_out"), "", "qmc"),
+        Component(
+            "macro", Ports(o_i="out", s="in"), "", "macro", False, [_ENSEMBLE_SIZE]
+        ),
+        Component("relay", Ports("in", o_f="out"), "", "explicit_relay"),
+        Component("relay2", Ports("in", o_f="out"), "", "explicit_relay"),
+        Component(
+            "micro", Ports("in", o_f="out"), "", "micro", False, [_ENSEMBLE_SIZE]
+        ),
+    ]
 
     conduits = [
-                Conduit('qmc.settings_out', 'macro.muscle_settings_in'),
-                Conduit('macro.out', 'relay.in'),
-                Conduit('relay.out', 'micro.in'),
-                Conduit('micro.out', 'relay2.in'),
-                Conduit('relay2.out', 'macro.in')]
+        Conduit("qmc.settings_out", "macro.muscle_settings_in"),
+        Conduit("macro.out", "relay.in"),
+        Conduit("relay.out", "micro.in"),
+        Conduit("micro.out", "relay2.in"),
+        Conduit("relay2.out", "macro.in"),
+    ]
 
-    model = Model('test_model', None, '', None, components, conduits)
+    model = Model("test_model", None, "", None, components, conduits)
 
-    settings = Settings(OrderedDict([
-                ('test1', 13),
-                ('test2', 13.3),
-                ('test3', 'testing'),
-                ('test4', True),
-                ('test5', [2.3, 5.6]),
-                ('test6', [[1.0, 2.0], [3.0, 1.0]])]))
+    settings = Settings(
+        OrderedDict(
+            [
+                ("test1", 13),
+                ("test2", 13.3),
+                ("test3", "testing"),
+                ("test4", True),
+                ("test5", [2.3, 5.6]),
+                ("test6", [[1.0, 2.0], [3.0, 1.0]]),
+            ]
+        )
+    )
 
-    configuration = Configuration('settings_overlays', None, [model], None, settings)
+    configuration = Configuration("settings_overlays", None, [model], None, settings)
 
     implementations = {
-            'qmc': qmc,
-            'macro': macro,
-            'explicit_relay': explicit_relay,
-            'micro': micro}
+        "qmc": qmc,
+        "macro": macro,
+        "explicit_relay": explicit_relay,
+        "micro": micro,
+    }
 
     run_simulation(configuration, implementations)

--- a/integration_test/test_python_tcp_reconnect.py
+++ b/integration_test/test_python_tcp_reconnect.py
@@ -47,40 +47,43 @@ def _inject_fault(socket: SocketType) -> None:
 
 @pytest.fixture
 def tcp_fault_injection():
-    with patch('libmuscle.mark.before_tcp_receive', _inject_fault):
-        with patch('libmuscle.mark.before_tcp_send', _inject_fault):
+    with patch("libmuscle.mark.before_tcp_receive", _inject_fault):
+        with patch("libmuscle.mark.before_tcp_send", _inject_fault):
             yield
 
 
 def component():
     _logger = logging.getLogger()
 
-    _logger.info('starting instance')
-    instance = Instance({
-        Operator.F_INIT: ['init'],
-        Operator.O_I: ['out'],
-        Operator.S: ['in'],
-        Operator.O_F: ['result']})
+    _logger.info("starting instance")
+    instance = Instance(
+        {
+            Operator.F_INIT: ["init"],
+            Operator.O_I: ["out"],
+            Operator.S: ["in"],
+            Operator.O_F: ["result"],
+        }
+    )
 
     j = 0
-    _logger.info('starting pre-receive')
+    _logger.info("starting pre-receive")
     while instance.reuse_instance():
-        _logger.info('top of reuse loop')
-        init_msg = instance.receive('init', default=Message(0.0, data=None))
+        _logger.info("top of reuse loop")
+        init_msg = instance.receive("init", default=Message(0.0, data=None))
         assert init_msg.data is None or init_msg.data == [j] * (j * _data_scale)
 
-        if instance.is_connected('out'):
+        if instance.is_connected("out"):
             for i in range(_loops):
-                _logger.info(f'i = {i}')
+                _logger.info(f"i = {i}")
                 data = [i] * (i * _data_scale)
                 out_msg = Message(float(i), data=data)
-                instance.send('out', out_msg)
+                instance.send("out", out_msg)
 
-                in_msg = instance.receive('in', default=out_msg)
+                in_msg = instance.receive("in", default=out_msg)
                 assert in_msg.data == data
 
-        _logger.info('sending final result')
-        instance.send('result', init_msg)
+        _logger.info("sending final result")
+        instance.send("result", init_msg)
         j += 1
 
 
@@ -91,20 +94,19 @@ def test_python_tcp_reconnect(tcp_fault_injection, log_file_in_tmpdir):
     _repeat_period = uniform(3.0, 5.0)
 
     components = [
-            Component('macro', Ports(o_i='out', s='in'), '', 'component'),
-            Component('micro', Ports('init', o_f='result'), '', 'component')]
+        Component("macro", Ports(o_i="out", s="in"), "", "component"),
+        Component("micro", Ports("init", o_f="result"), "", "component"),
+    ]
 
-    conduits = [
-                Conduit('macro.out', 'micro.init'),
-                Conduit('micro.result', 'macro.in')]
+    conduits = [Conduit("macro.out", "micro.init"), Conduit("micro.result", "macro.in")]
 
-    model = Model('test_python_tcp_reconnect', None, '', None, components, conduits)
+    model = Model("test_python_tcp_reconnect", None, "", None, components, conduits)
     settings = Settings()
-    settings['muscle_remote_log_level'] = 'warning'
-    settings['muscle_local_log_level'] = 'debug'
+    settings["muscle_remote_log_level"] = "warning"
+    settings["muscle_local_log_level"] = "debug"
 
-    configuration = Configuration('python_tcp_reconnect', None, [model], None, settings)
+    configuration = Configuration("python_tcp_reconnect", None, [model], None, settings)
 
-    implementations = {'component': component}
+    implementations = {"component": component}
 
     run_simulation(configuration, implementations)

--- a/integration_test/test_registration.py
+++ b/integration_test/test_registration.py
@@ -6,67 +6,71 @@ from ymmsl.v0_2 import Conduit, Operator, Port, Reference
 
 
 def test_registration(log_file_in_tmpdir, mmp_server):
-    instance_name = Reference('test_instance')
+    instance_name = Reference("test_instance")
     client = MMPClient(instance_name, mmp_server.get_location())
-    port = Port(Reference('test_in'), Operator.S)
+    port = Port(Reference("test_in"), Operator.S)
 
-    client.register_instance(['tcp:localhost:10000'], [port])
+    client.register_instance(["tcp:localhost:10000"], [port])
 
     registry = mmp_server._handler._instance_registry
 
-    assert registry.get_locations(instance_name) == ['tcp:localhost:10000']
-    assert registry.get_ports(instance_name)[0].name == 'test_in'
+    assert registry.get_locations(instance_name) == ["tcp:localhost:10000"]
+    assert registry.get_ports(instance_name)[0].name == "test_in"
     assert registry.get_ports(instance_name)[0].operator == Operator.S
     client.close()
 
 
 def test_wiring(log_file_in_tmpdir, mmp_server_process):
     # mmp_server_process starts a server and returns its location
-    client = MMPClient(Reference('macro'), mmp_server_process)
+    client = MMPClient(Reference("macro"), mmp_server_process)
 
-    client.register_instance(['direct:macro'], [])
+    client.register_instance(["direct:macro"], [])
 
-    client2 = MMPClient(Reference('micro[0]'), mmp_server_process)
+    client2 = MMPClient(Reference("micro[0]"), mmp_server_process)
     peer_info = client2.request_peers()
     client2.close()
 
-    assert Conduit('macro.out', 'micro.in') in peer_info._conduits
-    assert Conduit('micro.out', 'macro.in') in peer_info._conduits
+    assert Conduit("macro.out", "micro.in") in peer_info._conduits
+    assert Conduit("micro.out", "macro.in") in peer_info._conduits
 
-    assert peer_info._peer_dims[Reference('macro')] == []
-    assert peer_info._peer_locations['macro'] == ['direct:macro']
+    assert peer_info._peer_dims[Reference("macro")] == []
+    assert peer_info._peer_locations["macro"] == ["direct:macro"]
 
-    with patch('libmuscle.mmp_client.PEER_TIMEOUT', 0.1), \
-            patch('libmuscle.mmp_client.PEER_INTERVAL_MIN', 0.01), \
-            patch('libmuscle.mmp_client.PEER_INTERVAL_MAX', 0.1):
+    with (
+        patch("libmuscle.mmp_client.PEER_TIMEOUT", 0.1),
+        patch("libmuscle.mmp_client.PEER_INTERVAL_MIN", 0.01),
+        patch("libmuscle.mmp_client.PEER_INTERVAL_MAX", 0.1),
+    ):
         with pytest.raises(RuntimeError):
             client.request_peers()
 
     for i in range(5):
-        instance = Reference(f'micro[{i}]')
+        instance = Reference(f"micro[{i}]")
         client2 = MMPClient(instance, mmp_server_process)
-        location = f'direct:{instance}'
+        location = f"direct:{instance}"
         client2.register_instance([location], [])
         client2.close()
 
-    with patch('libmuscle.mmp_client.PEER_TIMEOUT', 0.1), \
-            patch('libmuscle.mmp_client.PEER_INTERVAL_MIN', 0.01), \
-            patch('libmuscle.mmp_client.PEER_INTERVAL_MAX', 0.1):
+    with (
+        patch("libmuscle.mmp_client.PEER_TIMEOUT", 0.1),
+        patch("libmuscle.mmp_client.PEER_INTERVAL_MIN", 0.01),
+        patch("libmuscle.mmp_client.PEER_INTERVAL_MAX", 0.1),
+    ):
         with pytest.raises(RuntimeError):
             client.request_peers()
 
     for i in range(5, 10):
-        instance = Reference(f'micro[{i}]')
+        instance = Reference(f"micro[{i}]")
         client2 = MMPClient(instance, mmp_server_process)
-        location = f'direct:{instance}'
+        location = f"direct:{instance}"
         client2.register_instance([location], [])
         client2.close()
 
     peer_info = client.request_peers()
 
-    assert Conduit('macro.out', 'micro.in') in peer_info._conduits
-    assert Conduit('micro.out', 'macro.in') in peer_info._conduits
+    assert Conduit("macro.out", "micro.in") in peer_info._conduits
+    assert Conduit("micro.out", "macro.in") in peer_info._conduits
 
-    assert peer_info._peer_dims[Reference('micro')] == [10]
-    assert peer_info._peer_locations['micro[7]'] == ['direct:micro[7]']
+    assert peer_info._peer_dims[Reference("micro")] == [10]
+    assert peer_info._peer_locations["micro[7]"] == ["direct:micro[7]"]
     client.close()

--- a/integration_test/test_snapshot_complex_coupling.py
+++ b/integration_test/test_snapshot_complex_coupling.py
@@ -16,17 +16,19 @@ from libmuscle import (
 
 from .conftest import ls_snapshots, run_manager_with_actors
 
-_LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
+_LOG_LEVEL = "INFO"  # set to DEBUG for additional debug info
 
 
 def cache_component(max_channels=2):
-    ports = {Operator.F_INIT: [f'in{i+1}' for i in range(max_channels)],
-             Operator.O_I: [f'sub_out{i+1}' for i in range(max_channels)],
-             Operator.S: [f'sub_in{i+1}' for i in range(max_channels)],
-             Operator.O_F: [f'out{i+1}' for i in range(max_channels)]}
+    ports = {
+        Operator.F_INIT: [f"in{i + 1}" for i in range(max_channels)],
+        Operator.O_I: [f"sub_out{i + 1}" for i in range(max_channels)],
+        Operator.S: [f"sub_in{i + 1}" for i in range(max_channels)],
+        Operator.O_F: [f"out{i + 1}" for i in range(max_channels)],
+    }
     instance = Instance(ports, USES_CHECKPOINT_API)
 
-    cache_t = float('-inf')
+    cache_t = float("-inf")
     cache_data = []
     max_cache_age = None
     nil_msg = Message(0.0)
@@ -36,20 +38,24 @@ def cache_component(max_channels=2):
             instance.load_snapshot()
 
         if instance.should_init():
-            cache_valid_range = instance.get_setting('cache_valid', '[float]')
+            cache_valid_range = instance.get_setting("cache_valid", "[float]")
             if max_cache_age is None:
                 max_cache_age = random.uniform(*cache_valid_range)
 
-            msgs = [instance.receive(port, default=nil_msg)
-                    for port in ports[Operator.F_INIT]]
+            msgs = [
+                instance.receive(port, default=nil_msg)
+                for port in ports[Operator.F_INIT]
+            ]
             cur_t = msgs[0].timestamp
 
         if cur_t - cache_t >= max_cache_age:
             # Cached value is no longer valid, run submodel for updated data
             for msg, port in zip(msgs, ports[Operator.O_I]):
                 instance.send(port, Message(cur_t, data=msg.data))
-            cache_data = [instance.receive(port, default=nil_msg).data
-                          for port in ports[Operator.S]]
+            cache_data = [
+                instance.receive(port, default=nil_msg).data
+                for port in ports[Operator.S]
+            ]
             cache_t = cur_t
             max_cache_age = random.uniform(*cache_valid_range)
 
@@ -61,8 +67,10 @@ def cache_component(max_channels=2):
 
 
 def echo_component(max_channels=2):
-    ports = {Operator.F_INIT: [f'in{i+1}' for i in range(max_channels)],
-             Operator.O_F: [f'out{i+1}' for i in range(max_channels)]}
+    ports = {
+        Operator.F_INIT: [f"in{i + 1}" for i in range(max_channels)],
+        Operator.O_F: [f"out{i + 1}" for i in range(max_channels)],
+    }
     instance = Instance(ports, KEEPS_NO_STATE_FOR_NEXT_USE | SKIP_MMSF_SEQUENCE_CHECKS)
 
     while instance.reuse_instance():
@@ -72,14 +80,18 @@ def echo_component(max_channels=2):
 
 
 def main_component():
-    instance = Instance({
-            Operator.O_I: ['state_out'],
-            Operator.S: ['Ai', 'Bi', 'Ci', 'Di'],
-            Operator.O_F: ['o_f']}, USES_CHECKPOINT_API)
+    instance = Instance(
+        {
+            Operator.O_I: ["state_out"],
+            Operator.S: ["Ai", "Bi", "Ci", "Di"],
+            Operator.O_F: ["o_f"],
+        },
+        USES_CHECKPOINT_API,
+    )
 
     while instance.reuse_instance():
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
         if instance.resuming():
             msg = instance.load_snapshot()
@@ -93,8 +105,8 @@ def main_component():
             i = 0
 
         while time.monotonic() < monotonic_end:
-            instance.send('state_out', Message(t_cur, data=i))
-            for port in ('Ai', 'Bi', 'Ci', 'Di'):
+            instance.send("state_out", Message(t_cur, data=i))
+            for port in ("Ai", "Bi", "Ci", "Di"):
                 instance.receive(port)
 
             t_cur += dt
@@ -102,10 +114,11 @@ def main_component():
             time.sleep(0.05)
 
             if instance.should_save_snapshot(t_cur):
-                instance.save_snapshot(Message(
-                        t_cur, data=[i, monotonic_end - time.monotonic()]))
+                instance.save_snapshot(
+                    Message(t_cur, data=[i, monotonic_end - time.monotonic()])
+                )
 
-        instance.send('o_f', Message(t_cur, data=i))
+        instance.send("o_f", Message(t_cur, data=i))
 
         if instance.should_save_final_snapshot():
             instance.save_final_snapshot(Message(t_cur, data=[i, 0]))
@@ -214,27 +227,27 @@ checkpoints:
 
 
 def test_snapshot_complex_coupling(tmp_path, config):
-    actors = {'main': ('python', main_component)}
-    for c in 'ABC':
-        actors['cache' + c] = ('python', cache_component)
-    for c in 'ABCD':
-        actors['calc' + c] = ('python', echo_component)
+    actors = {"main": ("python", main_component)}
+    for c in "ABC":
+        actors["cache" + c] = ("python", cache_component)
+    for c in "ABCD":
+        actors["calc" + c] = ("python", echo_component)
 
-    run_dir1 = RunDir(tmp_path / 'run1')
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(dump(config), run_dir1.path, actors)
 
     # Note: snapshotting based on wallclock time is less reliable, and depending on
     # many factors (OS load, machine speed, etc.) different amounts of snapshots may be
     # created with each run of this test. Asserts only check that at least 1 exists,
     # even though we expect more
-    assert len(ls_snapshots(run_dir1, 'main')) >= 1
-    assert len(ls_snapshots(run_dir1, 'cacheA')) >= 1
-    assert len(ls_snapshots(run_dir1, 'cacheB')) >= 1
-    assert len(ls_snapshots(run_dir1, 'cacheC')) >= 1
-    assert len(ls_snapshots(run_dir1, 'calcA')) >= 1
-    assert len(ls_snapshots(run_dir1, 'calcB')) >= 1
-    assert len(ls_snapshots(run_dir1, 'calcC')) >= 1
-    assert len(ls_snapshots(run_dir1, 'calcD')) >= 1
+    assert len(ls_snapshots(run_dir1, "main")) >= 1
+    assert len(ls_snapshots(run_dir1, "cacheA")) >= 1
+    assert len(ls_snapshots(run_dir1, "cacheB")) >= 1
+    assert len(ls_snapshots(run_dir1, "cacheC")) >= 1
+    assert len(ls_snapshots(run_dir1, "calcA")) >= 1
+    assert len(ls_snapshots(run_dir1, "calcB")) >= 1
+    assert len(ls_snapshots(run_dir1, "calcC")) >= 1
+    assert len(ls_snapshots(run_dir1, "calcD")) >= 1
 
     snapshots_ymmsl = ls_snapshots(run_dir1)
     snapshot_docs = list(map(load, snapshots_ymmsl))

--- a/integration_test/test_snapshot_dispatch.py
+++ b/integration_test/test_snapshot_dispatch.py
@@ -7,17 +7,17 @@ from libmuscle import USES_CHECKPOINT_API, Instance, Message
 
 from .conftest import ls_snapshots, run_manager_with_actors
 
-_LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
+_LOG_LEVEL = "INFO"  # set to DEBUG for additional debug info
 
 
 def component():
-    instance = Instance({
-            Operator.F_INIT: ['f_i'],
-            Operator.O_F: ['o_f']}, USES_CHECKPOINT_API)
+    instance = Instance(
+        {Operator.F_INIT: ["f_i"], Operator.O_F: ["o_f"]}, USES_CHECKPOINT_API
+    )
 
     while instance.reuse_instance():
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
         if instance.resuming():
             msg = instance.load_snapshot()
@@ -25,7 +25,7 @@ def component():
             i, t_stop = msg.data
 
         if instance.should_init():
-            msg = instance.receive('f_i', default=Message(0, data=0))
+            msg = instance.receive("f_i", default=Message(0, data=0))
             t_cur = msg.timestamp
             i = msg.data
             t_stop = t_cur + t_max
@@ -37,7 +37,7 @@ def component():
             if instance.should_save_snapshot(t_cur):
                 instance.save_snapshot(Message(t_cur, data=[i, t_stop]))
 
-        instance.send('o_f', Message(t_cur, data=i))
+        instance.send("o_f", Message(t_cur, data=i))
 
         if instance.should_save_final_snapshot():
             instance.save_final_snapshot(Message(t_cur, data=[i, t_stop]))
@@ -100,15 +100,15 @@ checkpoints:
 
 
 def test_snapshot_dispatch(tmp_path, dispatch_config):
-    actors = {f'comp{i + 1}': ('python', component) for i in range(5)}
-    run_dir1 = RunDir(tmp_path / 'run1')
+    actors = {f"comp{i + 1}": ("python", component) for i in range(5)}
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(dump(dispatch_config), run_dir1.path, actors)
 
-    assert len(ls_snapshots(run_dir1, 'comp1')) == 2  # t=0, at_end
-    assert len(ls_snapshots(run_dir1, 'comp2')) == 5  # t=0, 2.5, 2.3, 2.8, at_end
-    assert len(ls_snapshots(run_dir1, 'comp3')) == 3  # t=2.5, 5, at_end
-    assert len(ls_snapshots(run_dir1, 'comp4')) == 3  # t=5, 7.5, at_end
-    assert len(ls_snapshots(run_dir1, 'comp5')) == 3  # t=7.5, 10, at_end
+    assert len(ls_snapshots(run_dir1, "comp1")) == 2  # t=0, at_end
+    assert len(ls_snapshots(run_dir1, "comp2")) == 5  # t=0, 2.5, 2.3, 2.8, at_end
+    assert len(ls_snapshots(run_dir1, "comp3")) == 3  # t=2.5, 5, at_end
+    assert len(ls_snapshots(run_dir1, "comp4")) == 3  # t=5, 7.5, at_end
+    assert len(ls_snapshots(run_dir1, "comp5")) == 3  # t=7.5, 10, at_end
 
     snapshots_ymmsl = ls_snapshots(run_dir1)
     snapshot_docs = list(map(load, snapshots_ymmsl))
@@ -117,18 +117,19 @@ def test_snapshot_dispatch(tmp_path, dispatch_config):
     assert len(snapshot_docs) == 16
 
     # resume from the snapshots taken at t>=2.3
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     dispatch_config.resume = {
-        'comp1': ls_snapshots(run_dir1, 'comp1')[1],
-        'comp2': ls_snapshots(run_dir1, 'comp2')[1]}
+        "comp1": ls_snapshots(run_dir1, "comp1")[1],
+        "comp2": ls_snapshots(run_dir1, "comp2")[1],
+    }
 
     run_manager_with_actors(dump(dispatch_config), run_dir2.path, actors)
 
-    assert len(ls_snapshots(run_dir2, 'comp1')) == 1  # resume
-    assert len(ls_snapshots(run_dir2, 'comp2')) == 4  # resume, t=2.5, 2.8, at_end
-    assert len(ls_snapshots(run_dir2, 'comp3')) == 3  # t=2.5, 5, at_end
-    assert len(ls_snapshots(run_dir2, 'comp4')) == 3  # t=5, 7.5, at_end
-    assert len(ls_snapshots(run_dir2, 'comp5')) == 3  # t=7.5, 10, at_end
+    assert len(ls_snapshots(run_dir2, "comp1")) == 1  # resume
+    assert len(ls_snapshots(run_dir2, "comp2")) == 4  # resume, t=2.5, 2.8, at_end
+    assert len(ls_snapshots(run_dir2, "comp3")) == 3  # t=2.5, 5, at_end
+    assert len(ls_snapshots(run_dir2, "comp4")) == 3  # t=5, 7.5, at_end
+    assert len(ls_snapshots(run_dir2, "comp5")) == 3  # t=7.5, 10, at_end
     # More ymmsl restarts files may be possible, depending on the sequence of
     # incoming SnapshotMetadata...
     assert len(ls_snapshots(run_dir2)) >= 13

--- a/integration_test/test_snapshot_interact.py
+++ b/integration_test/test_snapshot_interact.py
@@ -12,22 +12,21 @@ from libmuscle import USES_CHECKPOINT_API, Instance, Message
 from .conftest import ls_snapshots, run_manager_with_actors
 
 # Make interact_coupling.py available (from docs/sources/examples)
-sys.path.append(str(
-        Path(__file__).parents[1] / 'docs' / 'source' / 'examples' / 'python'))
+sys.path.append(
+    str(Path(__file__).parents[1] / "docs" / "source" / "examples" / "python")
+)
 import interact_coupling  # noqa
 
-_LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
+_LOG_LEVEL = "INFO"  # set to DEBUG for additional debug info
 
 
 def component():
-    instance = Instance({
-            Operator.O_I: ['o_i'],
-            Operator.S: ['s']}, USES_CHECKPOINT_API)
+    instance = Instance({Operator.O_I: ["o_i"], Operator.S: ["s"]}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
-        t0 = instance.get_setting('t0', 'float')
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        t0 = instance.get_setting("t0", "float")
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
         if instance.resuming():
             msg = instance.load_snapshot()
@@ -45,13 +44,14 @@ def component():
             t_next = t_cur + dt
             if t_next >= t_stop:
                 t_next = None
-            logging.info(f'Sending {i} at {t_cur}, next at {t_next}')
-            instance.send('o_i', Message(t_cur, t_next, i))
+            logging.info(f"Sending {i} at {t_cur}, next at {t_next}")
+            instance.send("o_i", Message(t_cur, t_next, i))
 
-            msg = instance.receive('s')
+            msg = instance.receive("s")
             logging.info(
-                    f'Received {msg.data} from time {msg.timestamp},'
-                    f' next at {msg.next_timestamp}')
+                f"Received {msg.data} from time {msg.timestamp},"
+                f" next at {msg.next_timestamp}"
+            )
             assert msg.data >= rcvd_i
             rcvd_i = msg.data
 
@@ -99,31 +99,31 @@ checkpoints:
     stop: 2.0
   - at:
     - 2.5"""
-    actors = {f'comp{i + 1}': ('python', component) for i in range(2)}
+    actors = {f"comp{i + 1}": ("python", component) for i in range(2)}
 
-    run_dir1 = RunDir(tmp_path / 'run1')
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(config, run_dir1.path, actors)
 
-    assert len(ls_snapshots(run_dir1, 'comp1')) == 3  # t=0.75, 1.75, 2.5
-    assert len(ls_snapshots(run_dir1, 'comp2')) == 3  # t=0.75, 1.75, 2.5
+    assert len(ls_snapshots(run_dir1, "comp1")) == 3  # t=0.75, 1.75, 2.5
+    assert len(ls_snapshots(run_dir1, "comp2")) == 3  # t=0.75, 1.75, 2.5
 
     snapshots_ymmsl = ls_snapshots(run_dir1)
     snapshot_docs = list(map(load, snapshots_ymmsl))
     assert len(snapshot_docs) == 3
 
     # resume from the snapshots taken at t>=1.75
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     config_doc = load(config)
     config_doc.update(snapshot_docs[1])
 
     run_manager_with_actors(dump(config_doc), run_dir2.path, actors)
 
-    assert len(ls_snapshots(run_dir2, 'comp1')) == 2  # resume, t=2.5
-    assert len(ls_snapshots(run_dir2, 'comp2')) == 2  # resume, t=2.5
+    assert len(ls_snapshots(run_dir2, "comp1")) == 2  # resume, t=2.5
+    assert len(ls_snapshots(run_dir2, "comp2")) == 2  # resume, t=2.5
     assert len(ls_snapshots(run_dir2)) == 2
 
 
-@pytest.mark.parametrize('scale', [0.1, 0.9, 1.0, 1.1, 1.5])
+@pytest.mark.parametrize("scale", [0.1, 0.9, 1.0, 1.1, 1.5])
 def test_snapshot_interact_varstep(tmp_path, scale):
     config = f"""ymmsl_version: v0.2
 description: Interact setup for testing checkpointing - different timesteps
@@ -172,26 +172,26 @@ checkpoints:
     stop: 2.0
   - at:
     - 2.5"""
-    actors = {f'comp{i + 1}': ('python', component) for i in range(2)}
-    actors['coupler'] = ('python', interact_coupling.checkpointing_temporal_coupler)
+    actors = {f"comp{i + 1}": ("python", component) for i in range(2)}
+    actors["coupler"] = ("python", interact_coupling.checkpointing_temporal_coupler)
 
-    run_dir1 = RunDir(tmp_path / 'run1')
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(config, run_dir1.path, actors)
 
-    assert len(ls_snapshots(run_dir1, 'comp1')) == 3  # t=0.75, 1.75, 2.5
-    assert len(ls_snapshots(run_dir1, 'comp2')) == 3  # t=0.75, 1.75, 2.5
+    assert len(ls_snapshots(run_dir1, "comp1")) == 3  # t=0.75, 1.75, 2.5
+    assert len(ls_snapshots(run_dir1, "comp2")) == 3  # t=0.75, 1.75, 2.5
 
     snapshots_ymmsl = ls_snapshots(run_dir1)
     snapshot_docs = list(map(load, snapshots_ymmsl))
     assert len(snapshot_docs) == 3
 
     # resume from the snapshots taken at t>=1.75
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     config_doc = load(config)
     config_doc.update(snapshot_docs[1])
 
     run_manager_with_actors(dump(config_doc), run_dir2.path, actors)
 
-    assert len(ls_snapshots(run_dir2, 'comp1')) == 2  # resume, t=2.5
-    assert len(ls_snapshots(run_dir2, 'comp2')) == 2  # resume, t=2.5
+    assert len(ls_snapshots(run_dir2, "comp1")) == 2  # resume, t=2.5
+    assert len(ls_snapshots(run_dir2, "comp2")) == 2  # resume, t=2.5
     assert len(ls_snapshots(run_dir2)) == 2

--- a/integration_test/test_snapshot_macro_micro.py
+++ b/integration_test/test_snapshot_macro_micro.py
@@ -18,17 +18,15 @@ from .conftest import (
     skip_if_python_only,
 )
 
-_LOG_LEVEL = 'INFO'  # set to DEBUG for additional debug info
+_LOG_LEVEL = "INFO"  # set to DEBUG for additional debug info
 
 
 def macro():
-    instance = Instance({
-            Operator.O_I: ['o_i'],
-            Operator.S: ['s']}, USES_CHECKPOINT_API)
+    instance = Instance({Operator.O_I: ["o_i"], Operator.S: ["s"]}, USES_CHECKPOINT_API)
 
     while instance.reuse_instance():
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
         if instance.resuming():
             msg = instance.load_snapshot()
@@ -38,16 +36,16 @@ def macro():
             assert i >= 1
 
         if instance.should_init():
-            t_cur = instance.get_setting('t0', 'float')
+            t_cur = instance.get_setting("t0", "float")
             i = 0
 
         while t_cur + dt <= t_max:
             t_next = t_cur + dt
             if t_next + dt > t_max:
                 t_next = None  # final iteration of this time-integration loop
-            instance.send('o_i', Message(t_cur, t_next, i))
+            instance.send("o_i", Message(t_cur, t_next, i))
 
-            msg = instance.receive('s')
+            msg = instance.receive("s")
             assert msg.data == i
 
             i += 1
@@ -61,13 +59,13 @@ def macro():
 
 
 def macro_vector():
-    instance = Instance({
-            Operator.O_I: ['o_i[]'],
-            Operator.S: ['s[]']}, USES_CHECKPOINT_API)
+    instance = Instance(
+        {Operator.O_I: ["o_i[]"], Operator.S: ["s[]"]}, USES_CHECKPOINT_API
+    )
 
     while instance.reuse_instance():
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
         if instance.resuming():
             msg = instance.load_snapshot()
@@ -77,18 +75,18 @@ def macro_vector():
             assert i >= 1
 
         if instance.should_init():
-            t_cur = instance.get_setting('t0', 'float')
+            t_cur = instance.get_setting("t0", "float")
             i = 0
 
         while t_cur + dt <= t_max:
             t_next = t_cur + dt
             if t_next + dt > t_max:
                 t_next = None  # final iteration of this time-integration loop
-            for slot in range(instance.get_port_length('o_i')):
-                instance.send('o_i', Message(t_cur, t_next, i), slot)
+            for slot in range(instance.get_port_length("o_i")):
+                instance.send("o_i", Message(t_cur, t_next, i), slot)
 
-            for slot in range(instance.get_port_length('s')):
-                msg = instance.receive('s', slot)
+            for slot in range(instance.get_port_length("s")):
+                msg = instance.receive("s", slot)
                 assert msg.data == i
 
             i += 1
@@ -102,13 +100,13 @@ def macro_vector():
 
 
 def micro():
-    instance = Instance({
-            Operator.F_INIT: ['f_i'],
-            Operator.O_F: ['o_f']}, USES_CHECKPOINT_API)
+    instance = Instance(
+        {Operator.F_INIT: ["f_i"], Operator.O_F: ["o_f"]}, USES_CHECKPOINT_API
+    )
 
     while instance.reuse_instance():
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
         if instance.resuming():
             msg = instance.load_snapshot()
@@ -116,7 +114,7 @@ def micro():
             i, t_stop = msg.data
 
         if instance.should_init():
-            msg = instance.receive('f_i')
+            msg = instance.receive("f_i")
             t_cur = msg.timestamp
             i = msg.data
             t_stop = t_cur + t_max
@@ -128,23 +126,22 @@ def micro():
             if instance.should_save_snapshot(t_cur):
                 instance.save_snapshot(Message(t_cur, data=[i, t_stop]))
 
-        instance.send('o_f', Message(t_cur, data=i))
+        instance.send("o_f", Message(t_cur, data=i))
 
         if instance.should_save_final_snapshot():
             instance.save_final_snapshot(Message(t_cur, data=[i, t_stop]))
 
 
 def stateless_micro():
-    instance = Instance({
-            Operator.F_INIT: ['f_i'],
-            Operator.O_F: ['o_f']},
-            KEEPS_NO_STATE_FOR_NEXT_USE)
+    instance = Instance(
+        {Operator.F_INIT: ["f_i"], Operator.O_F: ["o_f"]}, KEEPS_NO_STATE_FOR_NEXT_USE
+    )
 
     while instance.reuse_instance():
-        dt = instance.get_setting('dt', 'float')
-        t_max = instance.get_setting('t_max', 'float')
+        dt = instance.get_setting("dt", "float")
+        t_max = instance.get_setting("t_max", "float")
 
-        msg = instance.receive('f_i')
+        msg = instance.receive("f_i")
         t_cur = msg.timestamp
         i = msg.data
         t_stop = t_cur + t_max
@@ -153,18 +150,17 @@ def stateless_micro():
             # faux time-integration for testing snapshots
             t_cur += dt
 
-        instance.send('o_f', Message(t_cur, data=i))
+        instance.send("o_f", Message(t_cur, data=i))
 
 
 def data_transformer():
-    instance = Instance({
-            Operator.F_INIT: ['f_i'],
-            Operator.O_F: ['o_f']},
-            KEEPS_NO_STATE_FOR_NEXT_USE)
+    instance = Instance(
+        {Operator.F_INIT: ["f_i"], Operator.O_F: ["o_f"]}, KEEPS_NO_STATE_FOR_NEXT_USE
+    )
 
     while instance.reuse_instance():
-        msg = instance.receive('f_i')
-        instance.send('o_f', msg)
+        msg = instance.receive("f_i")
+        instance.send("o_f", msg)
 
 
 @pytest.fixture
@@ -253,134 +249,161 @@ checkpoints:
   - every: 0.4""")
 
 
-@pytest.mark.parametrize('actors', [
-    {'macro': ('python', macro), 'micro': ('python', micro)},
-    pytest.param(
-        {'macro': ('cpp', 'snapshot_components_test', 'macro'),
-         'micro': ('cpp', 'snapshot_components_test', 'micro')},
-        marks=skip_if_python_only),
-    pytest.param(
-        {'macro': ('fortran', 'fortran_snapshot_macro_test'),
-         'micro': ('fortran', 'fortran_snapshot_micro_test')},
-        marks=[skip_if_python_only, skip_if_no_fortran]),
-    pytest.param(
-        {'macro': ('python', macro), 'micro': ('cpp', 'mpi_snapshot_micro_test', '2')},
-        marks=[skip_if_python_only, skip_if_no_mpi_cpp])
-])
+@pytest.mark.parametrize(
+    "actors",
+    [
+        {"macro": ("python", macro), "micro": ("python", micro)},
+        pytest.param(
+            {
+                "macro": ("cpp", "snapshot_components_test", "macro"),
+                "micro": ("cpp", "snapshot_components_test", "micro"),
+            },
+            marks=skip_if_python_only,
+        ),
+        pytest.param(
+            {
+                "macro": ("fortran", "fortran_snapshot_macro_test"),
+                "micro": ("fortran", "fortran_snapshot_micro_test"),
+            },
+            marks=[skip_if_python_only, skip_if_no_fortran],
+        ),
+        pytest.param(
+            {
+                "macro": ("python", macro),
+                "micro": ("cpp", "mpi_snapshot_micro_test", "2"),
+            },
+            marks=[skip_if_python_only, skip_if_no_mpi_cpp],
+        ),
+    ],
+)
 def test_snapshot_macro_micro(tmp_path, base_config, actors):
-    run_dir1 = RunDir(tmp_path / 'run1')
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(dump(base_config), run_dir1.path, actors)
 
-    macro_snapshots = ls_snapshots(run_dir1, 'macro')
+    macro_snapshots = ls_snapshots(run_dir1, "macro")
     assert len(macro_snapshots) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
-    micro_snapshots = ls_snapshots(run_dir1, 'micro')
+    micro_snapshots = ls_snapshots(run_dir1, "micro")
     assert len(micro_snapshots) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
     snapshots_ymmsl = ls_snapshots(run_dir1)
     snapshot_docs = list(map(load, snapshots_ymmsl))
     assert len(snapshot_docs) == 7
-    assert snapshot_docs[0].resume['macro'] == macro_snapshots[0]
-    assert snapshot_docs[0].resume['micro'] == micro_snapshots[0]
-    assert snapshot_docs[1].resume['macro'] == macro_snapshots[0]
-    assert snapshot_docs[1].resume['micro'] == micro_snapshots[1]
+    assert snapshot_docs[0].resume["macro"] == macro_snapshots[0]
+    assert snapshot_docs[0].resume["micro"] == micro_snapshots[0]
+    assert snapshot_docs[1].resume["macro"] == macro_snapshots[0]
+    assert snapshot_docs[1].resume["micro"] == micro_snapshots[1]
     for i in range(2, 7):
-        assert snapshot_docs[i].resume['macro'] == macro_snapshots[i - 1]
-        assert snapshot_docs[i].resume['micro'] == micro_snapshots[i - 1]
+        assert snapshot_docs[i].resume["macro"] == macro_snapshots[i - 1]
+        assert snapshot_docs[i].resume["micro"] == micro_snapshots[i - 1]
 
     # resume from the snapshots taken at t>=1.2
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     base_config.update(snapshot_docs[4])  # add resume info
     run_manager_with_actors(dump(base_config), run_dir2.path, actors)
 
-    assert len(ls_snapshots(run_dir2, 'macro')) == 3  # resume, 1.6, final
-    assert len(ls_snapshots(run_dir2, 'micro')) == 3  # resume, 1.6, final
+    assert len(ls_snapshots(run_dir2, "macro")) == 3  # resume, 1.6, final
+    assert len(ls_snapshots(run_dir2, "micro")) == 3  # resume, 1.6, final
     assert len(ls_snapshots(run_dir2)) == 3
 
     # resume from the first workflow snapshot (this restarts macro from scratch)
-    run_dir3 = RunDir(tmp_path / 'run3')
-    base_config.resume = {}                     # clear resume information
-    base_config.update(snapshot_docs[0])        # add resume info
-    base_config.settings['macro.t_max'] = 0.6   # run shorter
+    run_dir3 = RunDir(tmp_path / "run3")
+    base_config.resume = {}  # clear resume information
+    base_config.update(snapshot_docs[0])  # add resume info
+    base_config.settings["macro.t_max"] = 0.6  # run shorter
     run_manager_with_actors(dump(base_config), run_dir3.path, actors)
 
 
-@pytest.mark.parametrize('micro_actor', [
-    ('python', stateless_micro),
-    pytest.param(
-        ('cpp', 'snapshot_components_test', 'stateless_micro'),
-        marks=skip_if_python_only),
-    pytest.param(
-        ('fortran', 'fortran_snapshot_stateless_micro_test'),
-        marks=[skip_if_python_only, skip_if_no_fortran]),
-])
+@pytest.mark.parametrize(
+    "micro_actor",
+    [
+        ("python", stateless_micro),
+        pytest.param(
+            ("cpp", "snapshot_components_test", "stateless_micro"),
+            marks=skip_if_python_only,
+        ),
+        pytest.param(
+            ("fortran", "fortran_snapshot_stateless_micro_test"),
+            marks=[skip_if_python_only, skip_if_no_fortran],
+        ),
+    ],
+)
 def test_snapshot_macro_stateless_micro(tmp_path, base_config, micro_actor):
-    actors = {'macro': ('python', macro), 'micro': micro_actor}
-    run_dir1 = RunDir(tmp_path / 'run1')
+    actors = {"macro": ("python", macro), "micro": micro_actor}
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(dump(base_config), run_dir1.path, actors)
 
-    assert len(ls_snapshots(run_dir1, 'macro')) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
-    assert len(ls_snapshots(run_dir1, 'micro')) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
+    assert len(ls_snapshots(run_dir1, "macro")) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
+    assert len(ls_snapshots(run_dir1, "micro")) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
     snapshots_ymmsl = ls_snapshots(run_dir1)
     snapshot_docs = list(map(load, snapshots_ymmsl))
     assert len(snapshot_docs) == 6
 
     # resume from the snapshot taken at t>=1.2
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     base_config.update(snapshot_docs[3])  # add resume info
     run_manager_with_actors(dump(base_config), run_dir2.path, actors)
 
-    assert len(ls_snapshots(run_dir2, 'macro')) == 3  # resume, 1.6, final
-    assert len(ls_snapshots(run_dir2, 'micro')) == 4  # resume, 1.2, 1.6, final
+    assert len(ls_snapshots(run_dir2, "macro")) == 3  # resume, 1.6, final
+    assert len(ls_snapshots(run_dir2, "micro")) == 4  # resume, 1.2, 1.6, final
     assert len(ls_snapshots(run_dir2)) == 3
 
 
-@pytest.mark.parametrize('macro_actor', [
-    ('python', macro_vector),
-    pytest.param(
-        ('cpp', 'snapshot_components_test', 'macro_vector'),
-        marks=skip_if_python_only),
-    pytest.param(
-        ('fortran', 'fortran_snapshot_macro_vector_test'),
-        marks=[skip_if_python_only, skip_if_no_fortran]),
-])
+@pytest.mark.parametrize(
+    "macro_actor",
+    [
+        ("python", macro_vector),
+        pytest.param(
+            ("cpp", "snapshot_components_test", "macro_vector"),
+            marks=skip_if_python_only,
+        ),
+        pytest.param(
+            ("fortran", "fortran_snapshot_macro_vector_test"),
+            marks=[skip_if_python_only, skip_if_no_fortran],
+        ),
+    ],
+)
 def test_snapshot_macro_vector_micro(tmp_path, base_config, macro_actor):
-    base_config.root_model().components['micro'].multiplicity = [2]
-    actors = {'macro': macro_actor,
-              'micro[0]': ('python', micro),
-              'micro[1]': ('python', micro)}
+    base_config.root_model().components["micro"].multiplicity = [2]
+    actors = {
+        "macro": macro_actor,
+        "micro[0]": ("python", micro),
+        "micro[1]": ("python", micro),
+    }
 
-    run_dir1 = RunDir(tmp_path / 'run1')
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(dump(base_config), run_dir1.path, actors)
 
-    assert len(ls_snapshots(run_dir1, 'macro')) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
-    assert len(ls_snapshots(run_dir1, 'micro[0]')) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
-    assert len(ls_snapshots(run_dir1, 'micro[1]')) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
+    assert len(ls_snapshots(run_dir1, "macro")) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
+    assert len(ls_snapshots(run_dir1, "micro[0]")) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
+    assert len(ls_snapshots(run_dir1, "micro[1]")) == 6  # 0, 0.4, 0.8, 1.2, 1.6, final
     snapshots_ymmsl = ls_snapshots(run_dir1)
     assert len(snapshots_ymmsl) == 8
 
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     base_config.update(load(snapshots_ymmsl[-3]))  # add resume info
     run_manager_with_actors(dump(base_config), run_dir2.path, actors)
 
-    assert len(ls_snapshots(run_dir2, 'macro')) == 3  # resume, 1.6, final
-    assert len(ls_snapshots(run_dir2, 'micro[0]')) == 3  # resume, 1.6, final
-    assert len(ls_snapshots(run_dir2, 'micro[1]')) == 3  # resume, 1.6, final
+    assert len(ls_snapshots(run_dir2, "macro")) == 3  # resume, 1.6, final
+    assert len(ls_snapshots(run_dir2, "micro[0]")) == 3  # resume, 1.6, final
+    assert len(ls_snapshots(run_dir2, "micro[1]")) == 3  # resume, 1.6, final
     assert len(ls_snapshots(run_dir2)) == 3
 
 
 def test_snapshot_macro_transformer_micro(tmp_path, config_with_transformer):
-    actors = {'macro': ('python', macro),
-              'micro': ('python', micro),
-              'transformer1': ('python', data_transformer),
-              'transformer2': ('python', data_transformer)}
+    actors = {
+        "macro": ("python", macro),
+        "micro": ("python", micro),
+        "transformer1": ("python", data_transformer),
+        "transformer2": ("python", data_transformer),
+    }
 
-    run_dir1 = RunDir(tmp_path / 'run1')
+    run_dir1 = RunDir(tmp_path / "run1")
     run_manager_with_actors(dump(config_with_transformer), run_dir1.path, actors)
 
     snapshots_ymmsl = ls_snapshots(run_dir1)
     assert len(snapshots_ymmsl) == 8
 
     # pick one to resume from
-    run_dir2 = RunDir(tmp_path / 'run2')
+    run_dir2 = RunDir(tmp_path / "run2")
     config_with_transformer.update(load(snapshots_ymmsl[4]))  # add resume info
     run_manager_with_actors(dump(config_with_transformer), run_dir2.path, actors)
 

--- a/integration_test/test_start_all.py
+++ b/integration_test/test_start_all.py
@@ -12,12 +12,12 @@ def test_start_all(tmpdir):
     tmppath = Path(str(tmpdir))
 
     # find our test component and its requirements
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    ld_lib_path = ':'.join(map(str, lib_paths))
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    ld_lib_path = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    test_component = cpp_test_dir / 'component_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    test_component = cpp_test_dir / "component_test"
 
     # make config
     ymmsl_text = f"""
@@ -56,10 +56,10 @@ resources:
     config = ymmsl.load(ymmsl_text)
 
     # set up
-    run_dir = RunDir(tmppath / 'run')
+    run_dir = RunDir(tmppath / "run")
 
     # launch MUSCLE Manager with simulation
-    manager = Manager(config, run_dir, 'DEBUG')
+    manager = Manager(config, run_dir, "DEBUG")
     manager.start_instances()
     success = manager.wait()
 

--- a/integration_test/test_start_mpi.py
+++ b/integration_test/test_start_mpi.py
@@ -13,13 +13,13 @@ def test_start_mpi(tmpdir, mpi_exec_model):
     tmppath = Path(str(tmpdir))
 
     # find our test components and their requirements
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    ld_lib_path = ':'.join(map(str, lib_paths))
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    ld_lib_path = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    test_component = cpp_test_dir / 'component_test'
-    mpi_test_component = cpp_test_dir / 'mpi_component_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    test_component = cpp_test_dir / "component_test"
+    mpi_test_component = cpp_test_dir / "mpi_component_test"
 
     # make config
     ymmsl_text = f"""
@@ -64,10 +64,10 @@ resources:
     config = ymmsl.load(ymmsl_text)
 
     # set up
-    run_dir = RunDir(tmppath / 'run')
+    run_dir = RunDir(tmppath / "run")
 
     # launch MUSCLE Manager with simulation
-    manager = Manager(config, run_dir, 'DEBUG')
+    manager = Manager(config, run_dir, "DEBUG")
     try:
         manager.start_instances()
     except:  # noqa

--- a/integration_test/test_start_nested.py
+++ b/integration_test/test_start_nested.py
@@ -13,12 +13,12 @@ def test_start_nested(tmpdir):
     tmppath = Path(str(tmpdir))
 
     # find our test component and its requirements
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    ld_lib_path = ':'.join(map(str, lib_paths))
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    ld_lib_path = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    test_component = cpp_test_dir / 'component_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    test_component = cpp_test_dir / "component_test"
 
     # make config
     ymmsl_text = f"""
@@ -72,10 +72,10 @@ resources:
     config = flatten(ymmsl.load(ymmsl_text))
 
     # set up
-    run_dir = RunDir(tmppath / 'run')
+    run_dir = RunDir(tmppath / "run")
 
     # launch MUSCLE Manager with simulation
-    manager = Manager(config, run_dir, 'DEBUG')
+    manager = Manager(config, run_dir, "DEBUG")
     manager.start_instances()
     success = manager.wait()
 

--- a/integration_test/test_start_script.py
+++ b/integration_test/test_start_script.py
@@ -13,13 +13,13 @@ def test_start_script(tmpdir):
     tmppath = Path(str(tmpdir))
 
     # find our test components and their requirements
-    cpp_build_dir = Path(__file__).parents[1] / 'libmuscle' / 'cpp' / 'build'
-    lib_paths = [cpp_build_dir / 'msgpack' / 'msgpack' / 'lib']
-    ld_lib_path = ':'.join(map(str, lib_paths))
+    cpp_build_dir = Path(__file__).parents[1] / "libmuscle" / "cpp" / "build"
+    lib_paths = [cpp_build_dir / "msgpack" / "msgpack" / "lib"]
+    ld_lib_path = ":".join(map(str, lib_paths))
 
-    cpp_test_dir = cpp_build_dir / 'libmuscle' / 'tests'
-    test_component = cpp_test_dir / 'component_test'
-    mpi_test_component = cpp_test_dir / 'mpi_component_test'
+    cpp_test_dir = cpp_build_dir / "libmuscle" / "tests"
+    test_component = cpp_test_dir / "component_test"
+    mpi_test_component = cpp_test_dir / "mpi_component_test"
 
     # make config
     ymmsl_text = f"""
@@ -71,10 +71,10 @@ resources:
     config = ymmsl.load(ymmsl_text)
 
     # set up
-    run_dir = RunDir(tmppath / 'run')
+    run_dir = RunDir(tmppath / "run")
 
     # launch MUSCLE Manager with simulation
-    manager = Manager(config, run_dir, 'DEBUG')
+    manager = Manager(config, run_dir, "DEBUG")
     try:
         manager.start_instances()
     except:  # noqa

--- a/integration_test/test_version.py
+++ b/integration_test/test_version.py
@@ -2,4 +2,4 @@ import libmuscle
 
 
 def test_version() -> None:
-    assert libmuscle.__version__ != ''
+    assert libmuscle.__version__ != ""

--- a/libmuscle/python/libmuscle/__init__.py
+++ b/libmuscle/python/libmuscle/__init__.py
@@ -11,8 +11,14 @@ from libmuscle import runner  # isort: skip
 # that it's not present.
 
 __all__ = [
-        '__version__', 'Grid', 'Instance', 'InstanceFlags', 'Message',
-        'ProfileDatabase', 'runner']
+    "__version__",
+    "Grid",
+    "Instance",
+    "InstanceFlags",
+    "Message",
+    "ProfileDatabase",
+    "runner",
+]
 
 
 # export InstanceFlag members to the module namespace

--- a/libmuscle/python/libmuscle/api_guard.py
+++ b/libmuscle/python/libmuscle/api_guard.py
@@ -13,6 +13,7 @@ class APIPhase(Enum):
     fine-grained and concerns checkpointing, which is not represented
     in the SEL.
     """
+
     BEFORE_FIRST_REUSE_INSTANCE = auto()
     """Before the first time calling reuse_instance"""
 
@@ -50,6 +51,7 @@ class APIGuard:
     called to signal that the corresponding function finished
     successfully, and that we are moving on to the next phase.
     """
+
     def __init__(self, uses_checkpointing: bool) -> None:
         """Create an APIGuard.
 
@@ -60,32 +62,34 @@ class APIGuard:
 
     def _generic_error_messages(self, verify_phase: str) -> None:
         if self._phase in (
-                APIPhase.BEFORE_FIRST_REUSE_INSTANCE,
-                APIPhase.AFTER_REUSE_LOOP):
-            msg = f'Please only call {verify_phase} inside the reuse loop.'
+            APIPhase.BEFORE_FIRST_REUSE_INSTANCE,
+            APIPhase.AFTER_REUSE_LOOP,
+        ):
+            msg = f"Please only call {verify_phase} inside the reuse loop."
         elif self._phase == APIPhase.BEFORE_REUSE_INSTANCE:
             msg = (
-                    f'Please do not call {verify_phase} after'
-                    ' should_save_final_snapshot. should_save_final_snapshot'
-                    ' should be at the end of the reuse loop.')
+                f"Please do not call {verify_phase} after"
+                " should_save_final_snapshot. should_save_final_snapshot"
+                " should be at the end of the reuse loop."
+            )
         elif self._phase == APIPhase.BEFORE_RESUMING:
-            msg = 'Inside the reuse loop you must call resuming first.'
+            msg = "Inside the reuse loop you must call resuming first."
         elif self._phase == APIPhase.BEFORE_LOAD_SNAPSHOT:
-            msg = (
-                    'If resuming returns True, then you must call'
-                    ' load_snapshot first.')
+            msg = "If resuming returns True, then you must call load_snapshot first."
         elif self._phase == APIPhase.BEFORE_SHOULD_INIT:
-            msg = 'After calling resuming, you must call should_init first.'
+            msg = "After calling resuming, you must call should_init first."
         elif self._phase == APIPhase.BEFORE_SHOULD_SAVE_SNAPSHOT:
-            msg = 'You must call save_snapshot or save_final_snapshot first.'
+            msg = "You must call save_snapshot or save_final_snapshot first."
         elif self._phase == APIPhase.BEFORE_SAVE_SNAPSHOT:
             msg = (
-                    'If should_save_snapshot returns True, then you must'
-                    ' call save_snapshot first.')
+                "If should_save_snapshot returns True, then you must"
+                " call save_snapshot first."
+            )
         elif self._phase == APIPhase.BEFORE_SAVE_FINAL_SNAPSHOT:
             msg = (
-                    'If should_save_final_snapshot returns True, then you'
-                    ' must call save_final_snapshot first.')
+                "If should_save_final_snapshot returns True, then you"
+                " must call save_final_snapshot first."
+            )
         else:
             return
         raise RuntimeError(msg)
@@ -93,12 +97,14 @@ class APIGuard:
     def verify_reuse_instance(self) -> None:
         """Check reuse_instance()"""
         if self._phase not in (
-                APIPhase.BEFORE_REUSE_INSTANCE,
-                APIPhase.BEFORE_FIRST_REUSE_INSTANCE):
+            APIPhase.BEFORE_REUSE_INSTANCE,
+            APIPhase.BEFORE_FIRST_REUSE_INSTANCE,
+        ):
             raise RuntimeError(
-                    'We reached the end of the reuse loop without checking'
-                    ' if a snapshot should be saved. Please add at least'
-                    ' a should_save_final_snapshot and save_final_snapshot.')
+                "We reached the end of the reuse loop without checking"
+                " if a snapshot should be saved. Please add at least"
+                " a should_save_final_snapshot and save_final_snapshot."
+            )
 
     def reuse_instance_done(self, reusing: bool) -> None:
         """Update phase on successful reuse_instance().
@@ -118,13 +124,14 @@ class APIGuard:
         """Check resuming()"""
         if not self._uses_checkpointing:
             raise RuntimeError(
-                    'Please add the flag'
-                    ' :attr:`InstanceFlag.USES_CHECKPOINT_API` to your'
-                    ' instance to use the MUSCLE3 checkpointing API.')
+                "Please add the flag"
+                " :attr:`InstanceFlag.USES_CHECKPOINT_API` to your"
+                " instance to use the MUSCLE3 checkpointing API."
+            )
         if self._phase != APIPhase.BEFORE_RESUMING:
             raise RuntimeError(
-                    'Please call resuming() only as the first thing in the'
-                    ' reuse loop.')
+                "Please call resuming() only as the first thing in the reuse loop."
+            )
 
     def resuming_done(self, resuming: bool) -> None:
         """Update phase on successful resuming().
@@ -141,8 +148,9 @@ class APIGuard:
         """Check load_snapshot()"""
         if self._phase != APIPhase.BEFORE_LOAD_SNAPSHOT:
             raise RuntimeError(
-                    'Please check that we are resuming by calling resuming()'
-                    ' before calling load_snapshot()')
+                "Please check that we are resuming by calling resuming()"
+                " before calling load_snapshot()"
+            )
 
     def load_snapshot_done(self) -> None:
         """Update phase on successful load_snapshot()"""
@@ -152,8 +160,9 @@ class APIGuard:
         """Check should_init()"""
         if self._phase != APIPhase.BEFORE_SHOULD_INIT:
             raise RuntimeError(
-                    'Please check whether to run f_init using should_init()'
-                    ' after resuming, and before trying to save a snapshot.')
+                "Please check whether to run f_init using should_init()"
+                " after resuming, and before trying to save a snapshot."
+            )
 
     def should_init_done(self) -> None:
         """Update phase on successful should_init()"""
@@ -162,7 +171,7 @@ class APIGuard:
     def verify_should_save_snapshot(self) -> None:
         """Check should_save_snapshot()"""
         if self._phase != APIPhase.BEFORE_SHOULD_SAVE_SNAPSHOT:
-            self._generic_error_messages('should_save_snapshot')
+            self._generic_error_messages("should_save_snapshot")
             raise RuntimeError()  # should be unreachable
 
     def should_save_snapshot_done(self, should_save: bool) -> None:
@@ -177,7 +186,7 @@ class APIGuard:
     def verify_save_snapshot(self) -> None:
         """Check save_snapshot()"""
         if self._phase != APIPhase.BEFORE_SAVE_SNAPSHOT:
-            self._generic_error_messages('save_snapshot')
+            self._generic_error_messages("save_snapshot")
             raise RuntimeError()  # should be unreachable
 
     def save_snapshot_done(self) -> None:
@@ -187,7 +196,7 @@ class APIGuard:
     def verify_should_save_final_snapshot(self) -> None:
         """Check should_save_final_snapshot()."""
         if self._phase != APIPhase.BEFORE_SHOULD_SAVE_SNAPSHOT:
-            self._generic_error_messages('should_save_final_snapshot')
+            self._generic_error_messages("should_save_final_snapshot")
             raise RuntimeError()  # should be unreachable
 
     def should_save_final_snapshot_done(self, should_save: bool) -> None:
@@ -204,7 +213,7 @@ class APIGuard:
     def verify_save_final_snapshot(self) -> None:
         """Check should_save_final_snapshot()"""
         if self._phase != APIPhase.BEFORE_SAVE_FINAL_SNAPSHOT:
-            self._generic_error_messages('save_final_snapshot')
+            self._generic_error_messages("save_final_snapshot")
             raise RuntimeError()  # should be unreachable
 
     def save_final_snapshot_done(self) -> None:

--- a/libmuscle/python/libmuscle/checkpoint_triggers.py
+++ b/libmuscle/python/libmuscle/checkpoint_triggers.py
@@ -118,8 +118,7 @@ class RangeCheckpointTrigger(CheckpointTrigger):
 
 
 class CombinedCheckpointTriggers(CheckpointTrigger):
-    """Checkpoint trigger based on a combination of "at" and "ranges"
-    """
+    """Checkpoint trigger based on a combination of "at" and "ranges" """
 
     def __init__(self, checkpoint_rules: list[CheckpointRule]) -> None:
         """Create a new combined checkpoint trigger from the given rules
@@ -136,42 +135,39 @@ class CombinedCheckpointTriggers(CheckpointTrigger):
             elif isinstance(rule, CheckpointRangeRule):
                 self._triggers.append(RangeCheckpointTrigger(rule))
             else:
-                raise RuntimeError('Unknown checkpoint rule')
+                raise RuntimeError("Unknown checkpoint rule")
         if at_rules:
             self._triggers.append(AtCheckpointTrigger(at_rules))
 
     def next_checkpoint(self, cur_time: float) -> Optional[float]:
-        checkpoints = (trigger.next_checkpoint(cur_time)
-                       for trigger in self._triggers)
+        checkpoints = (trigger.next_checkpoint(cur_time) for trigger in self._triggers)
         # return earliest of all not-None next-checkpoints
-        return min((checkpoint
-                    for checkpoint in checkpoints
-                    if checkpoint is not None),
-                   default=None)  # return None if all triggers return None
+        return min(
+            (checkpoint for checkpoint in checkpoints if checkpoint is not None),
+            default=None,
+        )  # return None if all triggers return None
 
     def previous_checkpoint(self, cur_time: float) -> Optional[float]:
-        checkpoints = (trigger.previous_checkpoint(cur_time)
-                       for trigger in self._triggers)
+        checkpoints = (
+            trigger.previous_checkpoint(cur_time) for trigger in self._triggers
+        )
         # return latest of all not-None previous-checkpoints
-        return max((checkpoint
-                    for checkpoint in checkpoints
-                    if checkpoint is not None),
-                   default=None)  # return None if all triggers return None
+        return max(
+            (checkpoint for checkpoint in checkpoints if checkpoint is not None),
+            default=None,
+        )  # return None if all triggers return None
 
 
 class TriggerManager:
-    """Manages all checkpoint triggers and checks if a snapshot must be saved.
-    """
+    """Manages all checkpoint triggers and checks if a snapshot must be saved."""
 
     def __init__(self) -> None:
         self._has_checkpoints = False
         self._last_triggers: list[str] = []
-        self._cpts_considered_until = float('-inf')
+        self._cpts_considered_until = float("-inf")
 
-    def set_checkpoint_info(
-            self, elapsed: float, checkpoints: Checkpoints) -> None:
-        """Register checkpoint info received from the muscle manager.
-        """
+    def set_checkpoint_info(self, elapsed: float, checkpoints: Checkpoints) -> None:
+        """Register checkpoint info received from the muscle manager."""
         self._mono_to_elapsed = elapsed - time.monotonic()
 
         if not checkpoints:
@@ -191,38 +187,33 @@ class TriggerManager:
         self._nextsim: Optional[float] = None
 
     def elapsed_walltime(self) -> float:
-        """Returns elapsed wallclock_time in seconds.
-        """
+        """Returns elapsed wallclock_time in seconds."""
         return time.monotonic() + self._mono_to_elapsed
 
     def checkpoints_considered_until(self) -> float:
-        """Return elapsed time of last should_save*
-        """
+        """Return elapsed time of last should_save*"""
         return self._cpts_considered_until
 
     def harmonise_wall_time(self, at_least: float) -> None:
-        """Ensure our elapsed time is at least the given value
-        """
+        """Ensure our elapsed time is at least the given value"""
         cur = self.elapsed_walltime()
         if cur < at_least:
             _logger.debug(
-                    'Harmonise wall time: advancing clock by %f seconds',
-                    at_least - cur)
+                "Harmonise wall time: advancing clock by %f seconds", at_least - cur
+            )
             self._mono_to_elapsed += at_least - cur
 
     def should_save_snapshot(self, timestamp: float) -> bool:
-        """Handles instance.should_save_snapshot
-        """
+        """Handles instance.should_save_snapshot"""
         if not self._has_checkpoints:
             return False
 
         return self.__should_save(timestamp)
 
     def should_save_final_snapshot(
-            self, do_reuse: bool, f_init_max_timestamp: Optional[float]
-            ) -> bool:
-        """Handles instance.should_save_final_snapshot
-        """
+        self, do_reuse: bool, f_init_max_timestamp: Optional[float]
+    ) -> bool:
+        """Handles instance.should_save_final_snapshot"""
         if not self._has_checkpoints:
             return False
 
@@ -230,12 +221,13 @@ class TriggerManager:
         if not do_reuse:
             if self._checkpoint_at_end:
                 value = True
-                self._last_triggers.append('at_end')
+                self._last_triggers.append("at_end")
         elif f_init_max_timestamp is None:
             # No F_INIT messages received: reuse triggered on muscle_settings_in
             # message.
-            _logger.debug('Reuse triggered by muscle_settings_in.'
-                          ' Not creating a snapshot.')
+            _logger.debug(
+                "Reuse triggered by muscle_settings_in. Not creating a snapshot."
+            )
         else:
             value = self.__should_save(f_init_max_timestamp)
 
@@ -255,8 +247,7 @@ class TriggerManager:
         self._nextsim = self._sim.next_checkpoint(timestamp)
 
     def get_triggers(self) -> list[str]:
-        """Get trigger description(s) for the current reason for checkpointing.
-        """
+        """Get trigger description(s) for the current reason for checkpointing."""
         triggers = self._last_triggers
         self._last_triggers = []
         return triggers

--- a/libmuscle/python/libmuscle/communicator.py
+++ b/libmuscle/python/libmuscle/communicator.py
@@ -35,12 +35,16 @@ class Message:
         settings (Settings): Overlay settings to send or that was
                 received.
     """
+
     # Note: This is for communication with the user, it's not what
     # actually goes out on the wire, see libmuscle.mcp.Message for that.
-    def __init__(self, timestamp: float, next_timestamp: Optional[float] = None,
-                 data: MessageObject = None,
-                 settings: Optional[Settings] = None
-                 ) -> None:
+    def __init__(
+        self,
+        timestamp: float,
+        next_timestamp: Optional[float] = None,
+        data: MessageObject = None,
+        settings: Optional[Settings] = None,
+    ) -> None:
         """Create a Message.
 
         Args:
@@ -69,10 +73,15 @@ class Communicator:
     leaves the actual data transmission to various protocol-specific
     servers and clients.
     """
+
     def __init__(
-            self, kernel: Reference, index: list[int],
-            port_manager: PortManager, profiler: Profiler,
-            manager: MMPClient) -> None:
+        self,
+        kernel: Reference,
+        index: list[int],
+        port_manager: PortManager,
+        profiler: Profiler,
+        manager: MMPClient,
+    ) -> None:
         """Create a Communicator.
 
         The instance reference must start with one or more Identifiers,
@@ -133,9 +142,12 @@ class Communicator:
         self._receive_timeout = receive_timeout
 
     def send_message(
-            self, port_name: str, message: Message,
-            slot: Optional[int] = None,
-            checkpoints_considered_until: float = float('-inf')) -> None:
+        self,
+        port_name: str,
+        message: Message,
+        slot: Optional[int] = None,
+        checkpoints_considered_until: float = float("-inf"),
+    ) -> None:
         """Send a message and settings to the outside world.
 
         Sending is non-blocking, a copy of the message will be made
@@ -149,10 +161,10 @@ class Communicator:
                 should save a snapshot (wallclock time).
         """
         if slot is None:
-            _logger.debug(f'Sending message on {port_name}')
+            _logger.debug(f"Sending message on {port_name}")
             slot_list: list[int] = []
         else:
-            _logger.debug(f'Sending message on {port_name}[{slot}]')
+            _logger.debug(f"Sending message on {port_name}[{slot}]")
             slot_list = [slot]
 
         snd_endpoint = self.__get_endpoint(port_name, slot_list)
@@ -162,24 +174,37 @@ class Communicator:
 
         port = self._port_manager.get_port(port_name)
         profile_event = ProfileEvent(
-                ProfileEventType.SEND, ProfileTimestamp(), None, port, None,
-                slot, port.get_num_messages(slot), None, message.timestamp)
+            ProfileEventType.SEND,
+            ProfileTimestamp(),
+            None,
+            port,
+            None,
+            slot,
+            port.get_num_messages(slot),
+            None,
+            message.timestamp,
+        )
 
         recv_endpoints = self._peer_info.get_peer_endpoints(
-                snd_endpoint.port, slot_list)
+            snd_endpoint.port, slot_list
+        )
 
         port_length = None
         if port.is_resizable():
             port_length = port.get_length()
 
         for recv_endpoint in recv_endpoints:
-            mpp_message = MPPMessage(snd_endpoint.ref(), recv_endpoint.ref(),
-                                     port_length,
-                                     message.timestamp, message.next_timestamp,
-                                     cast(Settings, message.settings),
-                                     port.get_num_messages(slot),
-                                     checkpoints_considered_until,
-                                     message.data)
+            mpp_message = MPPMessage(
+                snd_endpoint.ref(),
+                recv_endpoint.ref(),
+                port_length,
+                message.timestamp,
+                message.next_timestamp,
+                cast(Settings, message.settings),
+                port.get_num_messages(slot),
+                checkpoints_considered_until,
+                message.data,
+            )
             encoded_message = mpp_message.encoded()
             self._server.deposit(recv_endpoint.ref(), encoded_message)
 
@@ -193,7 +218,8 @@ class Communicator:
             self._profiler.record_event(profile_event)
 
     def receive_message(
-            self, port_name: str, slot: Optional[int] = None) -> tuple[Message, float]:
+        self, port_name: str, slot: Optional[int] = None
+    ) -> tuple[Message, float]:
         """Receive a message and attached settings overlay.
 
         Receiving is a blocking operation. This function will contact
@@ -219,7 +245,7 @@ class Communicator:
             RuntimeError: If the network connection had an error, or the
                     message number was incorrect.
         """
-        if port_name == 'muscle_settings_in':
+        if port_name == "muscle_settings_in":
             port = self._port_manager._muscle_settings_in
         else:
             port = self._port_manager.get_port(port_name)
@@ -230,27 +256,39 @@ class Communicator:
         else:
             port_and_slot = f"{port_name}[{slot}]"
             slot_list = [slot]
-        _logger.debug(f'Waiting for message on {port_and_slot}')
+        _logger.debug(f"Waiting for message on {port_and_slot}")
 
         recv_endpoint = self.__get_endpoint(port_name, slot_list)
 
         receive_event = ProfileEvent(
-                ProfileEventType.RECEIVE, ProfileTimestamp(), None, port, None,
-                slot, port.get_num_messages())
+            ProfileEventType.RECEIVE,
+            ProfileTimestamp(),
+            None,
+            port,
+            None,
+            slot,
+            port.get_num_messages(),
+        )
 
         # peer_info already checks that there is at most one snd_endpoint
         # connected to the port we receive on
         snd_endpoint = self._peer_info.get_peer_endpoints(
-                recv_endpoint.port, slot_list)[0]
+            recv_endpoint.port, slot_list
+        )[0]
         client = self.__get_client(snd_endpoint.instance())
         timeout_handler = None
         if self._receive_timeout >= 0:
             timeout_handler = ReceiveTimeoutHandler(
-                    self._manager, snd_endpoint.instance(),
-                    port_name, slot, self._receive_timeout)
+                self._manager,
+                snd_endpoint.instance(),
+                port_name,
+                slot,
+                self._receive_timeout,
+            )
         try:
             mpp_message_bytes, profile = client.receive(
-                    recv_endpoint.ref(), timeout_handler)
+                recv_endpoint.ref(), timeout_handler
+            )
         except (ConnectionError, SocketClosed) as exc:
             raise RuntimeError(
                 "Error while receiving a message: connection with peer"
@@ -265,9 +303,15 @@ class Communicator:
             ) from None
 
         recv_decode_event = ProfileEvent(
-                ProfileEventType.RECEIVE_DECODE, ProfileTimestamp(), None,
-                port, None, slot, port.get_num_messages(),
-                len(memoryview(mpp_message_bytes)))
+            ProfileEventType.RECEIVE_DECODE,
+            ProfileTimestamp(),
+            None,
+            port,
+            None,
+            slot,
+            port.get_num_messages(),
+            len(memoryview(mpp_message_bytes)),
+        )
         mpp_message = MPPMessage.from_bytes(mpp_message_bytes)
         recv_decode_event.stop()
 
@@ -279,18 +323,35 @@ class Communicator:
             port.set_closed(slot)
 
         message = Message(
-                mpp_message.timestamp, mpp_message.next_timestamp,
-                mpp_message.data, mpp_message.settings_overlay)
+            mpp_message.timestamp,
+            mpp_message.next_timestamp,
+            mpp_message.data,
+            mpp_message.settings_overlay,
+        )
 
         recv_wait_event = ProfileEvent(
-                ProfileEventType.RECEIVE_WAIT, profile[0], profile[1], port,
-                mpp_message.port_length, slot, port.get_num_messages(),
-                len(memoryview(mpp_message_bytes)), message.timestamp)
+            ProfileEventType.RECEIVE_WAIT,
+            profile[0],
+            profile[1],
+            port,
+            mpp_message.port_length,
+            slot,
+            port.get_num_messages(),
+            len(memoryview(mpp_message_bytes)),
+            message.timestamp,
+        )
 
         recv_xfer_event = ProfileEvent(
-                ProfileEventType.RECEIVE_TRANSFER, profile[1], profile[2],
-                port, mpp_message.port_length, slot, port.get_num_messages(),
-                len(memoryview(mpp_message_bytes)), message.timestamp)
+            ProfileEventType.RECEIVE_TRANSFER,
+            profile[1],
+            profile[2],
+            port,
+            mpp_message.port_length,
+            slot,
+            port.get_num_messages(),
+            len(memoryview(mpp_message_bytes)),
+            message.timestamp,
+        )
 
         recv_decode_event.message_timestamp = message.timestamp
         receive_event.message_timestamp = message.timestamp
@@ -311,28 +372,33 @@ class Communicator:
 
         expected_message_number = port.get_num_messages(slot)
         if expected_message_number != mpp_message.message_number:
-            if (expected_message_number - 1 == mpp_message.message_number and
-                    port.is_resuming(slot)):
-                _logger.debug(f'Discarding received message on {port_and_slot}'
-                              ': resuming from weakly consistent snapshot')
+            if (
+                expected_message_number - 1 == mpp_message.message_number
+                and port.is_resuming(slot)
+            ):
+                _logger.debug(
+                    f"Discarding received message on {port_and_slot}"
+                    ": resuming from weakly consistent snapshot"
+                )
                 port.set_resumed(slot)
                 return self.receive_message(port_name, slot)
-            raise RuntimeError(f'Received message on {port_and_slot} with'
-                               ' unexpected message number'
-                               f' {mpp_message.message_number}. Was expecting'
-                               f' {expected_message_number}. Are you resuming'
-                               ' from an inconsistent snapshot?')
+            raise RuntimeError(
+                f"Received message on {port_and_slot} with"
+                " unexpected message number"
+                f" {mpp_message.message_number}. Was expecting"
+                f" {expected_message_number}. Are you resuming"
+                " from an inconsistent snapshot?"
+            )
         port.increment_num_messages(slot)
 
-        _logger.debug(f'Received message on {port_and_slot}')
+        _logger.debug(f"Received message on {port_and_slot}")
         if isinstance(mpp_message.data, ClosePort):
-            _logger.debug(f'Port {port_and_slot} is now closed')
+            _logger.debug(f"Port {port_and_slot} is now closed")
 
         return message, mpp_message.saved_until
 
     def shutdown(self) -> None:
-        """Shuts down the Communicator, closing connections.
-        """
+        """Shuts down the Communicator, closing connections."""
         self._close_ports()
 
         for client in self._clients.values():
@@ -347,8 +413,7 @@ class Communicator:
         self._profiler.record_event(shutdown_event)
 
     def __instance_id(self) -> Reference:
-        """Returns our complete instance id.
-        """
+        """Returns our complete instance id."""
         return self._kernel + self._index
 
     def __get_client(self, instance: Reference) -> MPPClient:
@@ -362,7 +427,7 @@ class Communicator:
         """
         if instance not in self._clients:
             locations = self._peer_info.get_peer_locations(instance)
-            _logger.info(f'Connecting to peer {instance} at {locations}')
+            _logger.info(f"Connecting to peer {instance} at {locations}")
             self._clients[instance] = MPPClient(locations)
 
         return self._clients[instance]
@@ -391,11 +456,11 @@ class Communicator:
         Args:
             port_name: The name of the port to close.
         """
-        message = Message(float('inf'), None, ClosePort(), Settings())
+        message = Message(float("inf"), None, ClosePort(), Settings())
         if slot is None:
-            _logger.debug(f'Closing port {port_name}')
+            _logger.debug(f"Closing port {port_name}")
         else:
-            _logger.debug(f'Closing port {port_name}[{slot}]')
+            _logger.debug(f"Closing port {port_name}[{slot}]")
         self.send_message(port_name, message, slot)
 
     def _close_outgoing_ports(self) -> None:
@@ -436,8 +501,7 @@ class Communicator:
             port_name: Port to drain.
         """
         port = self._port_manager.get_port(port_name)
-        while not all([not port.is_open(slot)
-                       for slot in range(port.get_length())]):
+        while not all([not port.is_open(slot) for slot in range(port.get_length())]):
             for slot in range(port.get_length()):
                 if port.is_open(slot):
                     self.receive_message(port_name, slot)
@@ -463,11 +527,13 @@ class Communicator:
                             self._drain_incoming_vector_port(port_name)
                     except RuntimeError:
                         peer_endpoints = self._peer_info.get_peer_endpoints(
-                                Identifier(port_name), [])
+                            Identifier(port_name), []
+                        )
                         peer_name = str(peer_endpoints[0].kernel)
                         _logger.warning(
                             "Connection with peer '%s' was lost at the end of the "
-                            "simulation, probably because it crashed.", peer_name
+                            "simulation, probably because it crashed.",
+                            peer_name,
                         )
 
     def _close_ports(self) -> None:

--- a/libmuscle/python/libmuscle/endpoint.py
+++ b/libmuscle/python/libmuscle/endpoint.py
@@ -36,8 +36,10 @@ class Endpoint:
     Conduit instances are never actually created in the code, but
     Endpoints are.
     """
-    def __init__(self, kernel: Reference, index: list[int], port: Identifier,
-                 slot: list[int]) -> None:
+
+    def __init__(
+        self, kernel: Reference, index: list[int], port: Identifier, slot: list[int]
+    ) -> None:
         """Create an Endpoint
 
         Note: kernel is a Reference, not an Identifier, because it may
@@ -84,8 +86,7 @@ class Endpoint:
         return str(self.ref())
 
     def instance(self) -> Reference:
-        """Get a Reference to the instance this endpoint is on.
-        """
+        """Get a Reference to the instance this endpoint is on."""
         ret = self.kernel
         if self.index:
             ret += self.index

--- a/libmuscle/python/libmuscle/grid.py
+++ b/libmuscle/python/libmuscle/grid.py
@@ -18,9 +18,8 @@ class Grid:
         array (np.ndarray): An array of data
         indexes (Optional[list[str]]): The names of the array's indexes.
     """
-    def __init__(
-            self, array: np.ndarray, indexes: Optional[list[str]] = None
-            ) -> None:
+
+    def __init__(self, array: np.ndarray, indexes: Optional[list[str]] = None) -> None:
         """Creates a Grid object.
 
         A Grid object represents an multi-dimensional array of data. It
@@ -46,8 +45,8 @@ class Grid:
         if indexes is not None:
             if len(indexes) != array.ndim:
                 raise ValueError(
-                        'Number of indexes must match number of array'
-                        ' dimensions')
+                    "Number of indexes must match number of array dimensions"
+                )
 
         self.array = array
         self.indexes = indexes

--- a/libmuscle/python/libmuscle/instance.py
+++ b/libmuscle/python/libmuscle/instance.py
@@ -94,9 +94,10 @@ class InstanceFlags(Flag):
 
 
 _CHECKPOINT_SUPPORT_MASK = (
-        InstanceFlags.USES_CHECKPOINT_API |
-        InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE |
-        InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE)
+    InstanceFlags.USES_CHECKPOINT_API
+    | InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE
+    | InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE
+)
 
 
 _NO_INSTANCE_FLAGS = InstanceFlags(0)
@@ -108,9 +109,12 @@ class Instance:
     This class provides a low-level send/receive API for the instance
     to use.
     """
+
     def __init__(
-            self, ports: Optional[dict[Operator, list[str]]] = None,
-            flags: InstanceFlags = _NO_INSTANCE_FLAGS) -> None:
+        self,
+        ports: Optional[dict[Operator, list[str]]] = None,
+        flags: InstanceFlags = _NO_INSTANCE_FLAGS,
+    ) -> None:
         """Create an Instance.
 
         Args:
@@ -137,8 +141,7 @@ class Instance:
 
         self.__set_up_logging()
 
-        self._api_guard = APIGuard(
-                InstanceFlags.USES_CHECKPOINT_API in self._flags)
+        self._api_guard = APIGuard(InstanceFlags.USES_CHECKPOINT_API in self._flags)
         """Checks that the user uses the API correctly."""
 
         self._profiler = Profiler(self.__manager)
@@ -148,8 +151,8 @@ class Instance:
         """PortManager for this instance."""
 
         self._communicator = Communicator(
-                self._name, self._index, self._port_manager, self._profiler,
-                self.__manager)
+            self._name, self._index, self._port_manager, self._profiler, self.__manager
+        )
         """Communicator for this instance."""
 
         self._declared_ports = ports
@@ -159,7 +162,8 @@ class Instance:
         """Settings for this instance."""
 
         self._snapshot_manager = SnapshotManager(
-                self._instance_id, self.__manager, self._port_manager)
+            self._instance_id, self.__manager, self._port_manager
+        )
         """Resumes, loads and saves snapshots."""
 
         self._trigger_manager = TriggerManager()
@@ -203,8 +207,10 @@ class Instance:
         self._setup_receive_timeout()
         # MMSFValidator needs a connected port manager, and does some logging
         self._mmsf_validator = (
-                None if InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS in self._flags
-                else MMSFValidator(self._port_manager))
+            None
+            if InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS in self._flags
+            else MMSFValidator(self._port_manager)
+        )
 
     def reuse_instance(self) -> bool:
         """Decide whether to run this instance again.
@@ -257,14 +263,18 @@ class Instance:
         # now _first_run, _do_resume and _do_init are also set correctly
 
         do_implicit_checkpoint = (
-                not self._first_run and
-                InstanceFlags.USES_CHECKPOINT_API not in self._flags and
-                (InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE in self._flags or
-                 InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE in self._flags))
+            not self._first_run
+            and InstanceFlags.USES_CHECKPOINT_API not in self._flags
+            and (
+                InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE in self._flags
+                or InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE in self._flags
+            )
+        )
 
         if do_implicit_checkpoint:
             if self._trigger_manager.should_save_final_snapshot(
-                    do_reuse, self.__f_init_max_timestamp):
+                do_reuse, self.__f_init_max_timestamp
+            ):
                 # store a None instead of a Message
                 self._save_snapshot(None, True, self.__f_init_max_timestamp)
 
@@ -306,51 +316,59 @@ class Instance:
 
     @overload
     def get_setting(
-            self, name: str, typ: Literal['str'], *,
-            default: Optional[str] = None) -> str:
-        ...
+        self, name: str, typ: Literal["str"], *, default: Optional[str] = None
+    ) -> str: ...
 
     @overload
     def get_setting(
-            self, name: str, typ: Literal['int'], *,
-            default: Optional[int] = None) -> int:
-        ...
-
-    @overload
-    def get_setting(self, name: str, typ: Literal['float'], *,
-                    default: Optional[float] = None) -> float:
-        ...
-
-    @overload
-    def get_setting(self, name: str, typ: Literal['bool'], *,
-                    default: Optional[bool] = None) -> bool:
-        ...
-
-    @overload
-    def get_setting(self, name: str, typ: Literal['[int]'], *,
-                    default: Optional[list[int]] = None) -> list[int]:
-        ...
-
-    @overload
-    def get_setting(self, name: str, typ: Literal['[float]'], *,
-                    default: Optional[list[float]] = None) -> list[float]:
-        ...
+        self, name: str, typ: Literal["int"], *, default: Optional[int] = None
+    ) -> int: ...
 
     @overload
     def get_setting(
-            self, name: str, typ: Literal['[[float]]'], *,
-            default: Optional[list[list[float]]] = None) -> list[list[float]]:
-        ...
+        self, name: str, typ: Literal["float"], *, default: Optional[float] = None
+    ) -> float: ...
 
     @overload
-    def get_setting(self, name: str, typ: None = None, *,
-                    default: Optional[SettingValue] = None) -> SettingValue:
-        ...
+    def get_setting(
+        self, name: str, typ: Literal["bool"], *, default: Optional[bool] = None
+    ) -> bool: ...
+
+    @overload
+    def get_setting(
+        self, name: str, typ: Literal["[int]"], *, default: Optional[list[int]] = None
+    ) -> list[int]: ...
+
+    @overload
+    def get_setting(
+        self,
+        name: str,
+        typ: Literal["[float]"],
+        *,
+        default: Optional[list[float]] = None,
+    ) -> list[float]: ...
+
+    @overload
+    def get_setting(
+        self,
+        name: str,
+        typ: Literal["[[float]]"],
+        *,
+        default: Optional[list[list[float]]] = None,
+    ) -> list[list[float]]: ...
+
+    @overload
+    def get_setting(
+        self, name: str, typ: None = None, *, default: Optional[SettingValue] = None
+    ) -> SettingValue: ...
 
     def get_setting(
-            self, name: str, typ: Optional[str] = None, *,
-            default: Optional[SettingValue] = None
-            ) -> SettingValue:
+        self,
+        name: str,
+        typ: Optional[str] = None,
+        *,
+        default: Optional[SettingValue] = None,
+    ) -> SettingValue:
         """Returns the value of a model setting.
 
         Args:
@@ -376,7 +394,8 @@ class Instance:
         """
         try:
             return self._settings_manager.get_setting(
-                self._instance_id, Reference(name), typ)
+                self._instance_id, Reference(name), typ
+            )
         except KeyError:
             if default is not None:
                 return default
@@ -467,8 +486,9 @@ class Instance:
         """
         self._port_manager.get_port(port).set_length(length)
 
-    def send(self, port_name: str, message: Message,
-             slot: Optional[int] = None) -> None:
+    def send(
+        self, port_name: str, message: Message, slot: Optional[int] = None
+    ) -> None:
         """Send a message to the outside world.
 
         Sending is non-blocking, a copy of the message will be made
@@ -487,12 +507,18 @@ class Instance:
             message.settings = self._settings_manager.overlay
 
         self._communicator.send_message(
-                port_name, message, slot,
-                self._trigger_manager.checkpoints_considered_until())
+            port_name,
+            message,
+            slot,
+            self._trigger_manager.checkpoints_considered_until(),
+        )
 
-    def receive(self, port_name: str, slot: Optional[int] = None,
-                default: Optional[Message] = None
-                ) -> Message:
+    def receive(
+        self,
+        port_name: str,
+        slot: Optional[int] = None,
+        default: Optional[Message] = None,
+    ) -> Message:
         """Receive a message from the outside world.
 
         Receiving is a blocking operation. This function will contact
@@ -523,9 +549,11 @@ class Instance:
         return self.__receive_message(port_name, slot, default, False)
 
     def receive_with_settings(
-            self, port_name: str, slot: Optional[int] = None,
-            default: Optional[Message] = None
-            ) -> Message:
+        self,
+        port_name: str,
+        slot: Optional[int] = None,
+        default: Optional[Message] = None,
+    ) -> Message:
         """Receive a message with attached settings overlay.
 
         This function should not be used in submodels. It is intended
@@ -657,7 +685,7 @@ class Instance:
         """
         self._api_guard.verify_save_snapshot()
         if message is None:
-            raise RuntimeError('Please specify a Message to save as snapshot.')
+            raise RuntimeError("Please specify a Message to save as snapshot.")
         self._save_snapshot(message, False)
         self._api_guard.save_snapshot_done()
 
@@ -688,7 +716,8 @@ class Instance:
 
         self._do_reuse = self._decide_reuse_instance()
         result = self._trigger_manager.should_save_final_snapshot(
-                self._do_reuse, self.__f_init_max_timestamp)
+            self._do_reuse, self.__f_init_max_timestamp
+        )
 
         self._api_guard.should_save_final_snapshot_done(result)
         return result
@@ -710,34 +739,27 @@ class Instance:
         """
         self._api_guard.verify_save_final_snapshot()
         if message is None:
-            raise RuntimeError('Please specify a Message to save as snapshot.')
+            raise RuntimeError("Please specify a Message to save as snapshot.")
         self._save_snapshot(message, True, self.__f_init_max_timestamp)
         self._api_guard.save_final_snapshot_done()
 
     @property
     def __f_init_max_timestamp(self) -> Optional[float]:
-        """Return max timestamp of pre-received F_INIT messages
-        """
-        return max(
-                (msg.timestamp for msg in self._f_init_cache.values()),
-                default=None)
+        """Return max timestamp of pre-received F_INIT messages"""
+        return max((msg.timestamp for msg in self._f_init_cache.values()), default=None)
 
     def _register(self) -> None:
-        """Register this instance with the manager.
-        """
-        register_event = ProfileEvent(
-                ProfileEventType.REGISTER, ProfileTimestamp())
+        """Register this instance with the manager."""
+        register_event = ProfileEvent(ProfileEventType.REGISTER, ProfileTimestamp())
         locations = self._communicator.get_locations()
         port_list = self.__list_declared_ports()
         self.__manager.register_instance(locations, port_list)
         self._profiler.record_event(register_event)
-        _logger.info('Registered with the manager')
+        _logger.info("Registered with the manager")
 
     def _connect(self) -> None:
-        """Connect this instance to the given peers / conduits.
-        """
-        connect_event = ProfileEvent(
-                ProfileEventType.CONNECT, ProfileTimestamp())
+        """Connect this instance to the given peers / conduits."""
+        connect_event = ProfileEvent(ProfileEventType.CONNECT, ProfileTimestamp())
 
         peer_info = self.__manager.request_peers()
         self._port_manager.connect_ports(peer_info)
@@ -746,18 +768,16 @@ class Instance:
         self._settings_manager.base = self.__manager.get_settings()
 
         self._profiler.record_event(connect_event)
-        _logger.info('Received peer locations and base settings')
+        _logger.info("Received peer locations and base settings")
 
     def _deregister(self) -> None:
-        """Deregister this instance from the manager.
-        """
+        """Deregister this instance from the manager."""
         # Make sure we record this even if profiling is disabled, so
         # that we always have register, connect and deregister at
         # least.
-        self._profiler.set_level('all')
+        self._profiler.set_level("all")
 
-        deregister_event = ProfileEvent(
-                ProfileEventType.DEREGISTER, ProfileTimestamp())
+        deregister_event = ProfileEvent(ProfileEventType.DEREGISTER, ProfileTimestamp())
         # We need to finish the event right away, because we need to
         # submit it before deregistering, which is the last interaction
         # with the manager we'll have.
@@ -770,11 +790,10 @@ class Instance:
         # Remove handler, the manager may be gone at this point so we
         # cannot send it any more log messages.
         logging.getLogger().removeHandler(self._mmp_handler)
-        _logger.info('Deregistered from the manager')
+        _logger.info("Deregistered from the manager")
 
     def _setup_checkpointing(self) -> None:
-        """Setup checkpointing.
-        """
+        """Setup checkpointing."""
         checkpoint_info = self.__manager.get_checkpoint_info()
 
         elapsed_time, checkpoints = checkpoint_info[0:2]
@@ -782,16 +801,16 @@ class Instance:
 
         if checkpoints and not (self._flags & _CHECKPOINT_SUPPORT_MASK):
             err_msg = (
-                    'The workflow has requested checkpoints, but this instance'
-                    ' does not support checkpointing. Please consult the'
-                    ' MUSCLE3 checkpointing documentation how to add'
-                    ' checkpointing support.')
+                "The workflow has requested checkpoints, but this instance"
+                " does not support checkpointing. Please consult the"
+                " MUSCLE3 checkpointing documentation how to add"
+                " checkpointing support."
+            )
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 
         resume_snapshot, snapshot_dir = checkpoint_info[2:4]
-        saved_at = self._snapshot_manager.prepare_resume(
-                resume_snapshot, snapshot_dir)
+        saved_at = self._snapshot_manager.prepare_resume(resume_snapshot, snapshot_dir)
         # Resume settings overlay
         overlay = self._snapshot_manager.resume_overlay
         if overlay is not None:
@@ -817,65 +836,68 @@ class Instance:
         # Neither getopt, optparse, or argparse will let me pick out
         # just one option from the command line and ignore the rest.
         # So we do it by hand.
-        prefix = '--muscle-manager='
+        prefix = "--muscle-manager="
         for arg in sys.argv[1:]:
             if arg.startswith(prefix):
-                return arg[len(prefix):]
+                return arg[len(prefix) :]
 
-        return os.environ.get('MUSCLE_MANAGER', 'tcp:localhost:9000')
+        return os.environ.get("MUSCLE_MANAGER", "tcp:localhost:9000")
 
     def __set_up_logging(self) -> None:
-        """Adds logging handlers for one or more instances.
-        """
+        """Adds logging handlers for one or more instances."""
         id_str = str(self._instance_id)
 
-        logfile = extract_log_file_location(f'muscle3.{id_str}.log')
+        logfile = extract_log_file_location(f"muscle3.{id_str}.log")
         if logfile is not None:
-            local_handler = logging.FileHandler(str(logfile), mode='w')
+            local_handler = logging.FileHandler(str(logfile), mode="w")
             formatter = logging.Formatter(
-                    '%(asctime)-15s: %(levelname)-7s %(name)s: %(message)s')
+                "%(asctime)-15s: %(levelname)-7s %(name)s: %(message)s"
+            )
             local_handler.setFormatter(formatter)
-            logging.getLogger('libmuscle').addHandler(local_handler)
-            logging.getLogger('ymmsl').addHandler(local_handler)
+            logging.getLogger("libmuscle").addHandler(local_handler)
+            logging.getLogger("ymmsl").addHandler(local_handler)
 
         if self.__manager is not None:
-            self._mmp_handler = MuscleManagerHandler(id_str, logging.WARNING,
-                                                     self.__manager)
+            self._mmp_handler = MuscleManagerHandler(
+                id_str, logging.WARNING, self.__manager
+            )
             logging.getLogger().addHandler(self._mmp_handler)
 
     def _setup_profiling(self) -> None:
-        """Configures profiler with settings from settings.
-        """
+        """Configures profiler with settings from settings."""
         try:
-            profile_level_str = self.get_setting('muscle_profile_level', 'str')
+            profile_level_str = self.get_setting("muscle_profile_level", "str")
         except KeyError:
-            profile_level_str = 'all'
+            profile_level_str = "all"
 
-        if profile_level_str not in ('none', 'all'):
+        if profile_level_str not in ("none", "all"):
             _logger.warning(
-                    'Invalid value for muscle_profile_level:'
-                    f' {profile_level_str}. Please specify "none" or "all".'
-                    ' Using default value "all".')
-            profile_level_str = 'all'
+                "Invalid value for muscle_profile_level:"
+                f' {profile_level_str}. Please specify "none" or "all".'
+                ' Using default value "all".'
+            )
+            profile_level_str = "all"
 
         self._profiler.set_level(profile_level_str)
 
     def _setup_receive_timeout(self) -> None:
-        """Configures receive timeout with settings from settings.
-        """
+        """Configures receive timeout with settings from settings."""
         try:
-            timeout = self.get_setting('muscle_deadlock_receive_timeout', 'float')
+            timeout = self.get_setting("muscle_deadlock_receive_timeout", "float")
             if 0 <= timeout < 0.1:
                 _logger.info(
-                        "Provided muscle_deadlock_receive_timeout (%f) was less than "
-                        "the minimum of 0.1 seconds, setting it to 0.1.", timeout)
+                    "Provided muscle_deadlock_receive_timeout (%f) was less than "
+                    "the minimum of 0.1 seconds, setting it to 0.1.",
+                    timeout,
+                )
                 timeout = 0.1
             self._communicator.set_receive_timeout(timeout)
         except KeyError:
             pass  # do nothing and keep the default
         _logger.debug(
-                "Timeout on receiving messages set to %f",
-                self._communicator._receive_timeout)
+            "Timeout on receiving messages set to %f",
+            self._communicator._receive_timeout,
+        )
 
     def _decide_reuse_instance(self) -> bool:
         """Decide whether and how to reuse the instance.
@@ -906,8 +928,8 @@ class Instance:
                 self._do_init = True
                 return got_f_init_messages
             else:
-                self._do_resume = False     # unused
-                self._do_init = False       # unused
+                self._do_resume = False  # unused
+                self._do_init = False  # unused
                 return False
 
         # fresh start or resuming from implicit snapshot
@@ -924,8 +946,11 @@ class Instance:
         return got_f_init_messages
 
     def _save_snapshot(
-            self, message: Optional[Message], final: bool,
-            f_init_max_timestamp: Optional[float] = None) -> None:
+        self,
+        message: Optional[Message],
+        final: bool,
+        f_init_max_timestamp: Optional[float] = None,
+    ) -> None:
         """Save a snapshot to disk and notify manager.
 
         Args:
@@ -937,14 +962,22 @@ class Instance:
         triggers = self._trigger_manager.get_triggers()
         walltime = self._trigger_manager.elapsed_walltime()
         timestamp = self._snapshot_manager.save_snapshot(
-                message, final, triggers, walltime,
-                f_init_max_timestamp, self._settings_manager.overlay)
+            message,
+            final,
+            triggers,
+            walltime,
+            f_init_max_timestamp,
+            self._settings_manager.overlay,
+        )
         self._trigger_manager.update_checkpoints(timestamp)
 
     def __receive_message(
-            self, port_name: str, slot: Optional[int],
-            default: Optional[Message], with_settings: bool
-            ) -> Message:
+        self,
+        port_name: str,
+        slot: Optional[int],
+        default: Optional[Message],
+        with_settings: bool,
+    ) -> Message:
         """Receives a message on the given port.
 
         This implements receive and receive_with_settings, see the
@@ -960,53 +993,62 @@ class Instance:
                 msg = self._f_init_cache[(port_name, slot)]
                 del self._f_init_cache[(port_name, slot)]
                 if with_settings and msg.settings is None:
-                    err_msg = ('If you use receive_with_settings()'
-                               ' on an F_INIT port, then you have to'
-                               ' set the flag'
-                               ' :attr:`InstanceFlag.DONT_APPLY_OVERLAY` when'
-                               ' creating the :class:`Instance`, otherwise the'
-                               ' settings will already have been applied by'
-                               ' MUSCLE.')
+                    err_msg = (
+                        "If you use receive_with_settings()"
+                        " on an F_INIT port, then you have to"
+                        " set the flag"
+                        " :attr:`InstanceFlag.DONT_APPLY_OVERLAY` when"
+                        " creating the :class:`Instance`, otherwise the"
+                        " settings will already have been applied by"
+                        " MUSCLE."
+                    )
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
             else:
                 if port.is_connected():
-                    err_msg = ('Tried to receive twice on the same'
-                               f' port "{port_name}", that\'s not possible.'
-                               ' Did you forget to call'
-                               ' reuse_instance() in your reuse loop?'
-                               )
+                    err_msg = (
+                        "Tried to receive twice on the same"
+                        f' port "{port_name}", that\'s not possible.'
+                        " Did you forget to call"
+                        " reuse_instance() in your reuse loop?"
+                    )
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
                 else:
                     if default is not None:
                         return default
-                    err_msg = (f'Tried to receive on port "{port_name}",'
-                               ' which is not connected, and no'
-                               ' default value was given. Please'
-                               ' connect this port!')
+                    err_msg = (
+                        f'Tried to receive on port "{port_name}",'
+                        " which is not connected, and no"
+                        " default value was given. Please"
+                        " connect this port!"
+                    )
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
 
         else:
             if not port.is_connected():
                 if default is None:
-                    raise RuntimeError(f'Tried to receive on port "{port_name}", which'
-                                        ' is disconnected, and no default value was'
-                                        ' given. Either specify a default, or'
-                                        ' connect a sending component to this'
-                                        ' port.')
+                    raise RuntimeError(
+                        f'Tried to receive on port "{port_name}", which'
+                        " is disconnected, and no default value was"
+                        " given. Either specify a default, or"
+                        " connect a sending component to this"
+                        " port."
+                    )
                 else:
                     _logger.debug(
-                            f'No message received on {port_name} as it is not'
-                            ' connected')
+                        f"No message received on {port_name} as it is not connected"
+                    )
                     return default
 
             else:
                 msg, saved_until = self._communicator.receive_message(port_name, slot)
                 if not port.is_open(slot):
-                    err_msg = (f'Port {port_name} was closed while trying to'
-                                ' receive on it, did the peer crash?')
+                    err_msg = (
+                        f"Port {port_name} was closed while trying to"
+                        " receive on it, did the peer crash?"
+                    )
                     self.__shutdown(err_msg)
                     raise RuntimeError(err_msg)
                 if not with_settings:
@@ -1015,13 +1057,13 @@ class Instance:
                 self._trigger_manager.harmonise_wall_time(saved_until)
         return msg
 
-    def __make_full_name(self
-                         ) -> tuple[Reference, list[int]]:
+    def __make_full_name(self) -> tuple[Reference, list[int]]:
         """Returns instance name and index.
 
         This takes the argument to the --muscle-instance= command-line
         option and splits it into a component name and an index.
         """
+
         def split_reference(ref: Reference) -> tuple[Reference, list[int]]:
             index: list[int] = []
             i = 0
@@ -1038,22 +1080,23 @@ class Instance:
         # Neither getopt, optparse, or argparse will let me pick out
         # just one option from the command line and ignore the rest.
         # So we do it by hand.
-        prefix_tag = '--muscle-instance='
+        prefix_tag = "--muscle-instance="
         for arg in sys.argv[1:]:
             if arg.startswith(prefix_tag):
-                prefix_str = arg[len(prefix_tag):]
+                prefix_str = arg[len(prefix_tag) :]
                 prefix_ref = Reference(prefix_str)
                 name, index = split_reference(prefix_ref)
                 break
         else:
-            if 'MUSCLE_INSTANCE' in os.environ:
-                prefix_ref = Reference(os.environ['MUSCLE_INSTANCE'])
+            if "MUSCLE_INSTANCE" in os.environ:
+                prefix_ref = Reference(os.environ["MUSCLE_INSTANCE"])
                 name, index = split_reference(prefix_ref)
             else:
                 raise RuntimeError(
-                    'A --muscle-instance command line argument or'
-                    ' MUSCLE_INSTANCE environment variable is required to'
-                    ' identify this instance. Please add one.')
+                    "A --muscle-instance command line argument or"
+                    " MUSCLE_INSTANCE environment variable is required to"
+                    " identify this instance. Please add one."
+                )
         return name, index
 
     def __list_declared_ports(self) -> list[Port]:
@@ -1066,39 +1109,46 @@ class Instance:
         if self._declared_ports is not None:
             for operator, port_names in self._declared_ports.items():
                 for name in port_names:
-                    if name.endswith('[]'):
+                    if name.endswith("[]"):
                         name = name[:-2]
                     result.append(Port(Identifier(name), operator))
         return result
 
     def __check_port(
-            self, port_name: str, slot: Optional[int], is_send: bool,
-            allow_slot_out_of_range: bool = False) -> None:
+        self,
+        port_name: str,
+        slot: Optional[int],
+        is_send: bool,
+        allow_slot_out_of_range: bool = False,
+    ) -> None:
         if not self._port_manager.port_exists(port_name):
-            err_msg = (f'Port "{port_name}" does not exist on "{self._name}". Please'
-                        ' check the name and the list of ports you gave for'
-                        ' this component.')
+            err_msg = (
+                f'Port "{port_name}" does not exist on "{self._name}". Please'
+                " check the name and the list of ports you gave for"
+                " this component."
+            )
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 
         port = self._port_manager.get_port(port_name)
         if is_send:
             if not port.operator.allows_sending():
-                err_msg = (f'Port "{port_name}" does not allow sending messages.')
+                err_msg = f'Port "{port_name}" does not allow sending messages.'
                 self.__shutdown(err_msg)
                 raise RuntimeError(err_msg)
         else:
             if not port.operator.allows_receiving():
-                err_msg = (f'Port "{port_name}" does not allow receiving messages.')
+                err_msg = f'Port "{port_name}" does not allow receiving messages.'
                 self.__shutdown(err_msg)
                 raise RuntimeError(err_msg)
 
         if slot is not None:
             if not port.is_vector():
                 err_msg = (
-                        f'Port "{port_name}" is not a vector port, but a slot was'
-                        ' given. Please check your send call and your port'
-                        ' declarations')
+                    f'Port "{port_name}" is not a vector port, but a slot was'
+                    " given. Please check your send call and your port"
+                    " declarations"
+                )
                 self.__shutdown(err_msg)
                 raise RuntimeError(err_msg)
 
@@ -1107,10 +1157,11 @@ class Instance:
                 if not (port.is_resizable() and allow_slot_out_of_range):
                     if port.get_length() <= slot:
                         err_msg = (
-                                f'Tried to send or receive on slot {slot} of port'
-                                f' "{port_name}", which has length {port.get_length()}.'
-                                f' Please check your code and/or the multiplicities in'
-                                f' the model description.')
+                            f"Tried to send or receive on slot {slot} of port"
+                            f' "{port_name}", which has length {port.get_length()}.'
+                            f" Please check your code and/or the multiplicities in"
+                            f" the model description."
+                        )
                         self.__shutdown(err_msg)
                         raise RuntimeError(err_msg)
 
@@ -1121,8 +1172,8 @@ class Instance:
         """
         ports = self._port_manager.list_ports()
         f_init_connected = any(
-                [self.is_connected(port)
-                 for port in ports.get(Operator.F_INIT, [])])
+            [self.is_connected(port) for port in ports.get(Operator.F_INIT, [])]
+        )
         return f_init_connected or self._port_manager.settings_in_connected()
 
     def _pre_receive(self) -> bool:
@@ -1157,14 +1208,16 @@ class Instance:
         Returns:
             False iff the port is connnected and ClosePort was received.
         """
-        message, saved_until = self._communicator.receive_message('muscle_settings_in')
+        message, saved_until = self._communicator.receive_message("muscle_settings_in")
 
         if isinstance(message.data, ClosePort):
             return False
         if not isinstance(message.data, Settings):
-            err_msg = (f'"{self._instance_id}" received a message on'
-                       ' muscle_settings_in that is not a Settings. It seems that your'
-                       ' simulation is miswired or the sending instance is broken.')
+            err_msg = (
+                f'"{self._instance_id}" received a message on'
+                " muscle_settings_in that is not a Settings. It seems that your"
+                " simulation is miswired or the sending instance is broken."
+            )
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 
@@ -1196,7 +1249,7 @@ class Instance:
         self._f_init_cache = dict()
         ports = self._port_manager.list_ports()
         for port_name in ports.get(Operator.F_INIT, []):
-            _logger.debug(f'Pre-receiving on port {port_name}')
+            _logger.debug(f"Pre-receiving on port {port_name}")
             port = self._port_manager.get_port(port_name)
             if not port.is_connected():
                 continue
@@ -1220,7 +1273,7 @@ class Instance:
         if it is currently higher, otherwise we still get no output.
         """
         try:
-            log_level_str = self.get_setting('muscle_remote_log_level', 'str')
+            log_level_str = self.get_setting("muscle_remote_log_level", "str")
         except KeyError:
             # muscle_remote_log_level not set, do nothing and keep the default
             return
@@ -1237,9 +1290,10 @@ class Instance:
 
         except KeyError:
             _logger.warning(
-                f'muscle_remote_log_level is set to {log_level_str}, which is not a'
-                ' valid remote log level. Please use one of DEBUG, INFO, WARNING,'
-                ' ERROR, CRITICAL, or DISABLED')
+                f"muscle_remote_log_level is set to {log_level_str}, which is not a"
+                " valid remote log level. Please use one of DEBUG, INFO, WARNING,"
+                " ERROR, CRITICAL, or DISABLED"
+            )
             return
 
     def _set_local_log_level(self) -> None:
@@ -1253,7 +1307,7 @@ class Instance:
         --muscle-log-file command line option.
         """
         try:
-            log_level_str = self.get_setting('muscle_local_log_level', 'str')
+            log_level_str = self.get_setting("muscle_local_log_level", "str")
         except KeyError:
             # muscle_remote_log_level not set, do nothing and keep the default
             return
@@ -1262,14 +1316,15 @@ class Instance:
             log_level = LogLevel[log_level_str.upper()]
         except KeyError:
             _logger.warning(
-                f'muscle_local_log_level is set to {log_level_str}, which is not a'
-                ' valid log level. Please use one of DEBUG, INFO, WARNING, ERROR,'
-                ' CRITICAL, or DISABLED')
+                f"muscle_local_log_level is set to {log_level_str}, which is not a"
+                " valid log level. Please use one of DEBUG, INFO, WARNING, ERROR,"
+                " CRITICAL, or DISABLED"
+            )
             return
 
         py_level = log_level.as_python_level()
-        logging.getLogger('libmuscle').setLevel(py_level)
-        logging.getLogger('ymmsl').setLevel(py_level)
+        logging.getLogger("libmuscle").setLevel(py_level)
+        logging.getLogger("ymmsl").setLevel(py_level)
 
     def __apply_overlay(self, message: Message) -> None:
         """Sets local overlay if we don't already have one.
@@ -1281,8 +1336,9 @@ class Instance:
             if message.settings is not None:
                 self._settings_manager.overlay = message.settings
 
-    def __check_compatibility(self, port_name: str,
-                              overlay: Optional[Settings]) -> None:
+    def __check_compatibility(
+        self, port_name: str, overlay: Optional[Settings]
+    ) -> None:
         """Checks whether a received overlay matches the current one.
 
         Args:
@@ -1294,10 +1350,11 @@ class Instance:
             return
         if self._settings_manager.overlay != overlay:
             err_msg = (
-                    'Unexpectedly received data from a parallel universe on port'
-                    f' "{port_name}". My settings are'
-                    f' "{self._settings_manager.overlay}" and I received from a'
-                    f' universe with "{overlay}".')
+                "Unexpectedly received data from a parallel universe on port"
+                f' "{port_name}". My settings are'
+                f' "{self._settings_manager.overlay}" and I received from a'
+                f' universe with "{overlay}".'
+            )
             self.__shutdown(err_msg)
             raise RuntimeError(err_msg)
 

--- a/libmuscle/python/libmuscle/logging.py
+++ b/libmuscle/python/libmuscle/logging.py
@@ -11,6 +11,7 @@ class LogLevel(Enum):
     be kept identical to those. They also match the Python logging log
     levels.
     """
+
     DISABLE = 100
     CRITICAL = 50
     ERROR = 40
@@ -20,7 +21,7 @@ class LogLevel(Enum):
     LOCAL = 0
 
     @staticmethod
-    def from_python_level(level: int) -> 'LogLevel':
+    def from_python_level(level: int) -> "LogLevel":
         """Creates a LogLevel from a Python log level.
 
         Args:
@@ -42,12 +43,13 @@ class LogLevel(Enum):
     def as_python_level(self) -> int:
         """Convert the LogLevel to the corresponding Python level."""
         to_python_level = {
-                LogLevel.CRITICAL: logging.CRITICAL,
-                LogLevel.ERROR: logging.ERROR,
-                LogLevel.WARNING: logging.WARNING,
-                LogLevel.INFO: logging.INFO,
-                LogLevel.DEBUG: logging.DEBUG,
-                LogLevel.LOCAL: logging.DEBUG}
+            LogLevel.CRITICAL: logging.CRITICAL,
+            LogLevel.ERROR: logging.ERROR,
+            LogLevel.WARNING: logging.WARNING,
+            LogLevel.INFO: logging.INFO,
+            LogLevel.DEBUG: logging.DEBUG,
+            LogLevel.LOCAL: logging.DEBUG,
+        }
         return to_python_level[self]
 
 
@@ -70,13 +72,10 @@ class LogMessage:
         level: Log level of the message.
         text: Content of the message.
     """
+
     def __init__(
-            self,
-            instance_id: str,
-            timestamp: Timestamp,
-            level: LogLevel,
-            text: str
-            ) -> None:
+        self, instance_id: str, timestamp: Timestamp, level: LogLevel, text: str
+    ) -> None:
 
         self.instance_id = instance_id
         self.timestamp = timestamp

--- a/libmuscle/python/libmuscle/logging_handler.py
+++ b/libmuscle/python/libmuscle/logging_handler.py
@@ -11,8 +11,8 @@ class MuscleManagerHandler(logging.Handler):
     be attached to a logger, and forwards log messages to the Muscle
     Manager for central logging.
     """
-    def __init__(self, instance_id: str, level: int, mmp_client: MMPClient
-                 ) -> None:
+
+    def __init__(self, instance_id: str, level: int, mmp_client: MMPClient) -> None:
         """Create a MuscleManagerHandler.
 
         Args:
@@ -32,17 +32,23 @@ class MuscleManagerHandler(logging.Handler):
         messages were dropped and try to get that into the manager log, referring the
         user to the instance log.
         """
-        message = LogMessage(self._instance_id, Timestamp(record.created),
-                             LogLevel.from_python_level(record.levelno),
-                             self.format(record))
+        message = LogMessage(
+            self._instance_id,
+            Timestamp(record.created),
+            LogLevel.from_python_level(record.levelno),
+            self.format(record),
+        )
 
         try:
             if self._num_dropped > 0:
                 dropped_msg = LogMessage(
-                        self._instance_id, Timestamp(), LogLevel.WARNING,
-                        f'{self._num_dropped} log messages were not sent to the manager'
-                        ' log due to manager overload or network connectivity problems.'
-                        ' Please see the instance log to read them.')
+                    self._instance_id,
+                    Timestamp(),
+                    LogLevel.WARNING,
+                    f"{self._num_dropped} log messages were not sent to the manager"
+                    " log due to manager overload or network connectivity problems."
+                    " Please see the instance log to read them.",
+                )
                 self._manager.submit_log_message(dropped_msg)
                 self._num_dropped = 0
 

--- a/libmuscle/python/libmuscle/manager/deadlock_detector.py
+++ b/libmuscle/python/libmuscle/manager/deadlock_detector.py
@@ -28,9 +28,12 @@ class DeadlockDetector:
         """list of deadlocked instance cycles. Set by _handle_potential_deadlock."""
 
     def waiting_for_receive(
-            self, instance_id: str, peer_instance_id: str,
-            port_name: str, slot: Optional[int]
-            ) -> None:
+        self,
+        instance_id: str,
+        peer_instance_id: str,
+        port_name: str,
+        slot: Optional[int],
+    ) -> None:
         """Process a WAITING_FOR_RECEIVE message from an instance.
 
         This method can be called from any thread.
@@ -51,9 +54,12 @@ class DeadlockDetector:
             self._check_for_deadlock(instance_id)
 
     def waiting_for_receive_done(
-            self, instance_id: str, peer_instance_id: str,
-            port_name: str, slot: Optional[int]
-            ) -> None:
+        self,
+        instance_id: str,
+        peer_instance_id: str,
+        port_name: str,
+        slot: Optional[int],
+    ) -> None:
         """Process a WAITING_FOR_RECEIVE_DONE message from an instance.
 
         This method can be called from any thread.
@@ -89,8 +95,9 @@ class DeadlockDetector:
             for deadlock_instances in self._detected_deadlocks:
                 if instance_id in deadlock_instances:
                     _logger.fatal(
-                            "Deadlock detected, simulation is aborting!\n%s",
-                            self._format_deadlock(deadlock_instances))
+                        "Deadlock detected, simulation is aborting!\n%s",
+                        self._format_deadlock(deadlock_instances),
+                    )
                     return True
         return False
 
@@ -128,7 +135,7 @@ class DeadlockDetector:
         num_instances = str(len(deadlock_instances))
         lines = [f"The following {num_instances} instances are deadlocked:"]
         for i, instance in enumerate(deadlock_instances):
-            num = str(i+1).rjust(len(num_instances))
+            num = str(i + 1).rjust(len(num_instances))
             peer_instance = self._waiting_instances[instance]
             port, slot = self._waiting_instance_ports[instance]
             slot_txt = "" if slot is None else f"[{slot}]"

--- a/libmuscle/python/libmuscle/manager/hammer.py
+++ b/libmuscle/python/libmuscle/manager/hammer.py
@@ -25,6 +25,7 @@ class Plate:
     program-implemented conduit and therefore final. The other one does the same, but
     the other way around, and the bool referring to the sending endpoint.
     """
+
     def __init__(self) -> None:
         """Create a Plate."""
         self._by_snd: dict[Reference, ConduitIndex] = {}
@@ -39,9 +40,13 @@ class Plate:
             recv_final: True iff the receiver is final (a program port)
         """
         self._by_snd.setdefault(conduit.sender, {})[conduit.receiver] = (
-                conduit, recv_final)
+            conduit,
+            recv_final,
+        )
         self._by_recv.setdefault(conduit.receiver, {})[conduit.sender] = (
-                conduit, snd_final)
+            conduit,
+            snd_final,
+        )
 
     def pop_by_receiver(self, receiver: Reference) -> ConduitIndex:
         """Remove and return all conduits with the given receiver.
@@ -93,7 +98,8 @@ being added to the flattened model.
 
 
 def process_components(
-        nested_config: Configuration, flat_model: Model, node: Node) -> list[Node]:
+    nested_config: Configuration, flat_model: Model, node: Node
+) -> list[Node]:
     """Copy components to the flattened model.
 
     This copies the components in the given model in nested_config to flat_model,
@@ -118,7 +124,8 @@ def process_components(
         cmp_path = parent_path + component.name
         cmp_mult = parent_mult + component.multiplicity
         impl_ref = nested_config.custom_implementations.get(
-                cmp_path, component.implementation)
+            cmp_path, component.implementation
+        )
         if impl_ref is None:
             continue
 
@@ -135,8 +142,8 @@ def process_components(
 
 
 def process_conduits(
-        nested_config: Configuration, flat_model: Model, node: Node, plate: Plate
-        ) -> None:
+    nested_config: Configuration, flat_model: Model, node: Node, plate: Plate
+) -> None:
     """Copy flat conduits to flat model and partial conduits to plate.
 
     This takes the conduits from current node's model, prefixes them with its component
@@ -157,7 +164,8 @@ def process_conduits(
         snd_cmp = conduit.sending_component()
         if snd_cmp != Reference([]):
             snd_impl = nested_config.custom_implementations.get(
-                    parent_path + snd_cmp, model.components[snd_cmp].implementation)
+                parent_path + snd_cmp, model.components[snd_cmp].implementation
+            )
             if snd_impl is None:
                 continue
             snd_is_program = snd_impl not in nested_config.models
@@ -167,7 +175,8 @@ def process_conduits(
         recv_cmp = conduit.receiving_component()
         if recv_cmp != Reference([]):
             recv_impl = nested_config.custom_implementations.get(
-                    parent_path + recv_cmp, model.components[recv_cmp].implementation)
+                parent_path + recv_cmp, model.components[recv_cmp].implementation
+            )
             if recv_impl is None:
                 continue
             recv_is_program = recv_impl not in nested_config.models
@@ -175,9 +184,10 @@ def process_conduits(
             recv_is_program = False
 
         prefixed_conduit = Conduit(
-                str(parent_path + conduit.sender),
-                str(parent_path + conduit.receiver),
-                conduit.filters)
+            str(parent_path + conduit.sender),
+            str(parent_path + conduit.receiver),
+            conduit.filters,
+        )
         if snd_is_program and recv_is_program:
             flat_model.conduits.append(prefixed_conduit)
         else:
@@ -185,8 +195,8 @@ def process_conduits(
 
 
 def glue_partial_conduits(
-        nested_config: Configuration, flat_model: Model, node: Node, plate: Plate
-        ) -> None:
+    nested_config: Configuration, flat_model: Model, node: Node, plate: Plate
+) -> None:
     """Glue together conduits at model ports.
 
     Conduits that do not lead directly from one program-implemented conduit to another
@@ -216,8 +226,10 @@ def glue_partial_conduits(
         for in_cdt, snd_final in incoming_conduits.values():
             for out_cdt, recv_final in outgoing_conduits.values():
                 joined_cdt = Conduit(
-                        str(in_cdt.sender), str(out_cdt.receiver),
-                        in_cdt.filters + out_cdt.filters)
+                    str(in_cdt.sender),
+                    str(out_cdt.receiver),
+                    in_cdt.filters + out_cdt.filters,
+                )
 
                 if snd_final and recv_final:
                     flat_model.conduits.append(joined_cdt)
@@ -226,8 +238,8 @@ def glue_partial_conduits(
 
 
 def flatten(
-        nested_config: Configuration, model: Optional[Reference] = None
-        ) -> Configuration:
+    nested_config: Configuration, model: Optional[Reference] = None
+) -> Configuration:
     """Creates a flat version of the given configuration.
 
     The result will have a single model, without any components that have a model for
@@ -258,8 +270,13 @@ def flatten(
     plate = Plate()
     root_model = config.root_model(model)
     flat_model = Model(
-            str(root_model.name), Ports(), root_model.description,
-            root_model.supported_settings, [], [])
+        str(root_model.name),
+        Ports(),
+        root_model.description,
+        root_model.supported_settings,
+        [],
+        [],
+    )
 
     queue: list[Node] = [(root_model, Reference([]), [])]
     while queue:

--- a/libmuscle/python/libmuscle/manager/instance_manager.py
+++ b/libmuscle/python/libmuscle/manager/instance_manager.py
@@ -34,6 +34,7 @@ class LogHandlingThread(Thread):
     This gets log records from a queue and sends them to the logging
     system.
     """
+
     def __init__(self, queue: Queue) -> None:
         """Creates a LogHandlingThread.
 
@@ -65,9 +66,13 @@ _ResultType = Union[Process, CrashedResult]
 
 class InstanceManager:
     """Instantiates and manages running instances"""
+
     def __init__(
-            self, configuration: Configuration, run_dir: RunDir,
-            instance_registry: InstanceRegistry) -> None:
+        self,
+        configuration: Configuration,
+        run_dir: RunDir,
+        instance_registry: InstanceRegistry,
+    ) -> None:
         """Create an InstanceManager.
 
         Args:
@@ -85,8 +90,12 @@ class InstanceManager:
         self._log_records_in: Queue[logging.LogRecord] = Queue()
 
         self._instantiator = NativeInstantiator(
-                self._resources_in, self._requests_out, self._results_in,
-                self._log_records_in, self._run_dir.path)
+            self._resources_in,
+            self._requests_out,
+            self._results_in,
+            self._log_records_in,
+            self._run_dir.path,
+        )
         self._instantiator.start()
 
         self._log_handler = LogHandlingThread(self._log_records_in)
@@ -95,11 +104,12 @@ class InstanceManager:
         self._allocations: Optional[dict[Reference, ResourceAssignment]] = None
 
         resources = self._resources_in.get()
-        _logger.debug(f'Got resources {resources}')
+        _logger.debug(f"Got resources {resources}")
         if isinstance(resources, CrashedResult):
             msg = (
-                'Instantiator crashed. This should not happen, please file a bug'
-                ' report.')
+                "Instantiator crashed. This should not happen, please file a bug"
+                " report."
+            )
             _logger.error(msg)
             raise RuntimeError(msg) from resources.exception
 
@@ -121,36 +131,44 @@ class InstanceManager:
         """Starts all the instances of the model."""
         self._allocations = self._planner.allocate_all(self._configuration)
         for instance, resources in self._allocations.items():
-            _logger.info(f'Planned {instance} on {resources.as_resources()}')
+            _logger.info(f"Planned {instance} on {resources.as_resources()}")
 
         model = self._configuration.root_model()
         for instance, resources in self._allocations.items():
             component = model.components[instance.without_trailing_ints()]
             if component.implementation is None:
                 _logger.warning(
-                        f'No implementation specified for {component.name}'
-                        ', not starting it.')
+                    f"No implementation specified for {component.name}"
+                    ", not starting it."
+                )
                 continue
             program = self._configuration.programs[component.implementation]
             if program.execution_model is ExecutionModel.MANUAL:
                 _logger.info(
-                        f'Instance {instance} has execution_model MANUAL'
-                        ' - please start it manually.')
+                    f"Instance {instance} has execution_model MANUAL"
+                    " - please start it manually."
+                )
                 continue
-            program.env['MUSCLE_MANAGER'] = self._manager_location
+            program.env["MUSCLE_MANAGER"] = self._manager_location
             idir = self._run_dir.add_instance_dir(instance)
-            workdir = idir / 'workdir'
+            workdir = idir / "workdir"
             workdir.mkdir()
-            stdout_path = idir / 'stdout.txt'
-            stderr_path = idir / 'stderr.txt'
+            stdout_path = idir / "stdout.txt"
+            stderr_path = idir / "stderr.txt"
 
             res_req = self._configuration.get_resources(model.name + component.name)
 
             request = InstantiationRequest(
-                    instance, program,
-                    res_req,
-                    resources, idir, workdir, stdout_path, stderr_path)
-            _logger.info(f'Instantiating {instance}')
+                instance,
+                program,
+                res_req,
+                resources,
+                idir,
+                workdir,
+                stdout_path,
+                stderr_path,
+            )
+            _logger.info(f"Instantiating {instance}")
             self._requests_out.put(request)
             self._num_running += 1
 
@@ -165,7 +183,8 @@ class InstanceManager:
         """
         if self._allocations is None:
             raise RuntimeError(
-                    'Tried to get resources but we are running without --start-all')
+                "Tried to get resources but we are running without --start-all"
+            )
 
         return self._allocations
 
@@ -190,8 +209,9 @@ class InstanceManager:
                     _logger.error(str(result.exception))
                 else:
                     _logger.error(
-                        'Instantiator crashed. This should not happen, please file'
-                        ' a bug report.')
+                        "Instantiator crashed. This should not happen, please file"
+                        " a bug report."
+                    )
                 return False
 
             results.append(result)
@@ -209,93 +229,93 @@ class InstanceManager:
             if result.status == ProcessStatus.CANCELED:
                 if result.exit_code == 0:
                     _logger.info(
-                            f'Instance {result.instance} was not started'
-                            f' because of an error elsewhere')
+                        f"Instance {result.instance} was not started"
+                        f" because of an error elsewhere"
+                    )
                 else:
                     _logger.info(
-                            f'Instance {result.instance} was shut down by'
-                            f' MUSCLE3 because an error occurred elsewhere')
+                        f"Instance {result.instance} was shut down by"
+                        f" MUSCLE3 because an error occurred elsewhere"
+                    )
                 # Ensure we don't see this as a succesful run when shutdown() is called
                 # by another thread:
                 all_seemingly_okay = False
             else:
-                stderr_file = (
-                        self._run_dir.instance_dir(result.instance) /
-                        'stderr.txt')
+                stderr_file = self._run_dir.instance_dir(result.instance) / "stderr.txt"
                 if result.exit_code == 0:
                     if self._instance_registry.did_register(result.instance):
                         _logger.info(
-                                f'Instance {result.instance} finished with'
-                                ' exit code 0')
+                            f"Instance {result.instance} finished with exit code 0"
+                        )
                     else:
                         _logger.error(
-                                f'Instance {result.instance} quit with no error'
-                                ' (exit code 0), but it never registered with the'
-                                ' manager. Maybe it never created an Instance'
-                                ' object?')
+                            f"Instance {result.instance} quit with no error"
+                            " (exit code 0), but it never registered with the"
+                            " manager. Maybe it never created an Instance"
+                            " object?"
+                        )
                         crashes.append((result, stderr_file))
                 else:
                     try:
                         with stderr_file.open() as f:
-                            peer_crash = any(['peer crash?' in line for line in f])
+                            peer_crash = any(["peer crash?" in line for line in f])
                     except FileNotFoundError:
                         peer_crash = False
 
                     if peer_crash:
                         _logger.warning(
-                                f'Instance {result.instance} crashed, likely because'
-                                f' an error occurred elsewhere.')
+                            f"Instance {result.instance} crashed, likely because"
+                            f" an error occurred elsewhere."
+                        )
                         indirect_crashes.append((result, stderr_file))
                     else:
                         _logger.error(
-                                f'Instance {result.instance} quit with exit code'
-                                f' {result.exit_code}')
+                            f"Instance {result.instance} quit with exit code"
+                            f" {result.exit_code}"
+                        )
                         crashes.append((result, stderr_file))
 
-            _logger.debug(f'Status: {result.status}')
-            _logger.debug(f'Exit code: {result.exit_code}')
-            _logger.debug(f'Error msg: {result.error_msg}')
+            _logger.debug(f"Status: {result.status}")
+            _logger.debug(f"Exit code: {result.exit_code}")
+            _logger.debug(f"Error msg: {result.error_msg}")
 
         # Show errors from crashed components
         if crashes:
             for result, stderr_file in crashes:
+                _logger.error(f"The last error output of {result.instance} was:")
+                _logger.error("\n" + indent(last_lines(stderr_file, 20), "    "))
                 _logger.error(
-                        f'The last error output of {result.instance} was:')
-                _logger.error(
-                        '\n' + indent(last_lines(stderr_file, 20), '    '))
-                _logger.error(
-                        'More output may be found in'
-                        f' {self._run_dir.instance_dir(result.instance)}\n'
-                        )
+                    "More output may be found in"
+                    f" {self._run_dir.instance_dir(result.instance)}\n"
+                )
         elif indirect_crashes:
             # Possibly a component exited without error, but prematurely. If this
             # caused ancillary crashes due to dropped connections, then the logs
             # of those will give a hint as to what the problem may be, so print
             # those instead.
             _logger.error(
-                    'At this point, one or more instances crashed because they'
-                    ' lost their connection to another instance, but no other'
-                    ' crashing instance was found that could have caused this.')
+                "At this point, one or more instances crashed because they"
+                " lost their connection to another instance, but no other"
+                " crashing instance was found that could have caused this."
+            )
             _logger.error(
-                    'This means that either another instance quit before it was'
-                    ' supposed to, but with exit code 0, or there was an actual'
-                    ' network problem that caused the connection to drop.')
-            _logger.error(
-                    'Here is the output of the instances that lost connection:')
+                "This means that either another instance quit before it was"
+                " supposed to, but with exit code 0, or there was an actual"
+                " network problem that caused the connection to drop."
+            )
+            _logger.error("Here is the output of the instances that lost connection:")
             for result, stderr_file in indirect_crashes:
+                _logger.error(f"The last error output of {result.instance} was:")
+                _logger.error("\n" + indent(last_lines(stderr_file, 20), "    "))
                 _logger.error(
-                        f'The last error output of {result.instance} was:')
-                _logger.error(
-                        '\n' + indent(last_lines(stderr_file, 20), '    '))
-                _logger.error(
-                        'More output may be found in'
-                        f' {self._run_dir.instance_dir(result.instance)}\n'
-                        )
+                    "More output may be found in"
+                    f" {self._run_dir.instance_dir(result.instance)}\n"
+                )
         elif not all_seemingly_okay:
             # shutdown() was called by another thread (e.g. the DeadlockDetector):
-            _logger.error('The simulation was aborted.')
+            _logger.error("The simulation was aborted.")
         else:
-            _logger.info('The simulation finished without error.')
+            _logger.info("The simulation finished without error.")
 
         return all_seemingly_okay
 
@@ -305,7 +325,7 @@ class InstanceManager:
         This will wait for any processes still running before shutting
         down and returning.
         """
-        _logger.debug('Shutting down instance manager')
+        _logger.debug("Shutting down instance manager")
         self._requests_out.put(CancelAllRequest())
         self._requests_out.put(ShutdownRequest())
         self._instantiator.join()
@@ -313,9 +333,12 @@ class InstanceManager:
         self._log_handler.join()
         # Close multiprocessing.Queues and ensure their feeder threads exit
         queues: list[Queue] = [
-                self._resources_in, self._requests_out,
-                self._results_in, self._log_records_in]
+            self._resources_in,
+            self._requests_out,
+            self._results_in,
+            self._log_records_in,
+        ]
         for queue in queues:
             queue.close()
             queue.join_thread()
-        _logger.debug('Instance manager shut down cleanly')
+        _logger.debug("Instance manager shut down cleanly")

--- a/libmuscle/python/libmuscle/manager/instance_registry.py
+++ b/libmuscle/python/libmuscle/manager/instance_registry.py
@@ -13,16 +13,16 @@ class InstanceRegistry:
     The InstanceRegistry is a simple in-memory database that stores
     information about running instances of simulation components.
     """
+
     def __init__(self) -> None:
         """Construct an empty InstanceRegistry"""
-        self._deregistered_one = Condition()    # doubles as lock
+        self._deregistered_one = Condition()  # doubles as lock
         self._locations: dict[Reference, list[str]] = {}
         self._ports: dict[Reference, list[Port]] = {}
         self._seen: set[Reference] = set()
         self._startup = True
 
-    def add(self, name: Reference, locations: list[str], ports: list[Port]
-            ) -> None:
+    def add(self, name: Reference, locations: list[str], ports: list[Port]) -> None:
         """Add an instance to the registry.
 
         Args:
@@ -36,7 +36,7 @@ class InstanceRegistry:
         """
         with self._deregistered_one:
             if name in self._locations:
-                raise AlreadyRegistered(f'Instance {name} tried to register twice')
+                raise AlreadyRegistered(f"Instance {name} tried to register twice")
 
             self._locations[name] = locations
             self._ports[name] = ports

--- a/libmuscle/python/libmuscle/manager/instantiator.py
+++ b/libmuscle/python/libmuscle/manager/instantiator.py
@@ -13,6 +13,7 @@ from libmuscle.planner.planner import ResourceAssignment
 
 class ProcessStatus(enum.Enum):
     """Status of a process (instance)."""
+
     STARTED = 0
     RUNNING = 1
     SUCCESS = 2
@@ -26,8 +27,10 @@ class ProcessStatus(enum.Enum):
         run.
         """
         return self in (
-                ProcessStatus.SUCCESS, ProcessStatus.ERROR,
-                ProcessStatus.CANCELED)
+            ProcessStatus.SUCCESS,
+            ProcessStatus.ERROR,
+            ProcessStatus.CANCELED,
+        )
 
 
 class Process:
@@ -40,6 +43,7 @@ class Process:
         exit_code: Exit code, if status is ERROR
         error_msg: Error message, if status is ERROR
     """
+
     def __init__(self, instance: Reference, resources: ResourceAssignment) -> None:
         """Create a Process object.
 
@@ -55,6 +59,7 @@ class Process:
 
 class InstantiatorRequest:
     """Base class for requests to an instantiator."""
+
     pass
 
 
@@ -63,6 +68,7 @@ class ShutdownRequest(InstantiatorRequest):
 
     The process will stop once all running processes are done.
     """
+
     pass
 
 
@@ -79,11 +85,18 @@ class InstantiationRequest(InstantiatorRequest):
         stdout_path: Path of file to redirect stdout to
         stderr_path: Path of file to redirect stderr to
     """
+
     def __init__(
-            self, instance: Reference, program: Program,
-            res_req: ResourceRequirements, resources: ResourceAssignment,
-            instance_dir: Path, work_dir: Path, stdout_path: Path, stderr_path: Path
-            ) -> None:
+        self,
+        instance: Reference,
+        program: Program,
+        res_req: ResourceRequirements,
+        resources: ResourceAssignment,
+        instance_dir: Path,
+        work_dir: Path,
+        stdout_path: Path,
+        stderr_path: Path,
+    ) -> None:
         """Create an InstantiationRequest.
 
         Args:
@@ -108,17 +121,20 @@ class InstantiationRequest(InstantiatorRequest):
 
 class CancelAllRequest(InstantiatorRequest):
     """Requests stopping all running processes."""
+
     pass
 
 
 class CrashedResult:
     """Signals that the instantiator process crashed."""
+
     def __init__(self, exception: Optional[BaseException] = None) -> None:
         self.exception = exception
 
 
 class QueueingLogHandler(logging.Handler):
     """A logging Handler that enqueues records."""
+
     def __init__(self, queue: mp.Queue) -> None:
         """Create a QueueingLogHandler.
 
@@ -135,8 +151,7 @@ class QueueingLogHandler(logging.Handler):
             record: A log record to enqueue.
         """
         if record.exc_info:
-            record.msg += '\n' + ''.join(
-                    traceback.format_exception(*record.exc_info))
+            record.msg += "\n" + "".join(traceback.format_exception(*record.exc_info))
             record.exc_info = None
 
         self._queue.put(record)
@@ -158,8 +173,8 @@ def reconfigure_logging(queue: mp.Queue) -> None:
 
 
 def create_instance_env(
-        instance: Reference, base_env: BaseEnv, overlay: dict[str, str]
-        ) -> dict[str, str]:
+    instance: Reference, base_env: BaseEnv, overlay: dict[str, str]
+) -> dict[str, str]:
     """Creates an environment for an instance.
 
     This takes the current (manager) environment variables and makes
@@ -171,7 +186,7 @@ def create_instance_env(
     """
     if base_env == BaseEnv.LOGIN:
         env = dict()
-        for var in ('HOME', 'LOGNAME', 'SHELL', 'TERM', 'USER'):
+        for var in ("HOME", "LOGNAME", "SHELL", "TERM", "USER"):
             if var in os.environ:
                 env[var] = os.environ[var]
     else:
@@ -188,31 +203,31 @@ def create_instance_env(
             # of the programs needs a clean shell, then the user will have to export
             # it manually between activating the virtualenv and starting the manager
             # and things will work.
-            vep = env.get('VIRTUAL_ENV_PROMPT')
+            vep = env.get("VIRTUAL_ENV_PROMPT")
             if vep is not None:
-                if 'PS1' in env:
-                    if env['PS1'].startswith(vep):
-                        env['PS1'] = env['PS1'][len(vep):]
-                del env['VIRTUAL_ENV_PROMPT']
+                if "PS1" in env:
+                    if env["PS1"].startswith(vep):
+                        env["PS1"] = env["PS1"][len(vep) :]
+                del env["VIRTUAL_ENV_PROMPT"]
 
-            ovp = env.get('_OLD_VIRTUAL_PYTHONHOME')
+            ovp = env.get("_OLD_VIRTUAL_PYTHONHOME")
             if ovp is not None:
-                env['PYTHONHOME'] = ovp
-                del env['_OLD_VIRTUAL_PYTHONHOME']
+                env["PYTHONHOME"] = ovp
+                del env["_OLD_VIRTUAL_PYTHONHOME"]
 
-            venv = env.get('VIRTUAL_ENV')
+            venv = env.get("VIRTUAL_ENV")
             if venv is not None:
-                path = env.get('PATH')
+                path = env.get("PATH")
                 if path is not None:
-                    paths = [p for p in path.split(':') if p != venv + '/bin']
-                    env['PATH'] = ':'.join(paths)
+                    paths = [p for p in path.split(":") if p != venv + "/bin"]
+                    env["PATH"] = ":".join(paths)
 
-                del env['VIRTUAL_ENV']
+                del env["VIRTUAL_ENV"]
 
-    env['MUSCLE_INSTANCE'] = str(instance)
+    env["MUSCLE_INSTANCE"] = str(instance)
 
     for key, value in overlay.items():
-        if key.startswith('+'):
+        if key.startswith("+"):
             if key[1:] in env:
                 env[key[1:]] += value
             else:

--- a/libmuscle/python/libmuscle/manager/logger.py
+++ b/libmuscle/python/libmuscle/manager/logger.py
@@ -8,6 +8,7 @@ from libmuscle.util import extract_log_file_location
 
 class Formatter(logging.Formatter):
     """A custom formatter that can format remote messages."""
+
     def usesTime(self) -> bool:
         """Tells the formatter to make asctime available."""
         return True
@@ -26,13 +27,15 @@ class Formatter(logging.Formatter):
             The formatted message.
         """
         # disabled the linter here; this follows the Python logging docs
-        if 'instance' in record.__dict__:
+        if "instance" in record.__dict__:
             return (
-                    '%(instance)-14s %(iasctime)-15s %(levelname)-7s'   # noqa: UP031
-                    ' %(name)s: %(message)s' % record.__dict__)         # noqa: UP031
+                "%(instance)-14s %(iasctime)-15s %(levelname)-7s"  # noqa: UP031
+                " %(name)s: %(message)s" % record.__dict__
+            )  # noqa: UP031
         return (
-                'muscle_manager %(asctime)s %(levelname)-7s %(name)s:'  # noqa: UP031
-                ' %(message)s' % record.__dict__)
+            "muscle_manager %(asctime)s %(levelname)-7s %(name)s:"  # noqa: UP031
+            " %(message)s" % record.__dict__
+        )
 
 
 class Logger:
@@ -43,9 +46,10 @@ class Logger:
     instances to write to it as well. Log levels are also set here.
 
     """
+
     def __init__(
-            self, log_dir: Optional[Path] = None,
-            log_level: Optional[str] = None) -> None:
+        self, log_dir: Optional[Path] = None, log_level: Optional[str] = None
+    ) -> None:
         """Create a Logger.
 
         Log levels may be any of the Python predefined log levels, i.e.
@@ -59,10 +63,10 @@ class Logger:
 
         if log_dir is None:
             log_dir = Path.cwd()
-        logfile = extract_log_file_location('muscle3_manager.log')
+        logfile = extract_log_file_location("muscle3_manager.log")
         if logfile is None:
-            logfile = log_dir / 'muscle3_manager.log'
-        self._local_handler = logging.FileHandler(str(logfile), mode='w')
+            logfile = log_dir / "muscle3_manager.log"
+        self._local_handler = logging.FileHandler(str(logfile), mode="w")
         self._local_handler.setFormatter(Formatter())
 
         # Find and remove default handler to disable automatic console output
@@ -70,8 +74,8 @@ class Logger:
         # seems reliable, and doesn't mess up pytest's caplog mechanism while
         # it also doesn't introduce a runtime dependency on pytest.
         logging.getLogger().handlers = [
-                h for h in logging.getLogger().handlers
-                if 'stderr' not in str(h)]
+            h for h in logging.getLogger().handlers if "stderr" not in str(h)
+        ]
 
         # add our own
         logging.getLogger().addHandler(self._local_handler)
@@ -82,26 +86,23 @@ class Logger:
 
         # set Manager log level
         if log_level is None:
-            log_level = 'INFO'
+            log_level = "INFO"
         else:
             log_level = log_level.upper()
 
-        logging.getLogger('libmuscle').setLevel(log_level)
+        logging.getLogger("libmuscle").setLevel(log_level)
 
         # YAtiML should be pretty reliable, and if there is an issue
         # then we can easily load the problem file in Python by hand
         # using the yMMSL library and set the log level there.
-        logging.getLogger('yatiml').setLevel(logging.WARNING)
+        logging.getLogger("yatiml").setLevel(logging.WARNING)
 
     def close(self) -> None:
         logging.getLogger().removeHandler(self._local_handler)
 
     def log_message(
-            self,
-            instance_id: str,
-            timestamp: Timestamp,
-            level: LogLevel,
-            text: str) -> None:
+        self, instance_id: str, timestamp: Timestamp, level: LogLevel, text: str
+    ) -> None:
         """Log a message.
 
         Args:
@@ -114,11 +115,10 @@ class Logger:
         """
         logger = logging.getLogger(instance_id)
         logger.log(
-                level.as_python_level(),
-                text,
-                extra={
-                    'instance': instance_id,
-                    'iasctime': timestamp.to_asctime()})
+            level.as_python_level(),
+            text,
+            extra={"instance": instance_id, "iasctime": timestamp.to_asctime()},
+        )
 
 
 def last_lines(file: Path, count: int) -> str:
@@ -137,18 +137,18 @@ def last_lines(file: Path, count: int) -> str:
         newlines.
     """
     if not file.exists():
-        return ''
+        return ""
 
     file_size = file.stat().st_size
     start_point = max(file_size - 10000, 0)
 
     lines: list[str] = []
-    with file.open('r') as f:
+    with file.open("r") as f:
         f.seek(start_point)
-        f.readline()    # skip partial line
+        f.readline()  # skip partial line
         line = f.readline()
         while line:
             lines.append(line)
             line = f.readline()
 
-    return '\n' + ''.join(lines[-count:])
+    return "\n" + "".join(lines[-count:])

--- a/libmuscle/python/libmuscle/manager/manager.py
+++ b/libmuscle/python/libmuscle/manager/manager.py
@@ -27,10 +27,13 @@ class Manager:
     This creates and manages instances and connects them together
     according to the simulation configuration.
     """
+
     def __init__(
-            self, configuration: Configuration,
-            run_dir: Optional[RunDir] = None, log_level: Optional[str] = None
-            ) -> None:
+        self,
+        configuration: Configuration,
+        run_dir: Optional[RunDir] = None,
+        log_level: Optional[str] = None,
+    ) -> None:
         """Create a Manager.
 
         This creates the manager and the associated server, but does
@@ -58,39 +61,49 @@ class Manager:
         else:
             snapshot_dir = Path.cwd()
             if self._configuration.checkpoints:
-                _logger.warning('Checkpoints are configured but no run'
-                                ' directory is provided. Snapshots will be'
-                                ' stored in the current working directory.')
+                _logger.warning(
+                    "Checkpoints are configured but no run"
+                    " directory is provided. Snapshots will be"
+                    " stored in the current working directory."
+                )
 
         if self._run_dir:
-            save_ymmsl(
-                    self._configuration,
-                    self._run_dir.path / 'configuration.ymmsl')
+            save_ymmsl(self._configuration, self._run_dir.path / "configuration.ymmsl")
 
-        self._profile_store.store_instances([
-            instance_name
-            for c in self._configuration.root_model().components.values()
-            for instance_name in c.instances()])
+        self._profile_store.store_instances(
+            [
+                instance_name
+                for c in self._configuration.root_model().components.values()
+                for instance_name in c.instances()
+            ]
+        )
 
         self._instance_manager: Optional[InstanceManager] = None
         if self._run_dir is not None:
             self._instance_manager = InstanceManager(
-                    configuration, self._run_dir, self._instance_registry)
+                configuration, self._run_dir, self._instance_registry
+            )
 
         # SnapshotRegistry creates a worker thread, must be created after
         # instance_manager which forks the process
         self._snapshot_registry = SnapshotRegistry(
-                configuration, snapshot_dir, self._topology_store)
+            configuration, snapshot_dir, self._topology_store
+        )
         self._snapshot_registry.start()
 
         self._server = MMPServer(
-                self._logger, self._profile_store, self._configuration,
-                self._instance_registry, self._topology_store,
-                self._snapshot_registry, self._deadlock_detector, run_dir)
+            self._logger,
+            self._profile_store,
+            self._configuration,
+            self._instance_registry,
+            self._topology_store,
+            self._snapshot_registry,
+            self._deadlock_detector,
+            run_dir,
+        )
 
         if self._instance_manager:
-            self._instance_manager.set_manager_location(
-                    self.get_server_location())
+            self._instance_manager.set_manager_location(self.get_server_location())
 
     def get_server_location(self) -> str:
         """Returns the network location of the server."""
@@ -99,22 +112,22 @@ class Manager:
     def start_instances(self) -> None:
         """Starts all required component instances."""
         if self._run_dir is None:
-            message = 'No run dir specified'
+            message = "No run dir specified"
             _logger.error(message)
             raise RuntimeError(message)
         if not self._instance_manager:
             message = (
-                    'For MUSCLE3 to be able to start instances, the'
-                    ' configuration must contain a model, implementations,'
-                    ' and resources. Please make sure they are all there.')
+                "For MUSCLE3 to be able to start instances, the"
+                " configuration must contain a model, implementations,"
+                " and resources. Please make sure they are all there."
+            )
             _logger.error(message)
             raise RuntimeError(message)
         try:
             self._instance_manager.start_all()
-            self._profile_store.store_resources(
-                    self._instance_manager.get_resources())
-        except:     # noqa
-            _logger.error('An error occurred while starting the components:')
+            self._profile_store.store_resources(self._instance_manager.get_resources())
+        except:  # noqa
+            _logger.error("An error occurred while starting the components:")
             for line in traceback.format_exception(*sys.exc_info()):
                 _logger.error(line)
             self._instance_manager.shutdown()

--- a/libmuscle/python/libmuscle/manager/mmp_server.py
+++ b/libmuscle/python/libmuscle/manager/mmp_server.py
@@ -55,21 +55,19 @@ def encode_conduit(conduit: Conduit) -> list[str]:
 
 def encode_ports(ports: Ports) -> list[list[str]]:
     """Convert a Ports to a MsgPack-compatible value."""
-    return [
-        [str(port_name), ports[port_name].operator.name]
-        for port_name in ports
-    ]
+    return [[str(port_name), ports[port_name].operator.name] for port_name in ports]
 
 
 def encode_checkpoint_rule(rule: CheckpointRule) -> dict[str, Any]:
     """Convert a CheckpointRule to a MsgPack-compatible value."""
     if isinstance(rule, CheckpointAtRule):
-        return {'at': list(map(float, rule.at))}
+        return {"at": list(map(float, rule.at))}
     if isinstance(rule, CheckpointRangeRule):
         return {
-            'start': None if rule.start is None else float(rule.start),
-            'stop': None if rule.stop is None else float(rule.stop),
-            'every': float(rule.every)}
+            "start": None if rule.start is None else float(rule.start),
+            "stop": None if rule.stop is None else float(rule.stop),
+            "every": float(rule.every),
+        }
     raise TypeError(f"Unknown checkpoint rule type: {type(rule)}.")
 
 
@@ -77,26 +75,27 @@ def encode_checkpoints(checkpoints: Checkpoints) -> dict[str, Any]:
     """Convert a Checkpoins to a MsgPack-compatible value."""
     return {
         "at_end": checkpoints.at_end,
-        "wallclock_time":
-            list(map(encode_checkpoint_rule, checkpoints.wallclock_time)),
-        "simulation_time":
-            list(map(encode_checkpoint_rule, checkpoints.simulation_time)),
+        "wallclock_time": list(map(encode_checkpoint_rule, checkpoints.wallclock_time)),
+        "simulation_time": list(
+            map(encode_checkpoint_rule, checkpoints.simulation_time)
+        ),
     }
 
 
 class MMPRequestHandler(RequestHandler):
     """Handles Manager requests."""
+
     def __init__(
-            self,
-            logger: Logger,
-            profile_store: ProfileStore,
-            configuration: Configuration,
-            instance_registry: InstanceRegistry,
-            topology_store: TopologyStore,
-            snapshot_registry: SnapshotRegistry,
-            deadlock_detector: DeadlockDetector,
-            run_dir: Optional[RunDir]
-            ) -> None:
+        self,
+        logger: Logger,
+        profile_store: ProfileStore,
+        configuration: Configuration,
+        instance_registry: InstanceRegistry,
+        topology_store: TopologyStore,
+        snapshot_registry: SnapshotRegistry,
+        deadlock_detector: DeadlockDetector,
+        run_dir: Optional[RunDir],
+    ) -> None:
         """Create an MMPRequestHandler.
 
         Args:
@@ -161,8 +160,12 @@ class MMPRequestHandler(RequestHandler):
         self._profile_store.close()
 
     def _register_instance(
-            self, instance_id: str, locations: list[str],
-            ports: list[list[str]], version: str = '') -> Any:
+        self,
+        instance_id: str,
+        locations: list[str],
+        ports: list[list[str]],
+        version: str = "",
+    ) -> Any:
         """Handle a register instance request.
 
         Args:
@@ -180,25 +183,27 @@ class MMPRequestHandler(RequestHandler):
         """
         if version != libmuscle.__version__:
             return [
-                    ResponseType.ERROR.value,
-                    f'Instance libmuscle version ({version}) does not match'
-                    f' manager libmuscle version ({libmuscle.__version__}).'
-                    ' Please ensure that the instance and the manager use the'
-                    ' same version of libmuscle.']
+                ResponseType.ERROR.value,
+                f"Instance libmuscle version ({version}) does not match"
+                f" manager libmuscle version ({libmuscle.__version__})."
+                " Please ensure that the instance and the manager use the"
+                " same version of libmuscle.",
+            ]
 
         port_objs = [decode_port(p) for p in ports]
         instance = Reference(instance_id)
         try:
             self._instance_registry.add(instance, locations, port_objs)
 
-            _logger.info(f'Registered instance {instance_id}')
+            _logger.info(f"Registered instance {instance_id}")
             return [ResponseType.SUCCESS.value]
         except AlreadyRegistered:
             return [
-                    ResponseType.ERROR.value,
-                    f'An instance with name {instance_id} was already'
-                    ' registered. Did you start a non-MPI component using'
-                    ' mpirun?']
+                ResponseType.ERROR.value,
+                f"An instance with name {instance_id} was already"
+                " registered. Did you start a non-MPI component using"
+                " mpirun?",
+            ]
 
     def _get_peers(self, instance_id: str) -> Any:
         """Handle a get peers request.
@@ -231,7 +236,7 @@ class MMPRequestHandler(RequestHandler):
         instance = Reference(instance_id)
         component = instance.without_trailing_ints()
         if not self._topology_store.has_component(component):
-            return [ResponseType.ERROR.value, f'Unknown component {component}']
+            return [ResponseType.ERROR.value, f"Unknown component {component}"]
 
         conduits = self._topology_store.get_conduits(component)
         mmp_conduits = [encode_conduit(c) for c in conduits]
@@ -245,17 +250,19 @@ class MMPRequestHandler(RequestHandler):
         try:
             peers = self._topology_store.get_peer_instances(instance)
             instance_locations = {
-                    str(peer): self._instance_registry.get_locations(peer)
-                    for peer in peers}
+                str(peer): self._instance_registry.get_locations(peer) for peer in peers
+            }
         except KeyError as e:
-            return [
-                    ResponseType.PENDING.value,
-                    f'Waiting for component {e.args[0]}']
+            return [ResponseType.PENDING.value, f"Waiting for component {e.args[0]}"]
 
-        _logger.debug(f'Sent peers to {instance_id}')
+        _logger.debug(f"Sent peers to {instance_id}")
         return [
-                ResponseType.SUCCESS.value,
-                mmp_conduits, mmp_dimensions, instance_locations, mmp_ports]
+            ResponseType.SUCCESS.value,
+            mmp_conduits,
+            mmp_dimensions,
+            instance_locations,
+            mmp_ports,
+        ]
 
     def _deregister_instance(self, instance_id: str) -> Any:
         """Handle a deregister instance request.
@@ -275,12 +282,13 @@ class MMPRequestHandler(RequestHandler):
         """
         try:
             self._instance_registry.remove(Reference(instance_id))
-            _logger.info(f'Deregistered instance {instance_id}')
+            _logger.info(f"Deregistered instance {instance_id}")
             return [ResponseType.SUCCESS.value]
         except ValueError:
             return [
-                    ResponseType.ERROR.value,
-                    f'No instance with name {instance_id} was registered']
+                ResponseType.ERROR.value,
+                f"No instance with name {instance_id} was registered",
+            ]
 
     def _get_settings(self) -> Any:
         """Handle a get settings request.
@@ -292,12 +300,13 @@ class MMPRequestHandler(RequestHandler):
             settings (dict[str, SettingValue]): The global settings
         """
         return [
-                ResponseType.SUCCESS.value,
-                self._configuration.settings.as_ordered_dict()]
+            ResponseType.SUCCESS.value,
+            self._configuration.settings.as_ordered_dict(),
+        ]
 
     def _submit_log_message(
-            self, instance_id: str, timestamp: float, level: int, text: str
-            ) -> Any:
+        self, instance_id: str, timestamp: float, level: int, text: str
+    ) -> Any:
         """Handle a submit log message request.
 
         Args:
@@ -312,11 +321,11 @@ class MMPRequestHandler(RequestHandler):
             status (ResponseType): SUCCESS
         """
         self._logger.log_message(
-                instance_id, Timestamp(timestamp), LogLevel(level), text)
+            instance_id, Timestamp(timestamp), LogLevel(level), text
+        )
         return [ResponseType.SUCCESS.value]
 
-    def _submit_profile_events(
-            self, instance_id: str, events: list[list[Any]]) -> Any:
+    def _submit_profile_events(self, instance_id: str, events: list[list[Any]]) -> Any:
         """Handle a submit profile events request.
 
         Args:
@@ -329,18 +338,24 @@ class MMPRequestHandler(RequestHandler):
             status (ResponseType): SUCCESS
         """
         ev = [
-                ProfileEvent(
-                    ProfileEventType(e[0]), ProfileTimestamp(e[1]),
-                    ProfileTimestamp(e[2]),
-                    Port(e[3][0], Operator[e[3][1]]) if e[3] else None,
-                    e[4], e[5], e[6], e[7], e[8])
-                for e in events]
+            ProfileEvent(
+                ProfileEventType(e[0]),
+                ProfileTimestamp(e[1]),
+                ProfileTimestamp(e[2]),
+                Port(e[3][0], Operator[e[3][1]]) if e[3] else None,
+                e[4],
+                e[5],
+                e[6],
+                e[7],
+                e[8],
+            )
+            for e in events
+        ]
 
         self._profile_store.add_events(Reference(instance_id), ev)
         return [ResponseType.SUCCESS.value]
 
-    def _submit_snapshot(
-            self, instance_id: str, snapshot: dict[str, Any]) -> Any:
+    def _submit_snapshot(self, instance_id: str, snapshot: dict[str, Any]) -> Any:
         """Handle a submit snapshot request.
 
         Returns:
@@ -379,15 +394,21 @@ class MMPRequestHandler(RequestHandler):
         if self._run_dir is not None:
             snapshot_directory = str(self._run_dir.snapshot_dir(instance))
 
-        return [ResponseType.SUCCESS.value,
-                time.monotonic() - self._reference_time,
-                encode_checkpoints(self._configuration.checkpoints),
-                resume,
-                snapshot_directory]
+        return [
+            ResponseType.SUCCESS.value,
+            time.monotonic() - self._reference_time,
+            encode_checkpoints(self._configuration.checkpoints),
+            resume,
+            snapshot_directory,
+        ]
 
     def _waiting_for_receive(
-            self, instance_id: str, peer_instance_id: str,
-            port_name: str, slot: Optional[int]) -> Any:
+        self,
+        instance_id: str,
+        peer_instance_id: str,
+        port_name: str,
+        slot: Optional[int],
+    ) -> Any:
         """Indicate that the instance is waiting to receive a message.
 
         Args:
@@ -396,12 +417,17 @@ class MMPRequestHandler(RequestHandler):
             slot: Slot that the instance is waiting for
         """
         self._deadlock_detector.waiting_for_receive(
-                instance_id, peer_instance_id, port_name, slot)
+            instance_id, peer_instance_id, port_name, slot
+        )
         return [ResponseType.SUCCESS.value]
 
     def _waiting_for_receive_done(
-            self, instance_id: str, peer_instance_id: str,
-            port_name: str, slot: Optional[int]) -> Any:
+        self,
+        instance_id: str,
+        peer_instance_id: str,
+        port_name: str,
+        slot: Optional[int],
+    ) -> Any:
         """Indicate that the instance is done waiting to receive a message.
 
         Args:
@@ -410,12 +436,12 @@ class MMPRequestHandler(RequestHandler):
             slot: Slot that the instance is waiting for
         """
         self._deadlock_detector.waiting_for_receive_done(
-                instance_id, peer_instance_id, port_name, slot)
+            instance_id, peer_instance_id, port_name, slot
+        )
         return [ResponseType.SUCCESS.value]
 
     def _is_deadlocked(self, instance_id: str) -> Any:
-        """Check if the provided instance is part of a detected deadlock.
-        """
+        """Check if the provided instance is part of a detected deadlock."""
         result = self._deadlock_detector.is_deadlocked(instance_id)
         return [ResponseType.SUCCESS.value, result]
 
@@ -427,17 +453,18 @@ class MMPServer:
     the multiscale model to be executed, and services them using an
     MMPRequestHandler.
     """
+
     def __init__(
-            self,
-            logger: Logger,
-            profile_store: ProfileStore,
-            configuration: Configuration,
-            instance_registry: InstanceRegistry,
-            topology_store: TopologyStore,
-            snapshot_registry: SnapshotRegistry,
-            deadlock_detector: DeadlockDetector,
-            run_dir: Optional[RunDir]
-            ) -> None:
+        self,
+        logger: Logger,
+        profile_store: ProfileStore,
+        configuration: Configuration,
+        instance_registry: InstanceRegistry,
+        topology_store: TopologyStore,
+        snapshot_registry: SnapshotRegistry,
+        deadlock_detector: DeadlockDetector,
+        run_dir: Optional[RunDir],
+    ) -> None:
         """Create an MMPServer.
 
         This starts a TCP Transport server and connects it to an
@@ -457,8 +484,15 @@ class MMPServer:
             run_dir: To save snapshots to
         """
         self._handler = MMPRequestHandler(
-                logger, profile_store, configuration, instance_registry,
-                topology_store, snapshot_registry, deadlock_detector, run_dir)
+            logger,
+            profile_store,
+            configuration,
+            instance_registry,
+            topology_store,
+            snapshot_registry,
+            deadlock_detector,
+            run_dir,
+        )
         try:
             self._server = TcpTransportServer(self._handler, 9000)
         except OSError as e:

--- a/libmuscle/python/libmuscle/manager/profile_database.py
+++ b/libmuscle/python/libmuscle/manager/profile_database.py
@@ -13,6 +13,7 @@ class ProfileDatabase:
     This class accesses a MUSCLE3 profiling database and provides basic
     analysis functionality.
     """
+
     def __init__(self, db_file: Union[str, Path]) -> None:
         """Open a ProfileDatabase.
 
@@ -53,11 +54,10 @@ class ProfileDatabase:
         """
         # If the thread never served a request, then we don't have a
         # connection.
-        if hasattr(self._local, 'conn'):
+        if hasattr(self._local, "conn"):
             self._local.conn.close()
 
-    def instance_stats(
-            self) -> tuple[list[str], list[float], list[float], list[float]]:
+    def instance_stats(self) -> tuple[list[str], list[float], list[float], list[float]]:
         """Calculate per-instance statistics.
 
         This calculates the total time spent computing, the total time
@@ -98,23 +98,21 @@ class ProfileDatabase:
         cur.execute("SELECT name FROM instances")
         instances = [row[0] for row in cur.fetchall()]
 
-        cur.execute(
-                "SELECT instance, stop_time"
-                " FROM all_events"
-                " WHERE type = 'CONNECT'")
+        cur.execute("SELECT instance, stop_time FROM all_events WHERE type = 'CONNECT'")
         start_run = dict(cur.fetchall())
 
         for name in instances:
             if name not in start_run:
                 warn(
-                        f'Instance {name} seems to have never registered with the'
-                        ' manager, and will be omitted from the results. Did it crash'
-                        ' on startup?', stacklevel=2)
+                    f"Instance {name} seems to have never registered with the"
+                    " manager, and will be omitted from the results. Did it crash"
+                    " on startup?",
+                    stacklevel=2,
+                )
 
         cur.execute(
-                "SELECT instance, start_time"
-                " FROM all_events"
-                " WHERE type = 'SHUTDOWN_WAIT'")
+            "SELECT instance, start_time FROM all_events WHERE type = 'SHUTDOWN_WAIT'"
+        )
         stop_run = dict(cur.fetchall())
 
         for name in instances:
@@ -122,39 +120,47 @@ class ProfileDatabase:
                 # instances with no connected f_init ports don't have SHUTDOWN_WAIT
                 # try to use the start of DISCONNECT_WAIT instead as the stop time
                 cur.execute(
-                        "SELECT start_time"
-                        " FROM all_events"
-                        " WHERE type = 'DISCONNECT_WAIT' and instance = ?", [name])
+                    "SELECT start_time"
+                    " FROM all_events"
+                    " WHERE type = 'DISCONNECT_WAIT' and instance = ?",
+                    [name],
+                )
                 result = cur.fetchall()
                 if result:
                     stop_run[name] = result[0][0]
                 else:
                     # as a last resort, just take the last registered event
                     warn(
-                            f'Instance {name} did not shut down cleanly, data may be'
-                            ' inaccurate or missing', stacklevel=2)
+                        f"Instance {name} did not shut down cleanly, data may be"
+                        " inaccurate or missing",
+                        stacklevel=2,
+                    )
 
                     cur.execute(
-                            "SELECT stop_time"
-                            " FROM all_events"
-                            " WHERE instance = ?"
-                            " ORDER BY stop_time DESC LIMIT 1", [name])
+                        "SELECT stop_time"
+                        " FROM all_events"
+                        " WHERE instance = ?"
+                        " ORDER BY stop_time DESC LIMIT 1",
+                        [name],
+                    )
                     result = cur.fetchall()
                     if result:
                         stop_run[name] = result[0][0]
 
         cur.execute(
-                "SELECT instance, SUM(stop_time - start_time)"
-                " FROM all_events"
-                " WHERE type = 'SEND' OR type = 'RECEIVE'"
-                " GROUP BY instance")
+            "SELECT instance, SUM(stop_time - start_time)"
+            " FROM all_events"
+            " WHERE type = 'SEND' OR type = 'RECEIVE'"
+            " GROUP BY instance"
+        )
         comm = dict(cur.fetchall())
 
         cur.execute(
-                "SELECT instance, SUM(stop_time - start_time)"
-                " FROM all_events"
-                " WHERE type = 'RECEIVE_WAIT'"
-                " GROUP BY instance")
+            "SELECT instance, SUM(stop_time - start_time)"
+            " FROM all_events"
+            " WHERE type = 'RECEIVE_WAIT'"
+            " GROUP BY instance"
+        )
         wait = dict(cur.fetchall())
 
         cur.execute("COMMIT")
@@ -164,15 +170,11 @@ class ProfileDatabase:
 
         total_times = [(stop_run[i] - start_run[i]) * 1e-9 for i in complete_instances]
         comm_times = [
-                (
-                    (comm[i] if i in comm else 0) -
-                    (wait[i] if i in wait else 0)
-                ) * 1e-9
-                for i in complete_instances]
+            ((comm[i] if i in comm else 0) - (wait[i] if i in wait else 0)) * 1e-9
+            for i in complete_instances
+        ]
         wait_times = [(wait[i] if i in wait else 0) * 1e-9 for i in complete_instances]
-        run_times = [
-                t - c - w
-                for t, c, w in zip(total_times, comm_times, wait_times)]
+        run_times = [t - c - w for t, c, w in zip(total_times, comm_times, wait_times)]
 
         return complete_instances, run_times, comm_times, wait_times
 
@@ -194,19 +196,18 @@ class ProfileDatabase:
         """
         instances, run_times, comm_times, _ = self.instance_stats()
 
-        active_times = {
-                i: r + c
-                for i, r, c in zip(instances, run_times, comm_times)}
+        active_times = {i: r + c for i, r, c in zip(instances, run_times, comm_times)}
 
         cur = self._get_cursor()
         cur.execute("BEGIN TRANSACTION")
         cur.execute(
-                "SELECT i.name, ac.node, ac.core"
-                " FROM instances AS i"
-                " JOIN assigned_cores AS ac ON (i.oid = ac.instance_oid)")
+            "SELECT i.name, ac.node, ac.core"
+            " FROM instances AS i"
+            " JOIN assigned_cores AS ac ON (i.oid = ac.instance_oid)"
+        )
         instances_by_core = defaultdict(list)
         for name, node, core in cur.fetchall():
-            instances_by_core[':'.join([node, str(core)])].append(name)
+            instances_by_core[":".join([node, str(core)])].append(name)
 
         cur.execute("COMMIT")
         cur.close()
@@ -219,11 +220,19 @@ class ProfileDatabase:
         return result
 
     def time_taken(
-            self, *, etype: str, instance: Optional[str] = None,
-            port: Optional[str] = None, slot: Optional[int] = None,
-            time: Optional[str] = 'start', etype2: Optional[str] = None,
-            port2: Optional[str] = None, slot2: Optional[int] = None,
-            time2: Optional[str] = 'stop', aggregate: str = 'mean') -> float:
+        self,
+        *,
+        etype: str,
+        instance: Optional[str] = None,
+        port: Optional[str] = None,
+        slot: Optional[int] = None,
+        time: Optional[str] = "start",
+        etype2: Optional[str] = None,
+        port2: Optional[str] = None,
+        slot2: Optional[int] = None,
+        time2: Optional[str] = "stop",
+        aggregate: str = "mean",
+    ) -> float:
         """Calculate time of and between events.
 
         This function returns the mean or total time spent on or
@@ -350,7 +359,7 @@ class ProfileDatabase:
             The mean or total time taken in nanoseconds.
         """
         if time is None:
-            time = 'start'
+            time = "start"
 
         if etype2 is None:
             etype2 = etype
@@ -362,21 +371,21 @@ class ProfileDatabase:
             slot2 = slot
 
         if time2 is None:
-            time2 = 'stop'
+            time2 = "stop"
 
-        if time in ('start', 'stop'):
-            timestamp = time + '_time'
+        if time in ("start", "stop"):
+            timestamp = time + "_time"
         else:
             raise ValueError(
-                    'Invalid time value, please specify either "start"'
-                    ' or "stop".')
+                'Invalid time value, please specify either "start" or "stop".'
+            )
 
-        if time2 in ('start', 'stop'):
-            timestamp2 = time2 + '_time'
+        if time2 in ("start", "stop"):
+            timestamp2 = time2 + "_time"
         else:
             raise ValueError(
-                    'Invalid time2 value, please specify either "start"'
-                    ' or "stop".')
+                'Invalid time2 value, please specify either "start" or "stop".'
+            )
 
         # To do sum(stop - start) across different events, we'd have
         # to do an expensive and tricky self-join on the events table
@@ -395,16 +404,21 @@ class ProfileDatabase:
         # have to time-travel to before 1970 to notice any problem.
 
         def get_sum_count(
-                cur: sqlite3.Cursor, etype: Optional[str], timestamp: str,
-                instance: Optional[str], port: Optional[str],
-                slot: Optional[int]) -> tuple[int, int, int]:
+            cur: sqlite3.Cursor,
+            etype: Optional[str],
+            timestamp: str,
+            instance: Optional[str],
+            port: Optional[str],
+            slot: Optional[int],
+        ) -> tuple[int, int, int]:
             """Get sums and count for one time point."""
             cur.execute("BEGIN TRANSACTION")
             query = (
-                    f"SELECT SUM({timestamp} >> 32), SUM({timestamp} & 0xffffffff),"
-                    " COUNT(*)"
-                    " FROM all_events"
-                    " WHERE type = ?")
+                f"SELECT SUM({timestamp} >> 32), SUM({timestamp} & 0xffffffff),"
+                " COUNT(*)"
+                " FROM all_events"
+                " WHERE type = ?"
+            )
             qargs: list[Any] = [etype]
 
             if instance is not None:
@@ -426,39 +440,44 @@ class ProfileDatabase:
 
         cur = self._get_cursor()
         sum1_high, sum1_low, count1 = get_sum_count(
-                cur, etype, timestamp, instance, port, slot)
+            cur, etype, timestamp, instance, port, slot
+        )
         sum2_high, sum2_low, count2 = get_sum_count(
-                cur, etype2, timestamp2, instance, port2, slot2)
+            cur, etype2, timestamp2, instance, port2, slot2
+        )
         cur.close()
 
         if count1 != count2:
             raise RuntimeError(
-                    'The number of start and stop events is not the same:'
-                    f' {count1} != {count2}')
+                "The number of start and stop events is not the same:"
+                f" {count1} != {count2}"
+            )
 
         if count1 == 0:
-            if aggregate == 'sum':
+            if aggregate == "sum":
                 return 0.0
-            raise RuntimeError('No matching events were found')
+            raise RuntimeError("No matching events were found")
 
         diff_high = (sum2_high - sum1_high) << 32
         diff_low = sum2_low - sum1_low
-        if aggregate == 'mean':
+        if aggregate == "mean":
             return (diff_high + diff_low) / count1
-        elif aggregate == 'sum':
+        elif aggregate == "sum":
             return diff_high + diff_low
         else:
             raise ValueError(
-                    f'Unknown aggregate {aggregate}, please specify either'
-                    ' "mean" or "sum"')
+                f'Unknown aggregate {aggregate}, please specify either "mean" or "sum"'
+            )
 
-    def __enter__(self) -> 'ProfileDatabase':
+    def __enter__(self) -> "ProfileDatabase":
         return self
 
     def __exit__(
-            self, exc_type: Optional[type[BaseException]],
-            exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-            ) -> None:
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         self.close()
 
     def _get_cursor(self) -> sqlite3.Cursor:
@@ -479,7 +498,6 @@ class ProfileDatabase:
         so we use thread-local storage to get a connection in each
         thread.
         """
-        if not hasattr(self._local, 'conn'):
-            self._local.conn = sqlite3.connect(
-                    self._db_file, isolation_level=None)
+        if not hasattr(self._local, "conn"):
+            self._local.conn = sqlite3.connect(self._db_file, isolation_level=None)
         return cast(sqlite3.Cursor, self._local.conn.cursor())

--- a/libmuscle/python/libmuscle/manager/profile_store.py
+++ b/libmuscle/python/libmuscle/manager/profile_store.py
@@ -27,16 +27,17 @@ class ProfileStore(ProfileDatabase):
     It's only used internally, and it's almost a non-const version
     of ProfileDatabase.
     """
+
     def __init__(self, db_dir: Path) -> None:
         """Create a new profile database.
 
         Args:
             db_file: The file to create and initialise.
         """
-        db_file = db_dir / 'performance.sqlite'
+        db_file = db_dir / "performance.sqlite"
 
         if db_file.exists():
-            _logger.info(f'Overwriting profiling database {db_file}')
+            _logger.info(f"Overwriting profiling database {db_file}")
             try:
                 # from Python 3.8, we can use missing_ok=True
                 db_file.unlink()
@@ -62,8 +63,7 @@ class ProfileStore(ProfileDatabase):
         self._thread.join()
         super().close()
 
-    def store_instances(
-            self, instances: list[Reference]) -> None:
+    def store_instances(self, instances: list[Reference]) -> None:
         """Store names of instances in the simulation.
 
         Args:
@@ -73,8 +73,9 @@ class ProfileStore(ProfileDatabase):
         cur.execute("BEGIN IMMEDIATE TRANSACTION")
 
         cur.executemany(
-                "INSERT INTO instances (name) VALUES (?)",
-                [(str(name),) for name in instances])
+            "INSERT INTO instances (name) VALUES (?)",
+            [(str(name),) for name in instances],
+        )
         cur.execute("COMMIT")
         cur.close()
 
@@ -91,21 +92,23 @@ class ProfileStore(ProfileDatabase):
             instance_oid = self._get_instance_oid(cur, instance_id)
 
             tuples = [
-                    (instance_oid, node.node_name, core.cid)
-                    for node in res.as_resources()
-                    for core in node.cpu_cores]
+                (instance_oid, node.node_name, core.cid)
+                for node in res.as_resources()
+                for core in node.cpu_cores
+            ]
 
             cur.executemany(
-                    "INSERT INTO assigned_cores (instance_oid, node, core)"
-                    " VALUES (?, ?, ?)",
-                    tuples)
+                "INSERT INTO assigned_cores (instance_oid, node, core)"
+                " VALUES (?, ?, ?)",
+                tuples,
+            )
 
         cur.execute("COMMIT")
         cur.close()
 
     def add_events(
-            self, instance_id: Reference, events: Iterable[ProfileEvent]
-            ) -> None:
+        self, instance_id: Reference, events: Iterable[ProfileEvent]
+    ) -> None:
         """Adds profiling events to the database.
 
         Args:
@@ -124,9 +127,18 @@ class ProfileStore(ProfileDatabase):
         writing.
         """
         Record = tuple[
-                int, int, float, float, Optional[str], Optional[int],
-                Optional[int], Optional[int], Optional[int], Optional[int],
-                Optional[float]]
+            int,
+            int,
+            float,
+            float,
+            Optional[str],
+            Optional[int],
+            Optional[int],
+            Optional[int],
+            Optional[int],
+            Optional[int],
+            Optional[float],
+        ]
 
         def to_tuple(e: ProfileEvent) -> Record:
             # Tell mypy this shouldn't happen
@@ -137,10 +149,18 @@ class ProfileStore(ProfileDatabase):
             port_operator = None if e.port is None else e.port.operator.value
 
             return (
-                    instance_oid, e.event_type.value, e.start_time.nanoseconds,
-                    e.stop_time.nanoseconds, port_name, port_operator,
-                    e.port_length, e.slot, e.message_number, e.message_size,
-                    e.message_timestamp)
+                instance_oid,
+                e.event_type.value,
+                e.start_time.nanoseconds,
+                e.stop_time.nanoseconds,
+                port_name,
+                port_operator,
+                e.port_length,
+                e.slot,
+                e.message_number,
+                e.message_size,
+                e.message_timestamp,
+            )
 
         cur = self._get_cursor()
         batch = self._queue.get()
@@ -153,12 +173,13 @@ class ProfileStore(ProfileDatabase):
             instance_oid = self._get_instance_oid(cur, instance_id)
 
             cur.executemany(
-                    "INSERT INTO events"
-                    " (instance_oid, event_type_oid, start_time, stop_time,"
-                    "  port_name, port_operator_oid, port_length, slot,"
-                    "  message_number, message_size, message_timestamp)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    map(to_tuple, events))
+                "INSERT INTO events"
+                " (instance_oid, event_type_oid, start_time, stop_time,"
+                "  port_name, port_operator_oid, port_length, slot,"
+                "  message_number, message_size, message_timestamp)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                map(to_tuple, events),
+            )
             cur.execute("COMMIT")
             if _SYNCHED:
                 self._confirmation_queue.put(None)
@@ -176,9 +197,7 @@ class ProfileStore(ProfileDatabase):
         Return:
             The oid used for it in the database
         """
-        cur.execute(
-                "SELECT oid FROM instances WHERE name = ?",
-                (str(instance_id),))
+        cur.execute("SELECT oid FROM instances WHERE name = ?", (str(instance_id),))
         oids = cur.fetchall()
         return cast(int, oids[0][0])
 
@@ -190,75 +209,80 @@ class ProfileStore(ProfileDatabase):
         cur = self._get_cursor()
         cur.execute("BEGIN IMMEDIATE TRANSACTION")
         cur.execute(
-                "CREATE TABLE muscle3_format ("
-                "    major_version INTEGER NOT NULL,"
-                "    minor_version INTEGER NOT NULL)")
+            "CREATE TABLE muscle3_format ("
+            "    major_version INTEGER NOT NULL,"
+            "    minor_version INTEGER NOT NULL)"
+        )
         cur.execute(
-                "INSERT INTO muscle3_format(major_version, minor_version)"
-                "    VALUES (1, 1)")
+            "INSERT INTO muscle3_format(major_version, minor_version)    VALUES (1, 1)"
+        )
 
         cur.execute(
-                "CREATE TABLE instances ("
-                "    oid INTEGER PRIMARY KEY,"
-                "    name TEXT UNIQUE)")
+            "CREATE TABLE instances (    oid INTEGER PRIMARY KEY,    name TEXT UNIQUE)"
+        )
 
         cur.execute(
-                "CREATE TABLE assigned_cores ("
-                "    instance_oid INTEGER NOT NULL REFERENCES instances(oid),"
-                "    node TEXT NOT NULL,"
-                "    core INTEGER NOT NULL)")
+            "CREATE TABLE assigned_cores ("
+            "    instance_oid INTEGER NOT NULL REFERENCES instances(oid),"
+            "    node TEXT NOT NULL,"
+            "    core INTEGER NOT NULL)"
+        )
 
         cur.execute(
-                "CREATE TABLE event_types ("
-                "    oid INTEGER PRIMARY KEY,"
-                "    name TEXT UNIQUE)")
+            "CREATE TABLE event_types ("
+            "    oid INTEGER PRIMARY KEY,"
+            "    name TEXT UNIQUE)"
+        )
         event_types = [(t.value, t.name) for t in ProfileEventType]
         cur.executemany(
-                "INSERT INTO event_types (oid, name) VALUES (?, ?)",
-                event_types)
+            "INSERT INTO event_types (oid, name) VALUES (?, ?)", event_types
+        )
 
         cur.execute(
-                "CREATE TABLE port_operators ("
-                "    oid INTEGER PRIMARY KEY,"
-                "    name TEXT UNIQUE)")
+            "CREATE TABLE port_operators ("
+            "    oid INTEGER PRIMARY KEY,"
+            "    name TEXT UNIQUE)"
+        )
         port_operators = [(o.value, o.name) for o in Operator]
         cur.executemany(
-                "INSERT INTO port_operators (oid, name) VALUES (?, ?)",
-                port_operators)
+            "INSERT INTO port_operators (oid, name) VALUES (?, ?)", port_operators
+        )
 
         cur.execute(
-                "CREATE TABLE events ("
-                "    instance_oid INTEGER NOT NULL REFERENCES instances(oid),"
-                "    event_type_oid INTEGER NOT NULL REFERENCES event_types(oid),"
-                "    start_time INTEGER NOT NULL,"
-                "    stop_time INTEGER NOT NULL,"
-                "    port_name TEXT,"
-                "    port_operator_oid INTEGER REFERENCES port_operators(oid),"
-                "    port_length INTEGER,"
-                "    slot INTEGER,"
-                "    message_number INTEGER,"
-                "    message_size INTEGER,"
-                "    message_timestamp DOUBLE)")
+            "CREATE TABLE events ("
+            "    instance_oid INTEGER NOT NULL REFERENCES instances(oid),"
+            "    event_type_oid INTEGER NOT NULL REFERENCES event_types(oid),"
+            "    start_time INTEGER NOT NULL,"
+            "    stop_time INTEGER NOT NULL,"
+            "    port_name TEXT,"
+            "    port_operator_oid INTEGER REFERENCES port_operators(oid),"
+            "    port_length INTEGER,"
+            "    slot INTEGER,"
+            "    message_number INTEGER,"
+            "    message_size INTEGER,"
+            "    message_timestamp DOUBLE)"
+        )
 
         cur.execute("CREATE INDEX instances_oid_idx ON instances(oid)")
 
         cur.execute("CREATE INDEX events_start_time_idx ON events(start_time)")
 
         cur.execute(
-                "CREATE VIEW all_events"
-                " AS SELECT"
-                "    i.name AS instance, et.name AS type,"
-                "    e.start_time AS start_time, e.stop_time AS stop_time,"
-                "    e.port_name AS port, o.name AS operator,"
-                "    e.port_length AS port_length, e.slot AS slot,"
-                "    e.message_number AS message_number,"
-                "    e.message_size AS message_size,"
-                "    e.message_timestamp AS message_timestamp"
-                " FROM"
-                "    events e"
-                "    JOIN instances i ON e.instance_oid = i.oid"
-                "    LEFT JOIN event_types et ON e.event_type_oid = et.oid"
-                "    LEFT JOIN port_operators o ON e.port_operator_oid = o.oid")
+            "CREATE VIEW all_events"
+            " AS SELECT"
+            "    i.name AS instance, et.name AS type,"
+            "    e.start_time AS start_time, e.stop_time AS stop_time,"
+            "    e.port_name AS port, o.name AS operator,"
+            "    e.port_length AS port_length, e.slot AS slot,"
+            "    e.message_number AS message_number,"
+            "    e.message_size AS message_size,"
+            "    e.message_timestamp AS message_timestamp"
+            " FROM"
+            "    events e"
+            "    JOIN instances i ON e.instance_oid = i.oid"
+            "    LEFT JOIN event_types et ON e.event_type_oid = et.oid"
+            "    LEFT JOIN port_operators o ON e.port_operator_oid = o.oid"
+        )
 
         cur.execute("COMMIT")
         cur.close()

--- a/libmuscle/python/libmuscle/manager/run_dir.py
+++ b/libmuscle/python/libmuscle/manager/run_dir.py
@@ -27,6 +27,7 @@ class RunDir:
             snapshots/
 
     """
+
     def __init__(self, run_dir: Path) -> None:
         """Create a RunDir managing the given directory.
 
@@ -37,7 +38,7 @@ class RunDir:
         if not self.path.exists():
             self.path.mkdir()
 
-        instances_dir = self.path / 'instances'
+        instances_dir = self.path / "instances"
         if not instances_dir.exists():
             instances_dir.mkdir()
 
@@ -50,9 +51,9 @@ class RunDir:
         Returns:
             The path to the new, empty directory
         """
-        idir = self.path / 'instances' / str(name)
+        idir = self.path / "instances" / str(name)
         if idir.exists():
-            raise ValueError('Instance already has a directory')
+            raise ValueError("Instance already has a directory")
         idir.mkdir()
         return idir
 
@@ -62,7 +63,7 @@ class RunDir:
         The directory may or may not exist, call add_instance_dir() to
         make it.
         """
-        return self.path / 'instances' / str(name)
+        return self.path / "instances" / str(name)
 
     def snapshot_dir(self, name: Optional[Reference] = None) -> Path:
         """Return the snapshot directory for the workflow or for an instance.
@@ -75,8 +76,8 @@ class RunDir:
             The path to the snapshot directory
         """
         if name is None:
-            path = self.path / 'snapshots'
+            path = self.path / "snapshots"
         else:
-            path = self.instance_dir(name) / 'snapshots'
+            path = self.instance_dir(name) / "snapshots"
         path.mkdir(parents=True, exist_ok=True)
         return path

--- a/libmuscle/python/libmuscle/manager/snapshot_registry.py
+++ b/libmuscle/python/libmuscle/manager/snapshot_registry.py
@@ -23,7 +23,7 @@ _QueueItemType = Optional[tuple[Reference, SnapshotMetadata]]
 _T = TypeVar("_T")
 
 # this snapshot is used as a placeholder for restarting from scratch
-_NULL_SNAPSHOT = SnapshotMetadata(["Instance start"], 0, 0, None, {}, True, '')
+_NULL_SNAPSHOT = SnapshotMetadata(["Instance start"], 0, 0, None, {}, True, "")
 
 
 def safe_get(lst: list[_T], index: int, default: _T) -> _T:
@@ -47,8 +47,8 @@ class _ConnectionInfo(Flag):
 
 
 def calc_consistency(
-        num1: int, num2: int, first_is_sent: bool, num2_is_restart: bool
-        ) -> bool:
+    num1: int, num2: int, first_is_sent: bool, num2_is_restart: bool
+) -> bool:
     """Calculate consistency of message counts.
 
     Args:
@@ -60,15 +60,21 @@ def calc_consistency(
     Returns:
         True iff the two message counts are consistent
     """
-    return (num1 == num2 or                             # strong
-            num1 + 1 == num2 and first_is_sent or       # weak (1 = sent)
-            # weak (2 = sent) - only allow if num2 is not a restart
-            num2 + 1 == num1 and not first_is_sent and not num2_is_restart)
+    return (
+        num1 == num2  # strong
+        or num1 + 1 == num2
+        and first_is_sent  # weak (1 = sent)
+        or
+        # weak (2 = sent) - only allow if num2 is not a restart
+        num2 + 1 == num1
+        and not first_is_sent
+        and not num2_is_restart
+    )
 
 
 def calc_consistency_list(
-        num1: list[int], num2: list[int], first_is_sent: bool,
-        num2_is_restart: bool) -> bool:
+    num1: list[int], num2: list[int], first_is_sent: bool, num2_is_restart: bool
+) -> bool:
     """Calculate consistency of message counts.
 
     Args:
@@ -86,9 +92,12 @@ def calc_consistency_list(
     else:
         allow_weak = not num2_is_restart
         slot_iter = zip_longest(num2, num1, fillvalue=0)
-    return all(slot_sent == slot_received or                    # strong
-               slot_sent + 1 == slot_received and allow_weak    # weak
-               for slot_sent, slot_received in slot_iter)
+    return all(
+        slot_sent == slot_received  # strong
+        or slot_sent + 1 == slot_received
+        and allow_weak  # weak
+        for slot_sent, slot_received in slot_iter
+    )
 
 
 @dataclass
@@ -104,26 +113,26 @@ class SnapshotNode:
         consistent_peers: Keeps track of snapshots per peer that are consistent
             with this one.
     """
+
     num: int
     instance: Reference
     snapshot: SnapshotMetadata
     peers: frozenset[Reference]
     consistent_peers: dict[Reference, list["SnapshotNode"]] = field(
-            default_factory=dict, repr=False)
+        default_factory=dict, repr=False
+    )
 
     def __hash__(self) -> int:
         return object.__hash__(self)
 
     @property
     def consistent(self) -> bool:
-        """Returns True iff there is a consistent checkpoint with all peers.
-        """
+        """Returns True iff there is a consistent checkpoint with all peers."""
         return self.consistent_peers.keys() == self.peers
 
     def do_consistency_check(
-            self,
-            peer_node: "SnapshotNode",
-            connections: list[_ConnectionType]) -> bool:
+        self, peer_node: "SnapshotNode", connections: list[_ConnectionType]
+    ) -> bool:
         """Check if the snapshot of the peer is consistent with us.
 
         When the peer snapshot is consistent, adds it to our list of consistent
@@ -147,24 +156,27 @@ class SnapshotNode:
             if conn & _ConnectionInfo.SELF_IS_VECTOR:
                 slot = int(peer_node.instance[-1])
                 consistent = calc_consistency(
-                        safe_get(i_msg_counts, slot, 0),
-                        safe_get(p_msg_counts, 0, 0),
-                        is_sending, peer_is_restart)
+                    safe_get(i_msg_counts, slot, 0),
+                    safe_get(p_msg_counts, 0, 0),
+                    is_sending,
+                    peer_is_restart,
+                )
             elif conn & _ConnectionInfo.PEER_IS_VECTOR:
                 slot = int(self.instance[-1])
                 consistent = calc_consistency(
-                        safe_get(i_msg_counts, 0, 0),
-                        safe_get(p_msg_counts, slot, 0),
-                        is_sending, peer_is_restart)
+                    safe_get(i_msg_counts, 0, 0),
+                    safe_get(p_msg_counts, slot, 0),
+                    is_sending,
+                    peer_is_restart,
+                )
             else:
                 consistent = calc_consistency_list(
-                        i_msg_counts, p_msg_counts, is_sending, peer_is_restart)
+                    i_msg_counts, p_msg_counts, is_sending, peer_is_restart
+                )
             if not consistent:
                 return False
-        self.consistent_peers.setdefault(
-                peer_node.instance, []).append(peer_node)
-        peer_node.consistent_peers.setdefault(
-                self.instance, []).append(self)
+        self.consistent_peers.setdefault(peer_node.instance, []).append(peer_node)
+        peer_node.consistent_peers.setdefault(self.instance, []).append(self)
         return True
 
 
@@ -180,14 +192,17 @@ class SnapshotRegistry(Thread):
     """
 
     def __init__(
-            self, config: Configuration, snapshot_folder: Path,
-            topology_store: TopologyStore) -> None:
+        self,
+        config: Configuration,
+        snapshot_folder: Path,
+        topology_store: TopologyStore,
+    ) -> None:
         """Create a snapshot graph using provided configuration.
 
         Args:
             config: ymmsl configuration describing the workflow, flattened.
         """
-        super().__init__(name='SnapshotRegistry')
+        super().__init__(name="SnapshotRegistry")
 
         self._configuration = config
         self._model = config.root_model()
@@ -206,7 +221,8 @@ class SnapshotRegistry(Thread):
             self.register_snapshot(instance, _NULL_SNAPSHOT)
 
     def register_snapshot(
-            self, instance: Reference, snapshot: SnapshotMetadata) -> None:
+        self, instance: Reference, snapshot: SnapshotMetadata
+    ) -> None:
         """Register a new snapshot.
 
         Args:
@@ -216,8 +232,7 @@ class SnapshotRegistry(Thread):
         self._queue.put((instance, snapshot))
 
     def run(self) -> None:
-        """Code executed in a separate thread
-        """
+        """Code executed in a separate thread"""
         while True:
             item = self._queue.get()
             if item is None:
@@ -225,12 +240,10 @@ class SnapshotRegistry(Thread):
             self._add_snapshot(*item)
 
     def shutdown(self) -> None:
-        """Stop the snapshot registry thread
-        """
+        """Stop the snapshot registry thread"""
         self._queue.put(None)
 
-    def _add_snapshot(
-            self, instance: Reference, snapshot: SnapshotMetadata) -> None:
+    def _add_snapshot(self, instance: Reference, snapshot: SnapshotMetadata) -> None:
         """Register a new snapshot.
 
         Args:
@@ -249,7 +262,8 @@ class SnapshotRegistry(Thread):
         for peer in stateful_peers:
             for peer_snapshot in self._snapshots.get(peer, []):
                 snapshotnode.do_consistency_check(
-                        peer_snapshot, self._get_connections(instance, peer))
+                    peer_snapshot, self._get_connections(instance, peer)
+                )
 
         # finally, check if this snapshotnode is now part of a workflow snapshot
         if snapshot is not _NULL_SNAPSHOT:
@@ -268,7 +282,8 @@ class SnapshotRegistry(Thread):
         self._cleanup_snapshots(workflow_snapshots)
 
     def _get_workflow_snapshots(
-            self, snapshot: SnapshotNode) -> list[list[SnapshotNode]]:
+        self, snapshot: SnapshotNode
+    ) -> list[list[SnapshotNode]]:
         """Return all workflow snapshots which contain the provided node.
 
         Args:
@@ -291,9 +306,10 @@ class SnapshotRegistry(Thread):
         allowed_snapshots: dict[Reference, frozenset[SnapshotNode]] = {}
         for instance in instances_to_cover:
             allowed_snapshots[instance] = frozenset(
-                    i_snapshot
-                    for i_snapshot in self._snapshots.get(instance, [])
-                    if i_snapshot.consistent)
+                i_snapshot
+                for i_snapshot in self._snapshots.get(instance, [])
+                if i_snapshot.consistent
+            )
             if not allowed_snapshots[instance]:
                 # there cannot be a workflow snapshot if this instance has no
                 # consistent snapshot nodes
@@ -341,7 +357,7 @@ class SnapshotRegistry(Thread):
             instance = instances_to_cover.pop()
 
             # 2. Select the oldest snapshot of this instance
-            snapshot = min(allowed_snapshots[instance], key=attrgetter('num'))
+            snapshot = min(allowed_snapshots[instance], key=attrgetter("num"))
             selected_snapshots.append(snapshot)
             # A shallow copy is ok: the values are immutable frozensets
             stack.append(allowed_snapshots.copy())
@@ -381,8 +397,7 @@ class SnapshotRegistry(Thread):
                 # Exhausted all roll back possibilities, so we are done now
                 return workflow_snapshots
 
-    def _write_snapshot_ymmsl(
-            self, selected_snapshots: list[SnapshotNode]) -> None:
+    def _write_snapshot_ymmsl(self, selected_snapshots: list[SnapshotNode]) -> None:
         """Write the snapshot ymmsl file to the snapshot folder.
 
         Args:
@@ -390,26 +405,27 @@ class SnapshotRegistry(Thread):
         """
         now = datetime.now()
         config = self._generate_snapshot_config(selected_snapshots, now)
-        time = now.strftime('%Y%m%d_%H%M%S')
+        time = now.strftime("%Y%m%d_%H%M%S")
         for i in range(_MAX_FILE_EXISTS_CHECK):
             if i:
-                snapshot_filename = f'snapshot_{time}_{i}.ymmsl'
+                snapshot_filename = f"snapshot_{time}_{i}.ymmsl"
             else:
-                snapshot_filename = f'snapshot_{time}.ymmsl'
+                snapshot_filename = f"snapshot_{time}.ymmsl"
             savepath = self._snapshot_folder / snapshot_filename
             if not savepath.exists():
                 save(config, savepath)
                 return
-        raise RuntimeError('Could not find an available filename for storing'
-                           f' the next workflow snapshot: {savepath} already'
-                           ' exists.')
+        raise RuntimeError(
+            "Could not find an available filename for storing"
+            f" the next workflow snapshot: {savepath} already"
+            " exists."
+        )
 
     def _generate_snapshot_config(
-                self, selected_snapshots: list[SnapshotNode], now: datetime
-                ) -> Configuration:
-        """Generate ymmsl configuration for snapshot file
-        """
-        selected_snapshots.sort(key=attrgetter('instance'))
+        self, selected_snapshots: list[SnapshotNode], now: datetime
+    ) -> Configuration:
+        """Generate ymmsl configuration for snapshot file"""
+        selected_snapshots.sort(key=attrgetter("instance"))
         resume = {}
         for node in selected_snapshots:
             if node.snapshot is not _NULL_SNAPSHOT:
@@ -421,39 +437,47 @@ class SnapshotRegistry(Thread):
         return Configuration(resume=resume, description=description)
 
     def _generate_description(
-            self, selected_snapshots: list[SnapshotNode], now: datetime) -> str:
-        """Generate a human-readable description of the workflow snapshot.
-        """
+        self, selected_snapshots: list[SnapshotNode], now: datetime
+    ) -> str:
+        """Generate a human-readable description of the workflow snapshot."""
         triggers: dict[str, list[str]] = {}
         component_info = []
-        max_instance_len = len('Instance ')
+        max_instance_len = len("Instance ")
         for node in selected_snapshots:
             for trigger in node.snapshot.triggers:
                 triggers.setdefault(trigger, []).append(str(node.instance))
-            component_info.append((
+            component_info.append(
+                (
                     str(node.instance),
-                    f'{node.snapshot.timestamp:<11.6g}',
-                    f'{node.snapshot.wallclock_time:<11.6g}',
-                    ("Intermediate", "Final")[node.snapshot.is_final_snapshot]))
+                    f"{node.snapshot.timestamp:<11.6g}",
+                    f"{node.snapshot.wallclock_time:<11.6g}",
+                    ("Intermediate", "Final")[node.snapshot.is_final_snapshot],
+                )
+            )
             max_instance_len = max(max_instance_len, len(str(node.instance)))
-        instance_with_padding = 'Instance'.ljust(max_instance_len)
+        instance_with_padding = "Instance".ljust(max_instance_len)
         component_table = [
-                f'{instance_with_padding} t           Wallclock time  Type',
-                f'{"-" * (max_instance_len + 41)}']
+            f"{instance_with_padding} t           Wallclock time  Type",
+            f"{'-' * (max_instance_len + 41)}",
+        ]
         component_table += [
-                f'{name.ljust(max_instance_len)} {timestamp} {walltime}'
-                f'     {typ}'
-                for name, timestamp, walltime, typ in component_info]
-        return (f'Workflow snapshot for {self._model.name}'
-                f' taken on {now.strftime("%Y-%m-%d %H:%M:%S")}.\n'
-                'Snapshot triggers:\n' +
-                '\n'.join(f'- {trigger} ({", ".join(triggers[trigger])})'
-                          for trigger in sorted(triggers)) +
-                '\n\n' +
-                '\n'.join(component_table) + '\n')
+            f"{name.ljust(max_instance_len)} {timestamp} {walltime}     {typ}"
+            for name, timestamp, walltime, typ in component_info
+        ]
+        return (
+            f"Workflow snapshot for {self._model.name}"
+            f" taken on {now.strftime('%Y-%m-%d %H:%M:%S')}.\n"
+            "Snapshot triggers:\n"
+            + "\n".join(
+                f"- {trigger} ({', '.join(triggers[trigger])})"
+                for trigger in sorted(triggers)
+            )
+            + "\n\n"
+            + "\n".join(component_table)
+            + "\n"
+        )
 
-    def _cleanup_snapshots(
-            self, workflow_snapshots: list[list[SnapshotNode]]) -> None:
+    def _cleanup_snapshots(self, workflow_snapshots: list[list[SnapshotNode]]) -> None:
         """Remove all snapshots that are older than the selected snapshots.
 
         Args:
@@ -463,8 +487,9 @@ class SnapshotRegistry(Thread):
             return
 
         # Find the newest snapshots per instance
-        newest_snapshots = {snapshot.instance: snapshot
-                            for snapshot in workflow_snapshots[0]}
+        newest_snapshots = {
+            snapshot.instance: snapshot for snapshot in workflow_snapshots[0]
+        }
         for workflow_snapshot in workflow_snapshots[1:]:
             for snapshot in workflow_snapshot:
                 if newest_snapshots[snapshot.instance].num < snapshot.num:
@@ -482,13 +507,13 @@ class SnapshotRegistry(Thread):
         # that are cleaned up
         for snapshot in removed_snapshots:
             for peer_snapshot in chain.from_iterable(
-                    snapshot.consistent_peers.values()):
+                snapshot.consistent_peers.values()
+            ):
                 if peer_snapshot in removed_snapshots:
                     # snapshot is removed anyway, no need to update references
                     continue
                 # peer_snapshot is still there, remove reference to us
-                peer_snapshot.consistent_peers[snapshot.instance].remove(
-                        snapshot)
+                peer_snapshot.consistent_peers[snapshot.instance].remove(snapshot)
 
     # The use of @cache on class methods can lead to a memory leak because the global
     # cache keeps a reference to the instance, keeping it from being garbage collected.
@@ -510,8 +535,9 @@ class SnapshotRegistry(Thread):
         return frozenset(self._topology_store.get_peer_instances(instance))
 
     @cache  # noqa: B019
-    def _get_connections(self, instance: Reference, peer: Reference
-                         ) -> list[_ConnectionType]:
+    def _get_connections(
+        self, instance: Reference, peer: Reference
+    ) -> list[_ConnectionType]:
         """Get the list of connections between instance and peer.
 
         Args:
@@ -538,16 +564,20 @@ class SnapshotRegistry(Thread):
 
         connected_ports: list[_ConnectionType] = []
         for conduit in self._model.conduits:
-            if (conduit.sending_component() == instance_kernel and
-                    conduit.receiving_component() == peer_kernel):
+            if (
+                conduit.sending_component() == instance_kernel
+                and conduit.receiving_component() == peer_kernel
+            ):
                 conn_type = _ConnectionInfo.SELF_IS_SENDING
-            elif (conduit.receiving_component() == instance_kernel and
-                    conduit.sending_component() == peer_kernel):
+            elif (
+                conduit.receiving_component() == instance_kernel
+                and conduit.sending_component() == peer_kernel
+            ):
                 conn_type = _ConnectionInfo(0)
             else:
                 continue
-            instance_ndim = (len(instance) - len(instance_kernel))
-            peer_ndim = (len(peer) - len(peer_kernel))
+            instance_ndim = len(instance) - len(instance_kernel)
+            peer_ndim = len(peer) - len(peer_kernel)
             if instance_ndim < peer_ndim:
                 conn_type |= _ConnectionInfo.SELF_IS_VECTOR
             if instance_ndim > peer_ndim:
@@ -555,15 +585,13 @@ class SnapshotRegistry(Thread):
             # we cannot distinguish scalar-scalar vs. vector-vector
             # but it does not matter for this logic :)
             if conn_type & _ConnectionInfo.SELF_IS_SENDING:
-                connected_ports.append((
-                        conduit.sending_port(),
-                        conduit.receiving_port(),
-                        conn_type))
+                connected_ports.append(
+                    (conduit.sending_port(), conduit.receiving_port(), conn_type)
+                )
             else:
-                connected_ports.append((
-                        conduit.receiving_port(),
-                        conduit.sending_port(),
-                        conn_type))
+                connected_ports.append(
+                    (conduit.receiving_port(), conduit.sending_port(), conn_type)
+                )
         return connected_ports
 
     @cache  # noqa: B019

--- a/libmuscle/python/libmuscle/manager/test/conftest.py
+++ b/libmuscle/python/libmuscle/manager/test/conftest.py
@@ -21,19 +21,34 @@ def logger(tmp_path):
 @pytest.fixture
 def mmp_configuration():
     return Configuration(
-            'mmp_configuration', [], [Model(
-                'test_model', None, '', None,
+        "mmp_configuration",
+        [],
+        [
+            Model(
+                "test_model",
+                None,
+                "",
+                None,
                 [
                     Component(
-                        'macro', Ports(o_i=['out'], s=['in']), '',
-                        'macro_implementation'),
+                        "macro",
+                        Ports(o_i=["out"], s=["in"]),
+                        "",
+                        "macro_implementation",
+                    ),
                     Component(
-                        'micro', Ports(f_init=['in'], o_f=['out']), '',
-                        'micro_implementation', False, [10, 10])],
-                [
-                    Conduit('macro.out', 'micro.in'),
-                    Conduit('micro.out', 'macro.in')
-                ])])
+                        "micro",
+                        Ports(f_init=["in"], o_f=["out"]),
+                        "",
+                        "micro_implementation",
+                        False,
+                        [10, 10],
+                    ),
+                ],
+                [Conduit("macro.out", "micro.in"), Conduit("micro.out", "macro.in")],
+            )
+        ],
+    )
 
 
 @pytest.fixture
@@ -65,56 +80,103 @@ def deadlock_detector() -> DeadlockDetector:
 
 @pytest.fixture
 def mmp_request_handler(
-        logger, profile_store, mmp_configuration, instance_registry,
-        topology_store, snapshot_registry, deadlock_detector):
+    logger,
+    profile_store,
+    mmp_configuration,
+    instance_registry,
+    topology_store,
+    snapshot_registry,
+    deadlock_detector,
+):
     return MMPRequestHandler(
-            logger, profile_store, mmp_configuration, instance_registry,
-            topology_store, snapshot_registry, deadlock_detector, None)
+        logger,
+        profile_store,
+        mmp_configuration,
+        instance_registry,
+        topology_store,
+        snapshot_registry,
+        deadlock_detector,
+        None,
+    )
 
 
 @pytest.fixture
 def loaded_instance_registry(instance_registry):
-    instance_registry.add(Reference('macro'), ['direct:macro'], [])
+    instance_registry.add(Reference("macro"), ["direct:macro"], [])
     for j in range(10):
         for i in range(10):
-            name = Reference('micro') + j + i
-            location = f'direct:{name}'
+            name = Reference("micro") + j + i
+            location = f"direct:{name}"
             instance_registry.add(name, [location], [])
     return instance_registry
 
 
 @pytest.fixture
 def registered_mmp_request_handler(
-        logger, profile_store, mmp_configuration, loaded_instance_registry,
-        topology_store, snapshot_registry, deadlock_detector):
+    logger,
+    profile_store,
+    mmp_configuration,
+    loaded_instance_registry,
+    topology_store,
+    snapshot_registry,
+    deadlock_detector,
+):
     return MMPRequestHandler(
-            logger, profile_store, mmp_configuration, loaded_instance_registry,
-            topology_store, snapshot_registry, deadlock_detector, None)
+        logger,
+        profile_store,
+        mmp_configuration,
+        loaded_instance_registry,
+        topology_store,
+        snapshot_registry,
+        deadlock_detector,
+        None,
+    )
 
 
 @pytest.fixture
 def mmp_configuration2():
     return Configuration(
-            'mmp_configuration2', [], [Model(
-                'test_model', None, '', None,
+        "mmp_configuration2",
+        [],
+        [
+            Model(
+                "test_model",
+                None,
+                "",
+                None,
                 [
                     Component(
-                        'macro', Ports(o_i=['out'], s=['in']), '',
-                        'macro_implementation'),
+                        "macro",
+                        Ports(o_i=["out"], s=["in"]),
+                        "",
+                        "macro_implementation",
+                    ),
                     Component(
-                        'meso',
-                        Ports(f_init=['init'], o_i=['out'], s=['in'], o_f=['final']),
-                        '', 'meso_implementation', False, [5]),
+                        "meso",
+                        Ports(f_init=["init"], o_i=["out"], s=["in"], o_f=["final"]),
+                        "",
+                        "meso_implementation",
+                        False,
+                        [5],
+                    ),
                     Component(
-                        'micro', Ports(f_init=['init'], o_f=['final']), '',
-                        'micro_implementation', False, [5, 10])
+                        "micro",
+                        Ports(f_init=["init"], o_f=["final"]),
+                        "",
+                        "micro_implementation",
+                        False,
+                        [5, 10],
+                    ),
                 ],
                 [
-                    Conduit('macro.out', 'meso.init'),
-                    Conduit('meso.out', 'micro.init'),
-                    Conduit('micro.final', 'meso.in'),
-                    Conduit('meso.final', 'macro.in')
-                ])])
+                    Conduit("macro.out", "meso.init"),
+                    Conduit("meso.out", "micro.init"),
+                    Conduit("micro.final", "meso.in"),
+                    Conduit("meso.final", "macro.in"),
+                ],
+            )
+        ],
+    )
 
 
 @pytest.fixture
@@ -131,26 +193,39 @@ def snapshot_registry2(mmp_configuration2, topology_store) -> SnapshotRegistry:
 def loaded_instance_registry2():
     instance_registry = InstanceRegistry()
 
-    instance_registry.add(Reference('macro'), ['direct:macro'], [])
+    instance_registry.add(Reference("macro"), ["direct:macro"], [])
 
     for j in range(5):
-        name = Reference('meso') + j
-        location = f'direct:{name}'
+        name = Reference("meso") + j
+        location = f"direct:{name}"
         instance_registry.add(name, [location], [])
 
     for j in range(5):
         for i in range(10):
-            name = Reference('micro') + j + i
-            location = f'direct:{name}'
+            name = Reference("micro") + j + i
+            location = f"direct:{name}"
             instance_registry.add(name, [location], [])
     return instance_registry
 
 
 @pytest.fixture
 def registered_mmp_request_handler2(
-        logger, profile_store, mmp_configuration, loaded_instance_registry2,
-        topology_store2, snapshot_registry2, deadlock_detector, tmp_path):
+    logger,
+    profile_store,
+    mmp_configuration,
+    loaded_instance_registry2,
+    topology_store2,
+    snapshot_registry2,
+    deadlock_detector,
+    tmp_path,
+):
     return MMPRequestHandler(
-            logger, profile_store, mmp_configuration,
-            loaded_instance_registry2, topology_store2, snapshot_registry2,
-            deadlock_detector, RunDir(tmp_path))
+        logger,
+        profile_store,
+        mmp_configuration,
+        loaded_instance_registry2,
+        topology_store2,
+        snapshot_registry2,
+        deadlock_detector,
+        RunDir(tmp_path),
+    )

--- a/libmuscle/python/libmuscle/manager/test/test_hammer.py
+++ b/libmuscle/python/libmuscle/manager/test/test_hammer.py
@@ -7,27 +7,27 @@ from libmuscle.manager.hammer import Plate, flatten
 
 @pytest.fixture
 def c1() -> Conduit:
-    return Conduit('macro.out', 'micro.in')
+    return Conduit("macro.out", "micro.in")
 
 
 @pytest.fixture
 def c2() -> Conduit:
-    return Conduit('micro.in', 'micro.program.in')
+    return Conduit("micro.in", "micro.program.in")
 
 
 @pytest.fixture
 def c3() -> Conduit:
-    return Conduit('micro.program.out', 'micro.out')
+    return Conduit("micro.program.out", "micro.out")
 
 
 @pytest.fixture
 def c4() -> Conduit:
-    return Conduit('micro.out', 'macro.in')
+    return Conduit("micro.out", "macro.in")
 
 
 @pytest.fixture
 def c5() -> Conduit:
-    return Conduit('micro.in', 'micro.program2.in')
+    return Conduit("micro.in", "micro.program2.in")
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def plate(c1: Conduit, c2: Conduit, c3: Conduit, c4: Conduit, c5: Conduit) -> Pl
     return plate
 
 
-def has_conduit(model: Model, sender: str, receiver: str, filters: str = '') -> bool:
+def has_conduit(model: Model, sender: str, receiver: str, filters: str = "") -> bool:
     """Helper function for checking whether a model has a given conduit.
 
     They're in a list, this makes it easier to search, although still inefficient.
@@ -49,725 +49,730 @@ def has_conduit(model: Model, sender: str, receiver: str, filters: str = '') -> 
     """
     for conduit in model.conduits:
         if conduit.sender == sender and conduit.receiver == receiver:
-            cfs = ' '.join([f.value for f in conduit.filters])
+            cfs = " ".join([f.value for f in conduit.filters])
             if cfs == filters:
                 return True
     return False
 
 
 def test_plate(plate, c2, c5) -> None:
-    macro_out_conduits = plate.pop_by_sender(Reference('micro.in'))
+    macro_out_conduits = plate.pop_by_sender(Reference("micro.in"))
     assert macro_out_conduits == {
-            Reference('micro.program.in'): (c2, True),
-            Reference('micro.program2.in'): (c5, True)}
+        Reference("micro.program.in"): (c2, True),
+        Reference("micro.program2.in"): (c5, True),
+    }
 
     # check that they were removed
-    assert len(plate.pop_by_sender(Reference('micro.in'))) == 0
+    assert len(plate.pop_by_sender(Reference("micro.in"))) == 0
 
 
 def test_plate2(plate, c1) -> None:
-    micro2_in_conduits = plate.pop_by_receiver(Reference('micro.in'))
-    assert micro2_in_conduits == {Reference('macro.out'): (c1, True)}
+    micro2_in_conduits = plate.pop_by_receiver(Reference("micro.in"))
+    assert micro2_in_conduits == {Reference("macro.out"): (c1, True)}
 
     # check that it was removed
-    assert len(plate.pop_by_receiver(Reference('micro.in'))) == 0
+    assert len(plate.pop_by_receiver(Reference("micro.in"))) == 0
 
 
 def test_flatten_simple() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Simple nested test configuration\n'
-            'models:\n'
-            '  outer:\n'
-            '    description: Model containing a submodel\n'
-            '    components:\n'
-            '      init:\n'
-            '        ports:\n'
-            '          o_f: init_out\n'
-            '        description: Creates initial conditions\n'
-            '        implementation: p1\n'
-            '      sim:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '        description: Simulates stuff\n'
-            '        implementation: inner\n'
-            '    conduits:\n'
-            '      init.init_out: sim.init_in\n'
-            '  inner:\n'
-            '    ports:\n'
-            '      f_init: init_in\n'
-            '    description: Nested simulation model\n'
-            '    components:\n'
-            '      simulate:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '        description: Simulation program\n'
-            '        implementation: p2\n'
-            '    conduits:\n'
-            '      init_in: simulate.in\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Program that calculates initial conditions\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Program that simulates stuff\n'
-            '    executable: /home/user/codes/p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Simple nested test configuration\n"
+        "models:\n"
+        "  outer:\n"
+        "    description: Model containing a submodel\n"
+        "    components:\n"
+        "      init:\n"
+        "        ports:\n"
+        "          o_f: init_out\n"
+        "        description: Creates initial conditions\n"
+        "        implementation: p1\n"
+        "      sim:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "        description: Simulates stuff\n"
+        "        implementation: inner\n"
+        "    conduits:\n"
+        "      init.init_out: sim.init_in\n"
+        "  inner:\n"
+        "    ports:\n"
+        "      f_init: init_in\n"
+        "    description: Nested simulation model\n"
+        "    components:\n"
+        "      simulate:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "        description: Simulation program\n"
+        "        implementation: p2\n"
+        "    conduits:\n"
+        "      init_in: simulate.in\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Program that calculates initial conditions\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Program that simulates stuff\n"
+        "    executable: /home/user/codes/p2\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'outer' in flat_config.models
+    assert "outer" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'outer'
+    assert model.name == "outer"
     assert len(model.components) == 2
-    assert 'init' in model.components
-    assert 'sim.simulate' in model.components
+    assert "init" in model.components
+    assert "sim.simulate" in model.components
     assert len(model.conduits) == 1
-    assert has_conduit(model, 'init.init_out', 'sim.simulate.in')
+    assert has_conduit(model, "init.init_out", "sim.simulate.in")
 
 
 def test_flatten_deep() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Three-deep nested test configuration\n'
-            'models:\n'
-            '  top:\n'
-            '    description: Model at the top\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_i: out\n'
-            '          s: in\n'
-            '        description: Calls c2\n'
-            '        implementation: p1\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: Submodel\n'
-            '        implementation: middle\n'
-            '    conduits:\n'
-            '      c1.out: c2.init_in\n'
-            '      c2.final_out: c1.in\n'
-            '  middle:\n'
-            '    ports:\n'
-            '      f_init: init_in\n'
-            '      o_f: final_out\n'
-            '    description: Middle simulation model, empty shell really\n'
-            '    components:\n'
-            '      c3:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: Forward again...\n'
-            '        implementation: bottom\n'
-            '    conduits:\n'
-            '      init_in: c3.init_in\n'
-            '      c3.final_out: final_out\n'
-            '  bottom:\n'
-            '    ports:\n'
-            '      f_init: init_in\n'
-            '      o_f: final_out\n'
-            '    description: Bottom simulation model\n'
-            '    components:\n'
-            '      c4:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: Actual simulation model\n'
-            '        implementation: p2\n'
-            '    conduits:\n'
-            '      init_in: c4.init_in\n'
-            '      c4.final_out: final_out\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Program that calculates initial conditions\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Program that simulates stuff\n'
-            '    executable: /home/user/codes/p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Three-deep nested test configuration\n"
+        "models:\n"
+        "  top:\n"
+        "    description: Model at the top\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_i: out\n"
+        "          s: in\n"
+        "        description: Calls c2\n"
+        "        implementation: p1\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: Submodel\n"
+        "        implementation: middle\n"
+        "    conduits:\n"
+        "      c1.out: c2.init_in\n"
+        "      c2.final_out: c1.in\n"
+        "  middle:\n"
+        "    ports:\n"
+        "      f_init: init_in\n"
+        "      o_f: final_out\n"
+        "    description: Middle simulation model, empty shell really\n"
+        "    components:\n"
+        "      c3:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: Forward again...\n"
+        "        implementation: bottom\n"
+        "    conduits:\n"
+        "      init_in: c3.init_in\n"
+        "      c3.final_out: final_out\n"
+        "  bottom:\n"
+        "    ports:\n"
+        "      f_init: init_in\n"
+        "      o_f: final_out\n"
+        "    description: Bottom simulation model\n"
+        "    components:\n"
+        "      c4:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: Actual simulation model\n"
+        "        implementation: p2\n"
+        "    conduits:\n"
+        "      init_in: c4.init_in\n"
+        "      c4.final_out: final_out\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Program that calculates initial conditions\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Program that simulates stuff\n"
+        "    executable: /home/user/codes/p2\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'top' in flat_config.models
+    assert "top" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'top'
+    assert model.name == "top"
     assert len(model.components) == 2
-    assert 'c1' in model.components
-    assert 'c2.c3.c4' in model.components
+    assert "c1" in model.components
+    assert "c2.c3.c4" in model.components
     assert len(model.conduits) == 2
-    assert has_conduit(model, 'c1.out', 'c2.c3.c4.init_in')
-    assert has_conduit(model, 'c2.c3.c4.final_out', 'c1.in')
+    assert has_conduit(model, "c1.out", "c2.c3.c4.init_in")
+    assert has_conduit(model, "c2.c3.c4.final_out", "c1.in")
 
 
 def test_flatten_nested_ensemble() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Three-deep nested test configuration\n'
-            'models:\n'
-            '  top:\n'
-            '    description: Model at the top\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_i: out\n'
-            '          s: in\n'
-            '        description: Calls c2\n'
-            '        implementation: p1\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: Submodel\n'
-            '        implementation: middle\n'
-            '        multiplicity: 10\n'
-            '    conduits:\n'
-            '      c1.out: c2.init_in\n'
-            '      c2.final_out: c1.in\n'
-            '  middle:\n'
-            '    ports:\n'
-            '      f_init: init_in\n'
-            '      o_f: final_out\n'
-            '    description: This should get replicated\n'
-            '    components:\n'
-            '      c3:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: Another subcomponent\n'
-            '        implementation: nested\n'
-            '        multiplicity: 5\n'
-            '    conduits:\n'
-            '      init_in: c3.init_in\n'
-            '      c3.final_out: final_out\n'
-            '  nested:\n'
-            '    ports:\n'
-            '      f_init: init_in\n'
-            '      o_f: final_out\n'
-            '    description: This should get replicated, nested\n'
-            '    components:\n'
-            '      c4:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: First component\n'
-            '        implementation: p2\n'
-            '      c5:\n'
-            '        ports:\n'
-            '          f_init: init_in\n'
-            '          o_f: final_out\n'
-            '        description: Second component\n'
-            '        implementation: p2\n'
-            '    conduits:\n'
-            '      init_in: c4.init_in\n'
-            '      c4.final_out: c5.init_in\n'
-            '      c5.final_out: final_out\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Program that calculates initial conditions\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Program that simulates stuff\n'
-            '    executable: /home/user/codes/p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Three-deep nested test configuration\n"
+        "models:\n"
+        "  top:\n"
+        "    description: Model at the top\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_i: out\n"
+        "          s: in\n"
+        "        description: Calls c2\n"
+        "        implementation: p1\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: Submodel\n"
+        "        implementation: middle\n"
+        "        multiplicity: 10\n"
+        "    conduits:\n"
+        "      c1.out: c2.init_in\n"
+        "      c2.final_out: c1.in\n"
+        "  middle:\n"
+        "    ports:\n"
+        "      f_init: init_in\n"
+        "      o_f: final_out\n"
+        "    description: This should get replicated\n"
+        "    components:\n"
+        "      c3:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: Another subcomponent\n"
+        "        implementation: nested\n"
+        "        multiplicity: 5\n"
+        "    conduits:\n"
+        "      init_in: c3.init_in\n"
+        "      c3.final_out: final_out\n"
+        "  nested:\n"
+        "    ports:\n"
+        "      f_init: init_in\n"
+        "      o_f: final_out\n"
+        "    description: This should get replicated, nested\n"
+        "    components:\n"
+        "      c4:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: First component\n"
+        "        implementation: p2\n"
+        "      c5:\n"
+        "        ports:\n"
+        "          f_init: init_in\n"
+        "          o_f: final_out\n"
+        "        description: Second component\n"
+        "        implementation: p2\n"
+        "    conduits:\n"
+        "      init_in: c4.init_in\n"
+        "      c4.final_out: c5.init_in\n"
+        "      c5.final_out: final_out\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Program that calculates initial conditions\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Program that simulates stuff\n"
+        "    executable: /home/user/codes/p2\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'top' in flat_config.models
+    assert "top" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'top'
+    assert model.name == "top"
     assert len(model.components) == 3
-    assert 'c1' in model.components
-    assert 'c2.c3.c4' in model.components
-    assert model.components['c2.c3.c4'].multiplicity == [10, 5]
-    assert 'c2.c3.c5' in model.components
-    assert model.components['c2.c3.c5'].multiplicity == [10, 5]
+    assert "c1" in model.components
+    assert "c2.c3.c4" in model.components
+    assert model.components["c2.c3.c4"].multiplicity == [10, 5]
+    assert "c2.c3.c5" in model.components
+    assert model.components["c2.c3.c5"].multiplicity == [10, 5]
     assert len(model.conduits) == 3
-    assert has_conduit(model, 'c2.c3.c4.final_out', 'c2.c3.c5.init_in')
-    assert has_conduit(model, 'c1.out', 'c2.c3.c4.init_in')
-    assert has_conduit(model, 'c2.c3.c5.final_out', 'c1.in')
+    assert has_conduit(model, "c2.c3.c4.final_out", "c2.c3.c5.init_in")
+    assert has_conduit(model, "c1.out", "c2.c3.c4.init_in")
+    assert has_conduit(model, "c2.c3.c5.final_out", "c1.in")
 
 
 def test_flatten_conduit_filters() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Macro-micro to macro-micro dispatch, nested\n'
-            'models:\n'
-            '  macro_micro:\n'
-            '    ports:\n'
-            '      f_init: macro_state_in micro_state_in\n'
-            '      o_f: macro_state_out micro_state_out\n'
-            '    description: Macro-micro model\n'
-            '    components:\n'
-            '      macro:\n'
-            '        ports:\n'
-            '          f_init: state_in\n'
-            '          o_i: boundary_out\n'
-            '          s: boundary_in\n'
-            '          o_f: state_out\n'
-            '        description: |\n'
-            '          Macro model that communicates its boundary conditions\n'
-            '          while running, and outputs its state at the end.\n'
-            '        implementation: p1\n'
-            '      micro:\n'
-            '        ports:\n'
-            '          f_init: state_in boundary_in\n'
-            '          o_f: state_out boundary_out\n'
-            '        description: |\n'
-            '          Stateful micro model that takes new boundary conditions and\n'
-            '          optionally a new state on each run. If a new state is received\n'
-            '          then it re-initialises, otherwise the current state is kept.\n'
-            '          Re-equilibrates to the new boundary conditions, then outputs\n'
-            '          boundary and state at the end of each run.\n'
-            '        implementation: p2\n'
-            '    conduits:\n'
-            '      macro_state_in: macro.state_in\n'
-            '      micro_state_in: pad micro.state_in\n'
-            '      macro.boundary_out: micro.boundary_in\n'
-            '      micro.boundary_out: macro.boundary_in\n'
-            '      macro.state_out: macro_state_out\n'
-            '      micro.state_out: last micro_state_out\n'
-            '  init:\n'
-            '    ports:\n'
-            '      o_f: macro_state_out micro_state_out\n'
-            '    description: Creates initial states\n'
-            '    components:\n'
-            '      init_macro:\n'
-            '        ports:\n'
-            '          o_f: state_out\n'
-            '        description: Creates initial conditions for macro\n'
-            '        implementation: p3\n'
-            '      init_micro:\n'
-            '        ports:\n'
-            '          o_f: state_out\n'
-            '        description: Creates initial conditions for micro\n'
-            '        implementation: p4\n'
-            '    conduits:\n'
-            '      init_macro.state_out: macro_state_out\n'
-            '      init_micro.state_out: micro_state_out\n'
-            '  macro_micro_dispatch:\n'
-            '    description: |\n'
-            '      Creates initial conditions, the runs a model until conditions\n'
-            '      change and that model doesn\'t apply anymore, after which we\n'
-            '      pass the state to a second model to finish the calculation.\n'
-            '      Actually uses the same model twice, but maybe with different\n'
-            '      settings. Note that the model here is a closed box, we cannot\n'
-            '      tell that there is a macro-micro inside, other than from the name\n'
-            '      of the model and its ports.\n'
-            '    components:\n'
-            '      init:\n'
-            '        ports:\n'
-            '          o_f: macro_state_out micro_state_out\n'
-            '        description: Calculates initial conditions\n'
-            '        implementation: init\n'
-            '      first:\n'
-            '        ports:\n'
-            '          f_init: macro_state_in micro_state_in\n'
-            '          o_f: macro_state_out micro_state_out\n'
-            '        description: First macro-micro model\n'
-            '        implementation: macro_micro\n'
-            '      second:\n'
-            '        ports:\n'
-            '          f_init: macro_state_in micro_state_in\n'
-            '        description: First macro-micro model\n'
-            '        implementation: macro_micro\n'
-            '    conduits:\n'
-            '      init.macro_state_out: first.macro_state_in\n'
-            '      init.micro_state_out: first.micro_state_in\n'
-            '      first.macro_state_out: second.macro_state_in\n'
-            '      first.micro_state_out: second.micro_state_in\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Implements macro model\n'
-            '    executable: /home/user/codes/macro\n'
-            '  p2:\n'
-            '    description: Implements micro model\n'
-            '    executable: /home/user/codes/micro\n'
-            '  p3:\n'
-            '    description: Program that calculates initial conditions for macro\n'
-            '    executable: /home/user/codes/macro_ic\n'
-            '  p4:\n'
-            '    description: Program that calculates initial conditions for micro\n'
-            '    executable: /home/user/codes/micro_ic\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Macro-micro to macro-micro dispatch, nested\n"
+        "models:\n"
+        "  macro_micro:\n"
+        "    ports:\n"
+        "      f_init: macro_state_in micro_state_in\n"
+        "      o_f: macro_state_out micro_state_out\n"
+        "    description: Macro-micro model\n"
+        "    components:\n"
+        "      macro:\n"
+        "        ports:\n"
+        "          f_init: state_in\n"
+        "          o_i: boundary_out\n"
+        "          s: boundary_in\n"
+        "          o_f: state_out\n"
+        "        description: |\n"
+        "          Macro model that communicates its boundary conditions\n"
+        "          while running, and outputs its state at the end.\n"
+        "        implementation: p1\n"
+        "      micro:\n"
+        "        ports:\n"
+        "          f_init: state_in boundary_in\n"
+        "          o_f: state_out boundary_out\n"
+        "        description: |\n"
+        "          Stateful micro model that takes new boundary conditions and\n"
+        "          optionally a new state on each run. If a new state is received\n"
+        "          then it re-initialises, otherwise the current state is kept.\n"
+        "          Re-equilibrates to the new boundary conditions, then outputs\n"
+        "          boundary and state at the end of each run.\n"
+        "        implementation: p2\n"
+        "    conduits:\n"
+        "      macro_state_in: macro.state_in\n"
+        "      micro_state_in: pad micro.state_in\n"
+        "      macro.boundary_out: micro.boundary_in\n"
+        "      micro.boundary_out: macro.boundary_in\n"
+        "      macro.state_out: macro_state_out\n"
+        "      micro.state_out: last micro_state_out\n"
+        "  init:\n"
+        "    ports:\n"
+        "      o_f: macro_state_out micro_state_out\n"
+        "    description: Creates initial states\n"
+        "    components:\n"
+        "      init_macro:\n"
+        "        ports:\n"
+        "          o_f: state_out\n"
+        "        description: Creates initial conditions for macro\n"
+        "        implementation: p3\n"
+        "      init_micro:\n"
+        "        ports:\n"
+        "          o_f: state_out\n"
+        "        description: Creates initial conditions for micro\n"
+        "        implementation: p4\n"
+        "    conduits:\n"
+        "      init_macro.state_out: macro_state_out\n"
+        "      init_micro.state_out: micro_state_out\n"
+        "  macro_micro_dispatch:\n"
+        "    description: |\n"
+        "      Creates initial conditions, the runs a model until conditions\n"
+        "      change and that model doesn't apply anymore, after which we\n"
+        "      pass the state to a second model to finish the calculation.\n"
+        "      Actually uses the same model twice, but maybe with different\n"
+        "      settings. Note that the model here is a closed box, we cannot\n"
+        "      tell that there is a macro-micro inside, other than from the name\n"
+        "      of the model and its ports.\n"
+        "    components:\n"
+        "      init:\n"
+        "        ports:\n"
+        "          o_f: macro_state_out micro_state_out\n"
+        "        description: Calculates initial conditions\n"
+        "        implementation: init\n"
+        "      first:\n"
+        "        ports:\n"
+        "          f_init: macro_state_in micro_state_in\n"
+        "          o_f: macro_state_out micro_state_out\n"
+        "        description: First macro-micro model\n"
+        "        implementation: macro_micro\n"
+        "      second:\n"
+        "        ports:\n"
+        "          f_init: macro_state_in micro_state_in\n"
+        "        description: First macro-micro model\n"
+        "        implementation: macro_micro\n"
+        "    conduits:\n"
+        "      init.macro_state_out: first.macro_state_in\n"
+        "      init.micro_state_out: first.micro_state_in\n"
+        "      first.macro_state_out: second.macro_state_in\n"
+        "      first.micro_state_out: second.micro_state_in\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Implements macro model\n"
+        "    executable: /home/user/codes/macro\n"
+        "  p2:\n"
+        "    description: Implements micro model\n"
+        "    executable: /home/user/codes/micro\n"
+        "  p3:\n"
+        "    description: Program that calculates initial conditions for macro\n"
+        "    executable: /home/user/codes/macro_ic\n"
+        "  p4:\n"
+        "    description: Program that calculates initial conditions for micro\n"
+        "    executable: /home/user/codes/micro_ic\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'macro_micro_dispatch' in flat_config.models
+    assert "macro_micro_dispatch" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'macro_micro_dispatch'
+    assert model.name == "macro_micro_dispatch"
     assert len(model.components) == 6
-    assert 'init.init_macro' in model.components
-    assert 'init.init_micro' in model.components
-    assert 'first.macro' in model.components
-    assert 'first.micro' in model.components
-    assert 'second.macro' in model.components
-    assert 'second.micro' in model.components
+    assert "init.init_macro" in model.components
+    assert "init.init_micro" in model.components
+    assert "first.macro" in model.components
+    assert "first.micro" in model.components
+    assert "second.macro" in model.components
+    assert "second.micro" in model.components
 
     assert len(model.conduits) == 8
 
-    assert has_conduit(model, 'init.init_macro.state_out', 'first.macro.state_in')
+    assert has_conduit(model, "init.init_macro.state_out", "first.macro.state_in")
     assert has_conduit(
-            model, 'init.init_micro.state_out', 'first.micro.state_in', 'pad')
+        model, "init.init_micro.state_out", "first.micro.state_in", "pad"
+    )
 
-    assert has_conduit(model, 'first.macro.boundary_out', 'first.micro.boundary_in')
-    assert has_conduit(model, 'first.micro.boundary_out', 'first.macro.boundary_in')
+    assert has_conduit(model, "first.macro.boundary_out", "first.micro.boundary_in")
+    assert has_conduit(model, "first.micro.boundary_out", "first.macro.boundary_in")
 
-    assert has_conduit(model, 'first.macro.state_out', 'second.macro.state_in')
+    assert has_conduit(model, "first.macro.state_out", "second.macro.state_in")
     assert has_conduit(
-            model, 'first.micro.state_out', 'second.micro.state_in', 'last pad')
+        model, "first.micro.state_out", "second.micro.state_in", "last pad"
+    )
 
-    assert has_conduit(model, 'second.macro.boundary_out', 'second.micro.boundary_in')
-    assert has_conduit(model, 'second.micro.boundary_out', 'second.macro.boundary_in')
+    assert has_conduit(model, "second.macro.boundary_out", "second.micro.boundary_in")
+    assert has_conduit(model, "second.micro.boundary_out", "second.macro.boundary_in")
 
 
 def test_flatten_multicast() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Testing wiring of multicast conduits\n'
-            'models:\n'
-            '  outer:\n'
-            '    description: Model containing a submodel\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_f: out\n'
-            '        description: Sends some data\n'
-            '        implementation: p1\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out1 out2\n'
-            '        description: Submodel\n'
-            '        implementation: inner\n'
-            '      c3:\n'
-            '        ports:\n'
-            '          f_init: in1 in2 in3\n'
-            '        description: Receives some data\n'
-            '        implementation: p3\n'
-            '      c4:\n'
-            '        ports:\n'
-            '          f_init: in1 in2\n'
-            '        description: Receives some data\n'
-            '        implementation: p3\n'
-            '    conduits:\n'
-            '      c1.out:\n'
-            '      - c2.in\n'
-            '      - c3.in1\n'
-            '      c2.out1:\n'
-            '      - c3.in2\n'
-            '      - c4.in1\n'
-            '      c2.out2:\n'
-            '      - c3.in3\n'
-            '      - c4.in2\n'
-            '  inner:\n'
-            '    ports:\n'
-            '      f_init: in\n'
-            '      o_f: out1 out2\n'
-            '    description: Nested simulation model\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out\n'
-            '        description: Simulation program\n'
-            '        implementation: p2\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out\n'
-            '        description: Simulation program\n'
-            '        implementation: p2\n'
-            '    conduits:\n'
-            '      in:\n'
-            '      - c1.in\n'
-            '      - c2.in\n'
-            '      c1.out:\n'
-            '      - out1\n'
-            '      - out2\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Program that sends something\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Program that simulates stuff\n'
-            '    executable: /home/user/codes/p2\n'
-            '  p3:\n'
-            '    description: Program that receives some things\n'
-            '    executable: /home/user/codes/p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Testing wiring of multicast conduits\n"
+        "models:\n"
+        "  outer:\n"
+        "    description: Model containing a submodel\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_f: out\n"
+        "        description: Sends some data\n"
+        "        implementation: p1\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "          o_f: out1 out2\n"
+        "        description: Submodel\n"
+        "        implementation: inner\n"
+        "      c3:\n"
+        "        ports:\n"
+        "          f_init: in1 in2 in3\n"
+        "        description: Receives some data\n"
+        "        implementation: p3\n"
+        "      c4:\n"
+        "        ports:\n"
+        "          f_init: in1 in2\n"
+        "        description: Receives some data\n"
+        "        implementation: p3\n"
+        "    conduits:\n"
+        "      c1.out:\n"
+        "      - c2.in\n"
+        "      - c3.in1\n"
+        "      c2.out1:\n"
+        "      - c3.in2\n"
+        "      - c4.in1\n"
+        "      c2.out2:\n"
+        "      - c3.in3\n"
+        "      - c4.in2\n"
+        "  inner:\n"
+        "    ports:\n"
+        "      f_init: in\n"
+        "      o_f: out1 out2\n"
+        "    description: Nested simulation model\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "          o_f: out\n"
+        "        description: Simulation program\n"
+        "        implementation: p2\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "          o_f: out\n"
+        "        description: Simulation program\n"
+        "        implementation: p2\n"
+        "    conduits:\n"
+        "      in:\n"
+        "      - c1.in\n"
+        "      - c2.in\n"
+        "      c1.out:\n"
+        "      - out1\n"
+        "      - out2\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Program that sends something\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Program that simulates stuff\n"
+        "    executable: /home/user/codes/p2\n"
+        "  p3:\n"
+        "    description: Program that receives some things\n"
+        "    executable: /home/user/codes/p2\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'outer' in flat_config.models
+    assert "outer" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'outer'
+    assert model.name == "outer"
 
     assert len(model.components) == 5
-    assert 'c1' in model.components
-    assert 'c2.c1' in model.components
-    assert 'c2.c2' in model.components
-    assert 'c3' in model.components
-    assert 'c4' in model.components
+    assert "c1" in model.components
+    assert "c2.c1" in model.components
+    assert "c2.c2" in model.components
+    assert "c3" in model.components
+    assert "c4" in model.components
 
     assert len(model.conduits) == 7
-    assert has_conduit(model, 'c1.out', 'c3.in1')
-    assert has_conduit(model, 'c1.out', 'c2.c1.in')
-    assert has_conduit(model, 'c1.out', 'c2.c2.in')
-    assert has_conduit(model, 'c2.c1.out', 'c3.in2')
-    assert has_conduit(model, 'c2.c1.out', 'c4.in1')
-    assert has_conduit(model, 'c2.c1.out', 'c3.in3')
-    assert has_conduit(model, 'c2.c1.out', 'c4.in2')
+    assert has_conduit(model, "c1.out", "c3.in1")
+    assert has_conduit(model, "c1.out", "c2.c1.in")
+    assert has_conduit(model, "c1.out", "c2.c2.in")
+    assert has_conduit(model, "c2.c1.out", "c3.in2")
+    assert has_conduit(model, "c2.c1.out", "c4.in1")
+    assert has_conduit(model, "c2.c1.out", "c3.in3")
+    assert has_conduit(model, "c2.c1.out", "c4.in2")
 
 
 def test_flatten_passthrough_overload() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Testing model passthroughs and custom implementations\n'
-            'models:\n'
-            '  framework:\n'
-            '    description: Model with a passthrough\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_f: out\n'
-            '        description: Sends some data\n'
-            '        implementation: p1\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '          o_f: out\n'
-            '        description: Extension point\n'
-            '        implementation: passthrough\n'
-            '      c3:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '        description: Receives some data\n'
-            '        implementation: p3\n'
-            '    conduits:\n'
-            '      c1.out: c2.in\n'
-            '      c2.out: c3.in\n'
-            '  passthrough:\n'
-            '    ports:\n'
-            '      f_init: in\n'
-            '      o_f: out\n'
-            '    description: Passes through the message\n'
-            '    conduits:\n'
-            '      in: out\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Program that sends something\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Program that simulates stuff\n'
-            '    executable: /home/user/codes/p2\n'
-            '  p3:\n'
-            '    description: Program that receives some things\n'
-            '    executable: /home/user/codes/p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Testing model passthroughs and custom implementations\n"
+        "models:\n"
+        "  framework:\n"
+        "    description: Model with a passthrough\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_f: out\n"
+        "        description: Sends some data\n"
+        "        implementation: p1\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "          o_f: out\n"
+        "        description: Extension point\n"
+        "        implementation: passthrough\n"
+        "      c3:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "        description: Receives some data\n"
+        "        implementation: p3\n"
+        "    conduits:\n"
+        "      c1.out: c2.in\n"
+        "      c2.out: c3.in\n"
+        "  passthrough:\n"
+        "    ports:\n"
+        "      f_init: in\n"
+        "      o_f: out\n"
+        "    description: Passes through the message\n"
+        "    conduits:\n"
+        "      in: out\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Program that sends something\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Program that simulates stuff\n"
+        "    executable: /home/user/codes/p2\n"
+        "  p3:\n"
+        "    description: Program that receives some things\n"
+        "    executable: /home/user/codes/p2\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'framework' in flat_config.models
+    assert "framework" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'framework'
+    assert model.name == "framework"
 
     assert len(model.components) == 2
-    assert 'c1' in model.components
-    assert 'c3' in model.components
+    assert "c1" in model.components
+    assert "c3" in model.components
 
     assert len(model.conduits) == 1
-    assert has_conduit(model, 'c1.out', 'c3.in')
+    assert has_conduit(model, "c1.out", "c3.in")
 
     nested_config = load(nested_config_yaml)
-    nested_config.custom_implementations[Reference('framework.c2')] = Reference('p2')
-    resolve(Reference([]), nested_config)      # apply custom_implementations
+    nested_config.custom_implementations[Reference("framework.c2")] = Reference("p2")
+    resolve(Reference([]), nested_config)  # apply custom_implementations
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'framework' in flat_config.models
+    assert "framework" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'framework'
+    assert model.name == "framework"
 
     assert len(model.components) == 3
-    assert 'c1' in model.components
-    assert 'c2' in model.components
-    assert 'c3' in model.components
+    assert "c1" in model.components
+    assert "c2" in model.components
+    assert "c3" in model.components
 
     assert len(model.conduits) == 2
-    assert has_conduit(model, 'c1.out', 'c2.in')
-    assert has_conduit(model, 'c2.out', 'c3.in')
+    assert has_conduit(model, "c1.out", "c2.in")
+    assert has_conduit(model, "c2.out", "c3.in")
 
     assert len(flat_config.custom_implementations) == 0
-    assert model.components['c2'].implementation == 'p2'
+    assert model.components["c2"].implementation == "p2"
 
 
 # optional component without implementation
 def test_remove_no_implementation() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Testing a component without implementation\n'
-            'models:\n'
-            '  optional_micro:\n'
-            '    description: Macro-micro with optional micro\n'
-            '    components:\n'
-            '      macro:\n'
-            '        ports:\n'
-            '          o_i: out\n'
-            '          s: in\n'
-            '        description: |\n'
-            '          Macro model that can run with and without a micro.\n'
-            '        implementation: p1\n'
-            '      micro:\n'
-            '        ports:\n'
-            '          f_init: init\n'
-            '          o_f: final\n'
-            '        description: Optional micro model, not implemented\n'
-            '    conduits:\n'
-            '      macro.out: micro.init\n'
-            '      micro.final: macro.in\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Macro model implementation\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Micro model implementation\n'
-            '    executable: /home/user/codes/p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Testing a component without implementation\n"
+        "models:\n"
+        "  optional_micro:\n"
+        "    description: Macro-micro with optional micro\n"
+        "    components:\n"
+        "      macro:\n"
+        "        ports:\n"
+        "          o_i: out\n"
+        "          s: in\n"
+        "        description: |\n"
+        "          Macro model that can run with and without a micro.\n"
+        "        implementation: p1\n"
+        "      micro:\n"
+        "        ports:\n"
+        "          f_init: init\n"
+        "          o_f: final\n"
+        "        description: Optional micro model, not implemented\n"
+        "    conduits:\n"
+        "      macro.out: micro.init\n"
+        "      micro.final: macro.in\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Macro model implementation\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Micro model implementation\n"
+        "    executable: /home/user/codes/p2\n"
+    )
 
     nested_config = load(nested_config_yaml)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'optional_micro' in flat_config.models
+    assert "optional_micro" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'optional_micro'
+    assert model.name == "optional_micro"
 
     assert len(model.components) == 1
-    assert 'macro' in model.components
+    assert "macro" in model.components
 
     assert len(model.conduits) == 0
 
-    nested_config.custom_implementations[Reference('optional_micro.micro')] = \
-        Reference('p2')
+    nested_config.custom_implementations[Reference("optional_micro.micro")] = Reference(
+        "p2"
+    )
     resolve(Reference([]), nested_config)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'optional_micro' in flat_config.models
+    assert "optional_micro" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'optional_micro'
+    assert model.name == "optional_micro"
 
     assert len(model.components) == 2
-    assert 'macro' in model.components
-    assert 'micro' in model.components
+    assert "macro" in model.components
+    assert "micro" in model.components
 
     assert len(model.conduits) == 2
-    assert has_conduit(model, 'macro.out', 'micro.init')
-    assert has_conduit(model, 'micro.final', 'macro.in')
+    assert has_conduit(model, "macro.out", "micro.init")
+    assert has_conduit(model, "micro.final", "macro.in")
 
     assert len(flat_config.custom_implementations) == 0
-    assert model.components['micro'].implementation == 'p2'
+    assert model.components["micro"].implementation == "p2"
 
     nested_config = load(nested_config_yaml)
-    nested_config.models['optional_micro'].components['micro'].implementation = \
-        Reference('p2')
-    nested_config.custom_implementations[Reference('optional_micro.micro')] = None
+    nested_config.models["optional_micro"].components[
+        "micro"
+    ].implementation = Reference("p2")
+    nested_config.custom_implementations[Reference("optional_micro.micro")] = None
     resolve(Reference([]), nested_config)
     flat_config = flatten(nested_config)
 
     assert len(flat_config.models) == 1
-    assert 'optional_micro' in flat_config.models
+    assert "optional_micro" in flat_config.models
     model = flat_config.root_model()
-    assert model.name == 'optional_micro'
+    assert model.name == "optional_micro"
 
     assert len(model.components) == 1
-    assert 'macro' in model.components
+    assert "macro" in model.components
 
     assert len(model.conduits) == 0
 
 
 def test_nested_custom_implementations() -> None:
     nested_config_yaml = (
-            'ymmsl_version: v0.2\n'
-            'description: Testing nested custom implementations\n'
-            'models:\n'
-            '  outer:\n'
-            '    description: Outer model\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_f: out\n'
-            '        description: Component c1\n'
-            '        implementation: p1\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          f_init: in\n'
-            '        description: Component c1\n'
-            '        implementation: p1\n'
-            '    conduits:\n'
-            '      c1.out: c2.in\n'
-            '  middle:\n'
-            '    ports:\n'
-            '      o_f: out\n'
-            '    description: Middle model\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_f: out\n'
-            '        description: Another component c1\n'
-            '      c2:\n'
-            '        ports:\n'
-            '          o_f: out\n'
-            '        description: Component c2\n'
-            '    conduits:\n'
-            '      c2.out: out\n'
-            '  inner:\n'
-            '    ports:\n'
-            '      o_f: out\n'
-            '    description: Inner model\n'
-            '    components:\n'
-            '      c1:\n'
-            '        ports:\n'
-            '          o_f: out\n'
-            '        description: Yet another c1, it could happen...\n'
-            '        implementation: p1\n'
-            '    conduits:\n'
-            '      c1.out: out\n'
-            'programs:\n'
-            '  p1:\n'
-            '    description: Program 1\n'
-            '    executable: /home/user/codes/p1\n'
-            '  p2:\n'
-            '    description: Program 2\n'
-            '    executable: /home/user/codes/p2\n'
-            'custom_implementations:\n'
-            '  outer.c1: middle\n'
-            '  outer.c1.c1: inner\n'
-            '  outer.c1.c2: inner\n'
-            '  outer.c1.c2.c1: p2\n'
-            )
+        "ymmsl_version: v0.2\n"
+        "description: Testing nested custom implementations\n"
+        "models:\n"
+        "  outer:\n"
+        "    description: Outer model\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_f: out\n"
+        "        description: Component c1\n"
+        "        implementation: p1\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          f_init: in\n"
+        "        description: Component c1\n"
+        "        implementation: p1\n"
+        "    conduits:\n"
+        "      c1.out: c2.in\n"
+        "  middle:\n"
+        "    ports:\n"
+        "      o_f: out\n"
+        "    description: Middle model\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_f: out\n"
+        "        description: Another component c1\n"
+        "      c2:\n"
+        "        ports:\n"
+        "          o_f: out\n"
+        "        description: Component c2\n"
+        "    conduits:\n"
+        "      c2.out: out\n"
+        "  inner:\n"
+        "    ports:\n"
+        "      o_f: out\n"
+        "    description: Inner model\n"
+        "    components:\n"
+        "      c1:\n"
+        "        ports:\n"
+        "          o_f: out\n"
+        "        description: Yet another c1, it could happen...\n"
+        "        implementation: p1\n"
+        "    conduits:\n"
+        "      c1.out: out\n"
+        "programs:\n"
+        "  p1:\n"
+        "    description: Program 1\n"
+        "    executable: /home/user/codes/p1\n"
+        "  p2:\n"
+        "    description: Program 2\n"
+        "    executable: /home/user/codes/p2\n"
+        "custom_implementations:\n"
+        "  outer.c1: middle\n"
+        "  outer.c1.c1: inner\n"
+        "  outer.c1.c2: inner\n"
+        "  outer.c1.c2.c1: p2\n"
+    )
     nested_config = load(nested_config_yaml)
     resolve(Reference([]), nested_config)
     flat_config = flatten(nested_config)
 
-    flat_model = flat_config.models['outer']
+    flat_model = flat_config.models["outer"]
     assert len(flat_model.components) == 3
-    assert flat_model.components['c1.c1.c1'].implementation == 'p1'
-    assert flat_model.components['c1.c2.c1'].implementation == 'p2'
+    assert flat_model.components["c1.c1.c1"].implementation == "p1"
+    assert flat_model.components["c1.c2.c1"].implementation == "p2"
     assert len(flat_model.conduits) == 1
-    assert flat_model.conduits[0].sender == 'c1.c2.c1.out'
-    assert flat_model.conduits[0].receiver == 'c2.in'
+    assert flat_model.conduits[0].sender == "c1.c2.c1.out"
+    assert flat_model.conduits[0].receiver == "c2.in"

--- a/libmuscle/python/libmuscle/manager/test/test_instance_manager.py
+++ b/libmuscle/python/libmuscle/manager/test/test_instance_manager.py
@@ -1,4 +1,5 @@
 """Tests for InstanceManager with ExecutionModel.MANUAL support."""
+
 import logging
 from queue import Empty
 from unittest.mock import patch
@@ -67,8 +68,9 @@ def configuration() -> Configuration:
 class MockNativeInstantiator:
     """Mock for NativeInstantiator that records requests and returns fake results."""
 
-    def __init__(self, resources_queue, requests_queue, results_queue,
-                 log_records_queue, run_dir):
+    def __init__(
+        self, resources_queue, requests_queue, results_queue, log_records_queue, run_dir
+    ):
         self._resources_queue = resources_queue
         self._requests_queue = requests_queue
 
@@ -76,7 +78,7 @@ class MockNativeInstantiator:
         # Send fake resources
         resources = Resources()
         cores = CoreSet([Core(i, {i}) for i in range(4)])
-        node = OnNodeResources('localhost', cores)
+        node = OnNodeResources("localhost", cores)
         resources.add_node(node)
         self._resources_queue.put(resources)
 
@@ -87,14 +89,13 @@ class MockNativeInstantiator:
 def test_start_all_skips_manual_instances(tmp_path, caplog, configuration):
     """Test that start_all() skips instances with ExecutionModel.MANUAL."""
     instance_registry = InstanceRegistry()
-    run_dir = RunDir(tmp_path / 'run')
+    run_dir = RunDir(tmp_path / "run")
 
     with patch(
-        'libmuscle.manager.instance_manager.NativeInstantiator',
-        MockNativeInstantiator
+        "libmuscle.manager.instance_manager.NativeInstantiator", MockNativeInstantiator
     ):
         instance_manager = InstanceManager(configuration, run_dir, instance_registry)
-        instance_manager.set_manager_location('localhost:9000')
+        instance_manager.set_manager_location("localhost:9000")
 
         with caplog.at_level(logging.INFO):
             instance_manager.start_all()
@@ -105,11 +106,12 @@ def test_start_all_skips_manual_instances(tmp_path, caplog, configuration):
         instance_manager.shutdown()
 
         assert isinstance(request, InstantiationRequest)
-        assert request.instance == Reference('micro')
+        assert request.instance == Reference("micro")
 
         manual_log_messages = [
-            r.message for r in caplog.records
-            if 'macro' in r.message and 'manual' in r.message.lower()
+            r.message
+            for r in caplog.records
+            if "macro" in r.message and "manual" in r.message.lower()
         ]
         assert len(manual_log_messages) > 0
 
@@ -117,14 +119,13 @@ def test_start_all_skips_manual_instances(tmp_path, caplog, configuration):
 def test_manual_instances_not_counted_in_num_running(tmp_path, configuration):
     """Test that MANUAL instances are not counted in _num_running."""
     instance_registry = InstanceRegistry()
-    run_dir = RunDir(tmp_path / 'run')
+    run_dir = RunDir(tmp_path / "run")
 
     with patch(
-        'libmuscle.manager.instance_manager.NativeInstantiator',
-        MockNativeInstantiator
+        "libmuscle.manager.instance_manager.NativeInstantiator", MockNativeInstantiator
     ):
         instance_manager = InstanceManager(configuration, run_dir, instance_registry)
-        instance_manager.set_manager_location('localhost:9000')
+        instance_manager.set_manager_location("localhost:9000")
         instance_manager.start_all()
         num_running = instance_manager._num_running
         instance_manager.shutdown()

--- a/libmuscle/python/libmuscle/manager/test/test_instance_registry.py
+++ b/libmuscle/python/libmuscle/manager/test/test_instance_registry.py
@@ -6,7 +6,7 @@ from libmuscle.manager.instance_registry import InstanceRegistry, Port
 
 @pytest.fixture
 def port():
-    return Port('test_port', Operator.F_INIT)
+    return Port("test_port", Operator.F_INIT)
 
 
 @pytest.fixture
@@ -15,38 +15,35 @@ def registry():
 
 
 def test_port(port):
-    assert port.name == 'test_port'
+    assert port.name == "test_port"
     assert port.operator == Operator.F_INIT
 
 
 def test_registry_add(registry, port):
-    registry.add('instance1', 'tcp://localhost:6253', [port])
-    assert (registry._locations['instance1'] ==
-            'tcp://localhost:6253')
-    assert registry._ports['instance1'] == [port]
+    registry.add("instance1", "tcp://localhost:6253", [port])
+    assert registry._locations["instance1"] == "tcp://localhost:6253"
+    assert registry._ports["instance1"] == [port]
 
 
 def test_registry_get(registry, port):
-    registry._locations['instance1'] = [
-            'tcp://localhost:6253']
-    registry._ports['instance1'] = [port]
-    assert registry.get_locations('instance1') == ['tcp://localhost:6253']
-    assert registry.get_ports('instance1') == [port]
+    registry._locations["instance1"] = ["tcp://localhost:6253"]
+    registry._ports["instance1"] = [port]
+    assert registry.get_locations("instance1") == ["tcp://localhost:6253"]
+    assert registry.get_ports("instance1") == [port]
 
     with pytest.raises(KeyError):
-        registry.get_locations('non-existant-instance')
+        registry.get_locations("non-existant-instance")
 
     with pytest.raises(KeyError):
-        registry.get_ports('non-existant-instance')
+        registry.get_ports("non-existant-instance")
 
 
 def test_registry_remove(registry, port):
-    registry._locations['instance1'] = [
-            'tcp://localhost:6253']
-    registry._ports['instance1'] = [port]
-    registry.remove('instance1')
-    assert 'instance1' not in registry._locations
-    assert 'instance1' not in registry._ports
+    registry._locations["instance1"] = ["tcp://localhost:6253"]
+    registry._ports["instance1"] = [port]
+    registry.remove("instance1")
+    assert "instance1" not in registry._locations
+    assert "instance1" not in registry._ports
 
     with pytest.raises(KeyError):
-        registry.remove('non-existant-instance')
+        registry.remove("non-existant-instance")

--- a/libmuscle/python/libmuscle/manager/test/test_logger.py
+++ b/libmuscle/python/libmuscle/manager/test/test_logger.py
@@ -17,9 +17,12 @@ def test_create_logger(tmpdir):
 
 def test_log_message(logger, caplog):
     logger.log_message(
-            'test_instance', Timestamp(123.0),
-            LogLevel.CRITICAL, 'Testing the logging system')
+        "test_instance",
+        Timestamp(123.0),
+        LogLevel.CRITICAL,
+        "Testing the logging system",
+    )
 
-    assert caplog.records[0].name == 'test_instance'
-    assert caplog.records[0].levelname == 'CRITICAL'
-    assert caplog.records[0].message == 'Testing the logging system'
+    assert caplog.records[0].name == "test_instance"
+    assert caplog.records[0].levelname == "CRITICAL"
+    assert caplog.records[0].message == "Testing the logging system"

--- a/libmuscle/python/libmuscle/manager/test/test_mmp_request_handler.py
+++ b/libmuscle/python/libmuscle/manager/test/test_mmp_request_handler.py
@@ -19,18 +19,34 @@ from libmuscle.snapshot import SnapshotMetadata
 
 
 def test_create_servicer(
-        logger, profile_store, mmp_configuration, instance_registry,
-        topology_store, snapshot_registry, deadlock_detector):
+    logger,
+    profile_store,
+    mmp_configuration,
+    instance_registry,
+    topology_store,
+    snapshot_registry,
+    deadlock_detector,
+):
     MMPRequestHandler(
-            logger, profile_store, mmp_configuration, instance_registry,
-            topology_store, snapshot_registry, deadlock_detector, None)
+        logger,
+        profile_store,
+        mmp_configuration,
+        instance_registry,
+        topology_store,
+        snapshot_registry,
+        deadlock_detector,
+        None,
+    )
 
 
 def test_log_message(mmp_request_handler, caplog):
     request = [
-            RequestType.SUBMIT_LOG_MESSAGE.value,
-            'test_instance_id', 0.0, LogLevel.WARNING.value,
-            'Testing log message']
+        RequestType.SUBMIT_LOG_MESSAGE.value,
+        "test_instance_id",
+        0.0,
+        LogLevel.WARNING.value,
+        "Testing log message",
+    ]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
@@ -41,9 +57,9 @@ def test_log_message(mmp_request_handler, caplog):
     assert len(decoded_result) == 1
     assert decoded_result[0] == ResponseType.SUCCESS.value
 
-    assert caplog.records[0].name == 'test_instance_id'
-    assert caplog.records[0].levelname == 'WARNING'
-    assert caplog.records[0].message == 'Testing log message'
+    assert caplog.records[0].name == "test_instance_id"
+    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].message == "Testing log message"
 
 
 def test_get_settings(mmp_configuration, mmp_request_handler):
@@ -57,12 +73,12 @@ def test_get_settings(mmp_configuration, mmp_request_handler):
     assert decoded_result[0] == ResponseType.SUCCESS.value
     assert decoded_result[1] == {}
 
-    mmp_configuration.settings['test1'] = 13
-    mmp_configuration.settings['test2'] = 12.3
-    mmp_configuration.settings['test3'] = 'testing'
-    mmp_configuration.settings['test4'] = True
-    mmp_configuration.settings['test5'] = [2.3, 7.4]
-    mmp_configuration.settings['test6'] = [[1.0, 2.0], [2.0, 1.0]]
+    mmp_configuration.settings["test1"] = 13
+    mmp_configuration.settings["test2"] = 12.3
+    mmp_configuration.settings["test3"] = "testing"
+    mmp_configuration.settings["test4"] = True
+    mmp_configuration.settings["test5"] = [2.3, 7.4]
+    mmp_configuration.settings["test6"] = [[1.0, 2.0], [2.0, 1.0]]
 
     result = mmp_request_handler.handle_request(encoded_request)
     decoded_result = msgpack.unpackb(result, raw=False)
@@ -72,75 +88,77 @@ def test_get_settings(mmp_configuration, mmp_request_handler):
     result_dict = decoded_result[1]
     assert len(result_dict) == 6
 
-    assert result_dict['test1'] == 13
-    assert result_dict['test2'] == 12.3
-    assert result_dict['test3'] == 'testing'
-    assert result_dict['test4'] is True
-    assert result_dict['test5'] == [2.3, 7.4]
-    assert result_dict['test6'] == [[1.0, 2.0], [2.0, 1.0]]
+    assert result_dict["test1"] == 13
+    assert result_dict["test2"] == 12.3
+    assert result_dict["test3"] == "testing"
+    assert result_dict["test4"] is True
+    assert result_dict["test5"] == [2.3, 7.4]
+    assert result_dict["test6"] == [[1.0, 2.0], [2.0, 1.0]]
     assert result_dict == mmp_configuration.settings.as_ordered_dict()
 
 
 def test_register_instance(mmp_request_handler, instance_registry):
     request = [
-            RequestType.REGISTER_INSTANCE.value,
-            'test_instance',
-            ['tcp://localhost:10000'],
-            [['test_in', 'F_INIT']],
-            libmuscle.__version__]
+        RequestType.REGISTER_INSTANCE.value,
+        "test_instance",
+        ["tcp://localhost:10000"],
+        [["test_in", "F_INIT"]],
+        libmuscle.__version__,
+    ]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
     decoded_result = msgpack.unpackb(result, raw=False)
 
     assert decoded_result[0] == ResponseType.SUCCESS.value
-    assert (instance_registry._locations['test_instance'] ==
-            ['tcp://localhost:10000'])
+    assert instance_registry._locations["test_instance"] == ["tcp://localhost:10000"]
 
     registered_ports = instance_registry._ports
-    assert registered_ports['test_instance'][0].name == 'test_in'
-    assert registered_ports['test_instance'][0].operator == Operator.F_INIT
+    assert registered_ports["test_instance"][0].name == "test_in"
+    assert registered_ports["test_instance"][0].operator == Operator.F_INIT
 
 
 def test_register_instance_no_version(mmp_request_handler):
     request = [
-            RequestType.REGISTER_INSTANCE.value,
-            'test_instance',
-            ['tcp://localhost:10000'],
-            [['test_in', 'F_INIT']]]
+        RequestType.REGISTER_INSTANCE.value,
+        "test_instance",
+        ["tcp://localhost:10000"],
+        [["test_in", "F_INIT"]],
+    ]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
     decoded_result = msgpack.unpackb(result, raw=False)
 
     assert decoded_result[0] == ResponseType.ERROR.value
-    assert 'version' in decoded_result[1]
+    assert "version" in decoded_result[1]
 
 
 def test_register_instance_version_mismatch(mmp_request_handler):
     request = [
-            RequestType.REGISTER_INSTANCE.value,
-            'test_instance',
-            ['tcp://localhost:10000'],
-            [['test_in', 'F_INIT']],
-            libmuscle.__version__ + "dev"]
+        RequestType.REGISTER_INSTANCE.value,
+        "test_instance",
+        ["tcp://localhost:10000"],
+        [["test_in", "F_INIT"]],
+        libmuscle.__version__ + "dev",
+    ]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
     decoded_result = msgpack.unpackb(result, raw=False)
 
     assert decoded_result[0] == ResponseType.ERROR.value
-    assert 'version' in decoded_result[1]
+    assert "version" in decoded_result[1]
 
 
 def test_get_checkpoint_info(mmp_configuration, mmp_request_handler):
-    resume_path = Path('/path/to/resume.pack')
-    mmp_configuration.resume = {Reference('test_instance'): resume_path}
+    resume_path = Path("/path/to/resume.pack")
+    mmp_configuration.resume = {Reference("test_instance"): resume_path}
     mmp_configuration.checkpoints = Checkpoints(
-            True,
-            [CheckpointRangeRule(every=10), CheckpointAtRule([1, 2, 3.0])])
+        True, [CheckpointRangeRule(every=10), CheckpointAtRule([1, 2, 3.0])]
+    )
 
-    request = [RequestType.GET_CHECKPOINT_INFO.value, 'test_instance']
+    request = [RequestType.GET_CHECKPOINT_INFO.value, "test_instance"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
@@ -152,17 +170,17 @@ def test_get_checkpoint_info(mmp_configuration, mmp_request_handler):
     assert elapsed_time > 0.0
 
     assert isinstance(checkpoints, dict)
-    assert checkpoints.keys() == {'at_end', 'wallclock_time', 'simulation_time'}
-    assert checkpoints['at_end'] is True
-    assert checkpoints['simulation_time'] == []
-    wallclock_time = checkpoints['wallclock_time']
+    assert checkpoints.keys() == {"at_end", "wallclock_time", "simulation_time"}
+    assert checkpoints["at_end"] is True
+    assert checkpoints["simulation_time"] == []
+    wallclock_time = checkpoints["wallclock_time"]
     assert len(wallclock_time) == 2
-    assert wallclock_time[0] == {'start': None, 'stop': None, 'every': 10}
-    assert all(isinstance(obj, (type(None), float))
-               for obj in wallclock_time[0].values())
-    assert wallclock_time[1] == {'at': [1, 2, 3.0]}
-    assert all(isinstance(obj, (type(None), float))
-               for obj in wallclock_time[1]['at'])
+    assert wallclock_time[0] == {"start": None, "stop": None, "every": 10}
+    assert all(
+        isinstance(obj, (type(None), float)) for obj in wallclock_time[0].values()
+    )
+    assert wallclock_time[1] == {"at": [1, 2, 3.0]}
+    assert all(isinstance(obj, (type(None), float)) for obj in wallclock_time[1]["at"])
 
     assert resume is not None
     assert Path(resume) == resume_path
@@ -171,7 +189,7 @@ def test_get_checkpoint_info(mmp_configuration, mmp_request_handler):
 
 
 def test_get_checkpoint_info2(registered_mmp_request_handler2, tmp_path):
-    request = [RequestType.GET_CHECKPOINT_INFO.value, 'test_instance']
+    request = [RequestType.GET_CHECKPOINT_INFO.value, "test_instance"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler2.handle_request(encoded_request)
@@ -179,17 +197,17 @@ def test_get_checkpoint_info2(registered_mmp_request_handler2, tmp_path):
 
     assert decoded_result[0] == ResponseType.SUCCESS.value
     snapshot_directory = decoded_result[4]
-    assert snapshot_directory == (
-            str(tmp_path) + '/instances/test_instance/snapshots')
+    assert snapshot_directory == (str(tmp_path) + "/instances/test_instance/snapshots")
 
 
 def test_double_register_instance(mmp_request_handler):
     request = [
-            RequestType.REGISTER_INSTANCE.value,
-            'test_instance',
-            ['tcp://localhost:10000'],
-            [['test_in', 'F_INIT']],
-            libmuscle.__version__]
+        RequestType.REGISTER_INSTANCE.value,
+        "test_instance",
+        ["tcp://localhost:10000"],
+        [["test_in", "F_INIT"]],
+        libmuscle.__version__,
+    ]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
@@ -201,25 +219,24 @@ def test_double_register_instance(mmp_request_handler):
     decoded_result = msgpack.unpackb(result, raw=False)
 
     assert decoded_result[0] == ResponseType.ERROR.value
-    assert 'test_instance' in decoded_result[1]
+    assert "test_instance" in decoded_result[1]
 
 
-def test_deregister_instance(
-        registered_mmp_request_handler, instance_registry):
-    assert Reference('macro') in instance_registry._locations
+def test_deregister_instance(registered_mmp_request_handler, instance_registry):
+    assert Reference("macro") in instance_registry._locations
 
-    request = [RequestType.DEREGISTER_INSTANCE.value, 'macro']
+    request = [RequestType.DEREGISTER_INSTANCE.value, "macro"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler.handle_request(encoded_request)
     decoded_result = msgpack.unpackb(result, raw=False)
 
     assert decoded_result[0] == ResponseType.SUCCESS.value
-    assert Reference('macro') not in instance_registry._locations
+    assert Reference("macro") not in instance_registry._locations
 
 
 def test_get_peers_pending(mmp_request_handler):
-    request = [RequestType.GET_PEERS.value, 'micro[0][0]']
+    request = [RequestType.GET_PEERS.value, "micro[0][0]"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = mmp_request_handler.handle_request(encoded_request)
@@ -229,7 +246,7 @@ def test_get_peers_pending(mmp_request_handler):
 
 
 def test_request_peers_fanout(registered_mmp_request_handler):
-    request = [RequestType.GET_PEERS.value, 'macro']
+    request = [RequestType.GET_PEERS.value, "macro"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler.handle_request(encoded_request)
@@ -238,22 +255,22 @@ def test_request_peers_fanout(registered_mmp_request_handler):
     status, conduits, dims, locations, ports = decoded_result
     assert status == ResponseType.SUCCESS.value
 
-    assert conduits[0][0] == 'macro.out'
-    assert conduits[0][1] == 'micro.in'
-    assert conduits[1][0] == 'micro.out'
-    assert conduits[1][1] == 'macro.in'
+    assert conduits[0][0] == "macro.out"
+    assert conduits[0][1] == "micro.in"
+    assert conduits[1][0] == "micro.out"
+    assert conduits[1][1] == "macro.in"
 
-    assert dims['micro'] == [10, 10]
+    assert dims["micro"] == [10, 10]
 
     for i, (name, locs) in enumerate(locations.items()):
-        assert name == f'micro[{i // 10}][{i % 10}]'
-        assert locs == [f'direct:{name}']
+        assert name == f"micro[{i // 10}][{i % 10}]"
+        assert locs == [f"direct:{name}"]
 
     assert ports == [["out", "O_I"], ["in", "S"]]
 
 
 def test_request_peers_fanin(registered_mmp_request_handler):
-    request = [RequestType.GET_PEERS.value, 'micro[4][3]']
+    request = [RequestType.GET_PEERS.value, "micro[4][3]"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler.handle_request(encoded_request)
@@ -262,20 +279,20 @@ def test_request_peers_fanin(registered_mmp_request_handler):
     status, conduits, dims, locations, ports = decoded_result
     assert status == ResponseType.SUCCESS.value
 
-    assert conduits[0][0] == 'macro.out'
-    assert conduits[0][1] == 'micro.in'
-    assert conduits[1][0] == 'micro.out'
-    assert conduits[1][1] == 'macro.in'
+    assert conduits[0][0] == "macro.out"
+    assert conduits[0][1] == "micro.in"
+    assert conduits[1][0] == "micro.out"
+    assert conduits[1][1] == "macro.in"
 
-    assert dims['macro'] == []
+    assert dims["macro"] == []
 
-    assert locations['macro'] == ['direct:macro']
+    assert locations["macro"] == ["direct:macro"]
 
     assert ports == [["in", "F_INIT"], ["out", "O_F"]]
 
 
 def test_request_peers_bidir(registered_mmp_request_handler2):
-    request = [RequestType.GET_PEERS.value, 'meso[2]']
+    request = [RequestType.GET_PEERS.value, "meso[2]"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler2.handle_request(encoded_request)
@@ -284,29 +301,29 @@ def test_request_peers_bidir(registered_mmp_request_handler2):
     status, conduits, dims, locations, ports = decoded_result
     assert status == ResponseType.SUCCESS.value
 
-    assert conduits[0][0] == 'macro.out'
-    assert conduits[0][1] == 'meso.init'
-    assert conduits[1][0] == 'meso.out'
-    assert conduits[1][1] == 'micro.init'
-    assert conduits[2][0] == 'micro.final'
-    assert conduits[2][1] == 'meso.in'
-    assert conduits[3][0] == 'meso.final'
-    assert conduits[3][1] == 'macro.in'
+    assert conduits[0][0] == "macro.out"
+    assert conduits[0][1] == "meso.init"
+    assert conduits[1][0] == "meso.out"
+    assert conduits[1][1] == "micro.init"
+    assert conduits[2][0] == "micro.final"
+    assert conduits[2][1] == "meso.in"
+    assert conduits[3][0] == "meso.final"
+    assert conduits[3][1] == "macro.in"
 
-    assert dims['micro'] == [5, 10]
-    assert dims['macro'] == []
+    assert dims["micro"] == [5, 10]
+    assert dims["macro"] == []
 
-    assert locations['macro'] == ['direct:macro']
+    assert locations["macro"] == ["direct:macro"]
 
-    assert locations['macro'] == ['direct:macro']
+    assert locations["macro"] == ["direct:macro"]
     for i in range(10):
-        assert locations[f'micro[2][{i}]'] == [f'direct:micro[2][{i}]']
+        assert locations[f"micro[2][{i}]"] == [f"direct:micro[2][{i}]"]
 
     assert ports == [["init", "F_INIT"], ["out", "O_I"], ["in", "S"], ["final", "O_F"]]
 
 
 def test_request_peers_own_conduits(registered_mmp_request_handler2):
-    request = [RequestType.GET_PEERS.value, 'macro']
+    request = [RequestType.GET_PEERS.value, "macro"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler2.handle_request(encoded_request)
@@ -315,16 +332,16 @@ def test_request_peers_own_conduits(registered_mmp_request_handler2):
     status, conduits, dims, locations, ports = decoded_result
     assert status == ResponseType.SUCCESS.value
 
-    assert conduits[0][0] == 'macro.out'
-    assert conduits[0][1] == 'meso.init'
-    assert conduits[1][0] == 'meso.final'
-    assert conduits[1][1] == 'macro.in'
+    assert conduits[0][0] == "macro.out"
+    assert conduits[0][1] == "meso.init"
+    assert conduits[1][0] == "meso.final"
+    assert conduits[1][1] == "macro.in"
 
     assert ports == [["out", "O_I"], ["in", "S"]]
 
 
 def test_request_peers_unknown(registered_mmp_request_handler2):
-    request = [RequestType.GET_PEERS.value, 'does_not_exist']
+    request = [RequestType.GET_PEERS.value, "does_not_exist"]
     encoded_request = msgpack.packb(request, use_bin_type=True)
 
     result = registered_mmp_request_handler2.handle_request(encoded_request)
@@ -333,18 +350,19 @@ def test_request_peers_unknown(registered_mmp_request_handler2):
     status, error_msg = decoded_result
     assert status == ResponseType.ERROR.value
     assert error_msg is not None
-    assert 'does_not_exist' in error_msg
+    assert "does_not_exist" in error_msg
 
 
 def test_submit_snapshot(registered_mmp_request_handler):
     register_snapshot = MagicMock()
-    registered_mmp_request_handler._snapshot_registry.register_snapshot = \
+    registered_mmp_request_handler._snapshot_registry.register_snapshot = (
         register_snapshot
+    )
 
-    instance_id = 'micro[1][2]'
+    instance_id = "micro[1][2]"
     snapshot = SnapshotMetadata(
-            ['1', '2'], 1.234, 2.345, 3.456,
-            {'in': [1], 'out': [0]}, True, 'fname')
+        ["1", "2"], 1.234, 2.345, 3.456, {"in": [1], "out": [0]}, True, "fname"
+    )
     snapshot_dict = dataclasses.asdict(snapshot)
 
     request = [RequestType.SUBMIT_SNAPSHOT.value, instance_id, snapshot_dict]

--- a/libmuscle/python/libmuscle/manager/test/test_profile_database.py
+++ b/libmuscle/python/libmuscle/manager/test/test_profile_database.py
@@ -13,67 +13,134 @@ from libmuscle.test.conftest import on_node_resources as onr
 
 @pytest.fixture
 def db_file(tmp_path) -> Path:
-    with patch('libmuscle.manager.profile_store._SYNCHED', True):
+    with patch("libmuscle.manager.profile_store._SYNCHED", True):
         store = ProfileStore(tmp_path)
         t1 = ProfileTimestamp()
 
-        store.store_instances([Reference('instance1'), Reference('instance2')])
+        store.store_instances([Reference("instance1"), Reference("instance2")])
 
-        resources1 = ResourceAssignment([
-            onr('node001', {0, 1}), onr('node002', {0, 1})])
+        resources1 = ResourceAssignment(
+            [onr("node001", {0, 1}), onr("node002", {0, 1})]
+        )
 
-        resources2 = ResourceAssignment([
-            onr('node001', {0}), onr('node002', {0, 1, 2})])
+        resources2 = ResourceAssignment(
+            [onr("node001", {0}), onr("node002", {0, 1, 2})]
+        )
 
-        store.store_resources({
-            Reference('instance1'): resources1,
-            Reference('instance2'): resources2})
+        store.store_resources(
+            {Reference("instance1"): resources1, Reference("instance2"): resources2}
+        )
 
         def t(offset: int) -> ProfileTimestamp:
             return ProfileTimestamp(t1.nanoseconds + offset)
 
         e1 = [
-                ProfileEvent(ProfileEventType.REGISTER, t(0), t(1000)),
-                ProfileEvent(ProfileEventType.CONNECT, t(1000), t(2000)),
-                ProfileEvent(
-                    ProfileEventType.SEND, t(2000), t(2100),
-                    Port('out', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.SEND, t(2200), t(2400),
-                    Port('out', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.SEND, t(2600), t(2900),
-                    Port('out', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, t(10000), t(11000)),
-                ProfileEvent(ProfileEventType.DEREGISTER, t(11000), t(11100))]
+            ProfileEvent(ProfileEventType.REGISTER, t(0), t(1000)),
+            ProfileEvent(ProfileEventType.CONNECT, t(1000), t(2000)),
+            ProfileEvent(
+                ProfileEventType.SEND,
+                t(2000),
+                t(2100),
+                Port("out", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.SEND,
+                t(2200),
+                t(2400),
+                Port("out", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.SEND,
+                t(2600),
+                t(2900),
+                Port("out", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, t(10000), t(11000)),
+            ProfileEvent(ProfileEventType.DEREGISTER, t(11000), t(11100)),
+        ]
 
-        store.add_events(Reference('instance1'), e1)
+        store.add_events(Reference("instance1"), e1)
 
         e2 = [
-                ProfileEvent(ProfileEventType.REGISTER, t(0), t(800)),
-                ProfileEvent(ProfileEventType.CONNECT, t(800), t(1600)),
-                ProfileEvent(
-                    ProfileEventType.RECEIVE, t(2000), t(2100),
-                    Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.RECEIVE_WAIT, t(2000), t(2090),
-                    Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.RECEIVE, t(2200), t(2400),
-                    Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.RECEIVE_WAIT, t(2200), t(2380),
-                    Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.RECEIVE, t(2600), t(2900),
-                    Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(
-                    ProfileEventType.RECEIVE_WAIT, t(2600), t(2870),
-                    Port('in', Operator.O_I), None, None, 1000000, 0.0),
-                ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, t(10000), t(11000)),
-                ProfileEvent(ProfileEventType.DEREGISTER, t(11000), t(11100))]
+            ProfileEvent(ProfileEventType.REGISTER, t(0), t(800)),
+            ProfileEvent(ProfileEventType.CONNECT, t(800), t(1600)),
+            ProfileEvent(
+                ProfileEventType.RECEIVE,
+                t(2000),
+                t(2100),
+                Port("in", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.RECEIVE_WAIT,
+                t(2000),
+                t(2090),
+                Port("in", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.RECEIVE,
+                t(2200),
+                t(2400),
+                Port("in", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.RECEIVE_WAIT,
+                t(2200),
+                t(2380),
+                Port("in", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.RECEIVE,
+                t(2600),
+                t(2900),
+                Port("in", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(
+                ProfileEventType.RECEIVE_WAIT,
+                t(2600),
+                t(2870),
+                Port("in", Operator.O_I),
+                None,
+                None,
+                1000000,
+                0.0,
+            ),
+            ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, t(10000), t(11000)),
+            ProfileEvent(ProfileEventType.DEREGISTER, t(11000), t(11100)),
+        ]
 
-        store.add_events(Reference('instance2'), e2)
+        store.add_events(Reference("instance2"), e2)
 
         db_file = store._db_file
         store.shutdown()
@@ -84,12 +151,12 @@ def db_file(tmp_path) -> Path:
 def test_instance_stats(db_file):
     with ProfileDatabase(db_file) as db:
         instances, run_time, comm_time, wait_time = db.instance_stats()
-        assert set(instances) == {'instance1', 'instance2'}
-        i1 = instances.index('instance1')
+        assert set(instances) == {"instance1", "instance2"}
+        i1 = instances.index("instance1")
         assert run_time[i1] == pytest.approx(7400.0 * 1e-9)
         assert comm_time[i1] == pytest.approx(600.0 * 1e-9)
         assert wait_time[i1] == 0.0
-        i2 = instances.index('instance2')
+        i2 = instances.index("instance2")
         assert run_time[i2] == pytest.approx(7800.0 * 1e-9)
         assert comm_time[i2] == pytest.approx(60.0 * 1e-9)
         assert wait_time[i2] == pytest.approx(540.0 * 1e-9)
@@ -98,38 +165,44 @@ def test_instance_stats(db_file):
 def test_resource_stats(db_file):
     with ProfileDatabase(db_file) as db:
         stats = db.resource_stats()
-        assert set(stats.keys()) == set([
-            'node001:0', 'node001:1',
-            'node002:0', 'node002:1', 'node002:2'])
+        assert set(stats.keys()) == set(
+            ["node001:0", "node001:1", "node002:0", "node002:1", "node002:2"]
+        )
 
-        assert stats['node001:0'] == {
-                'instance1': 8000.0 * 1e-9,
-                'instance2': 7860.0 * 1e-9}
+        assert stats["node001:0"] == {
+            "instance1": 8000.0 * 1e-9,
+            "instance2": 7860.0 * 1e-9,
+        }
 
-        assert stats['node001:1'] == {
-                'instance1': 8000.0 * 1e-9}
+        assert stats["node001:1"] == {"instance1": 8000.0 * 1e-9}
 
-        assert stats['node002:0'] == {
-                'instance1': 8000.0 * 1e-9,
-                'instance2': 7860.0 * 1e-9}
+        assert stats["node002:0"] == {
+            "instance1": 8000.0 * 1e-9,
+            "instance2": 7860.0 * 1e-9,
+        }
 
-        assert stats['node002:1'] == {
-                'instance1': 8000.0 * 1e-9,
-                'instance2': 7860.0 * 1e-9}
+        assert stats["node002:1"] == {
+            "instance1": 8000.0 * 1e-9,
+            "instance2": 7860.0 * 1e-9,
+        }
 
-        assert stats['node002:2'] == {
-                'instance2': 7860.0 * 1e-9}
+        assert stats["node002:2"] == {"instance2": 7860.0 * 1e-9}
 
 
 def test_time_taken(db_file):
     with ProfileDatabase(db_file) as db:
-        assert 1000.0 == db.time_taken(etype='REGISTER', instance='instance1')
-        assert 100.0 == db.time_taken(etype='DEREGISTER')
+        assert 1000.0 == db.time_taken(etype="REGISTER", instance="instance1")
+        assert 100.0 == db.time_taken(etype="DEREGISTER")
         assert 11100.0 == db.time_taken(
-                etype='REGISTER', instance='instance1', etype2='DEREGISTER')
+            etype="REGISTER", instance="instance1", etype2="DEREGISTER"
+        )
         assert 10000.0 == db.time_taken(
-                etype='REGISTER', instance='instance1', time='stop',
-                etype2='DEREGISTER', time2='start')
-        assert 200.0 == db.time_taken(etype='SEND')
-        assert 200.0 == db.time_taken(etype='DEREGISTER', aggregate='sum')
-        assert 600.0 == db.time_taken(etype='SEND', aggregate='sum')
+            etype="REGISTER",
+            instance="instance1",
+            time="stop",
+            etype2="DEREGISTER",
+            time2="start",
+        )
+        assert 200.0 == db.time_taken(etype="SEND")
+        assert 200.0 == db.time_taken(etype="DEREGISTER", aggregate="sum")
+        assert 600.0 == db.time_taken(etype="SEND", aggregate="sum")

--- a/libmuscle/python/libmuscle/manager/test/test_profile_store.py
+++ b/libmuscle/python/libmuscle/manager/test/test_profile_store.py
@@ -11,7 +11,7 @@ def test_create_profile_store(tmp_path):
     db = ProfileStore(tmp_path)
     db.shutdown()
 
-    db_path = tmp_path / 'performance.sqlite'
+    db_path = tmp_path / "performance.sqlite"
     conn = sqlite3.connect(db_path, isolation_level=None)
     cur = conn.cursor()
     cur.execute("BEGIN TRANSACTION")
@@ -33,9 +33,10 @@ def test_create_profile_store(tmp_path):
     assert len(instances) == 0
 
     cur.execute(
-            "SELECT instance_oid, event_type_oid, start_time, stop_time, port_name,"
-            "       port_operator_oid, port_length, slot, message_number, message_size,"
-            "       message_timestamp FROM events")
+        "SELECT instance_oid, event_type_oid, start_time, stop_time, port_name,"
+        "       port_operator_oid, port_length, slot, message_number, message_size,"
+        "       message_timestamp FROM events"
+    )
     events = cur.fetchall()
     assert len(events) == 0
 
@@ -44,73 +45,98 @@ def test_create_profile_store(tmp_path):
     conn.close()
 
 
-@patch('libmuscle.manager.profile_store._SYNCHED', True)
+@patch("libmuscle.manager.profile_store._SYNCHED", True)
 def test_add_events(tmp_path):
     db = ProfileStore(tmp_path)
 
-    db_path = tmp_path / 'performance.sqlite'
+    db_path = tmp_path / "performance.sqlite"
     conn = sqlite3.connect(db_path, isolation_level=None)
     cur = conn.cursor()
 
     events = [
-            ProfileEvent(
-                ProfileEventType.REGISTER, ProfileTimestamp(0),
-                ProfileTimestamp(1000)),
-            ProfileEvent(
-                ProfileEventType.SEND, ProfileTimestamp(800),
-                ProfileTimestamp(812),
-                Port('out_port', Operator.O_I), 10, 3, 67, 12345, 13.42),
-            ProfileEvent(
-                ProfileEventType.DEREGISTER, ProfileTimestamp(1000000000000),
-                ProfileTimestamp(1100000000000))]
+        ProfileEvent(
+            ProfileEventType.REGISTER, ProfileTimestamp(0), ProfileTimestamp(1000)
+        ),
+        ProfileEvent(
+            ProfileEventType.SEND,
+            ProfileTimestamp(800),
+            ProfileTimestamp(812),
+            Port("out_port", Operator.O_I),
+            10,
+            3,
+            67,
+            12345,
+            13.42,
+        ),
+        ProfileEvent(
+            ProfileEventType.DEREGISTER,
+            ProfileTimestamp(1000000000000),
+            ProfileTimestamp(1100000000000),
+        ),
+    ]
 
     def check_send_event(instance):
         cur.execute("BEGIN TRANSACTION")
         cur.execute(
-                "SELECT *"
-                " FROM events AS e, instances AS i, event_types AS et,"
-                "      port_operators AS o"
-                " WHERE e.instance_oid = i.oid AND e.event_type_oid = et.oid"
-                " AND e.port_operator_oid = o.oid AND i.name = 'instance[0]'"
-                " AND et.name = (?)", (ProfileEventType.SEND.name,))
+            "SELECT *"
+            " FROM events AS e, instances AS i, event_types AS et,"
+            "      port_operators AS o"
+            " WHERE e.instance_oid = i.oid AND e.event_type_oid = et.oid"
+            " AND e.port_operator_oid = o.oid AND i.name = 'instance[0]'"
+            " AND et.name = (?)",
+            (ProfileEventType.SEND.name,),
+        )
         events2 = cur.fetchall()
 
         assert len(events2) == 1
         e = events2[0]
         assert e[1:11] == (
-                ProfileEventType.SEND.value, 800, 812, 'out_port',
-                Operator.O_I.value, 10, 3, 67, 12345, 13.42)
-        assert e[12] == 'instance[0]'
-        assert e[14] == 'SEND'
-        assert e[16] == 'O_I'
+            ProfileEventType.SEND.value,
+            800,
+            812,
+            "out_port",
+            Operator.O_I.value,
+            10,
+            3,
+            67,
+            12345,
+            13.42,
+        )
+        assert e[12] == "instance[0]"
+        assert e[14] == "SEND"
+        assert e[16] == "O_I"
 
         cur.execute("COMMIT")
 
-    db.store_instances([Reference('instance[0]'), Reference('instance[1]')])
+    db.store_instances([Reference("instance[0]"), Reference("instance[1]")])
 
-    db.add_events(Reference('instance[0]'), events)
-    check_send_event('instance[0]')
+    db.add_events(Reference("instance[0]"), events)
+    check_send_event("instance[0]")
 
-    db.add_events(Reference('instance[1]'), events)
-    check_send_event('instance[1]')
+    db.add_events(Reference("instance[1]"), events)
+    check_send_event("instance[1]")
 
     def check_register_event(typ, start, stop):
         cur.execute("BEGIN TRANSACTION")
         cur.execute(
-                "SELECT i.name, e.start_time, e.stop_time"
-                " FROM events AS e, instances AS i, event_types AS et"
-                " WHERE e.instance_oid = i.oid AND e.event_type_oid = et.oid"
-                " AND et.name = ?", (typ,))
+            "SELECT i.name, e.start_time, e.stop_time"
+            " FROM events AS e, instances AS i, event_types AS et"
+            " WHERE e.instance_oid = i.oid AND e.event_type_oid = et.oid"
+            " AND et.name = ?",
+            (typ,),
+        )
 
         events2 = cur.fetchall()
         cur.execute("COMMIT")
 
         assert len(events2) == 2
         assert set(events2) == {
-                ('instance[0]', start, stop), ('instance[1]', start, stop)}
+            ("instance[0]", start, stop),
+            ("instance[1]", start, stop),
+        }
 
-    check_register_event('REGISTER', 0, 1000)
-    check_register_event('DEREGISTER', 1000000000000, 1100000000000)
+    check_register_event("REGISTER", 0, 1000)
+    check_register_event("DEREGISTER", 1000000000000, 1100000000000)
 
     cur.close()
     conn.close()

--- a/libmuscle/python/libmuscle/manager/test/test_snapshot_registry.py
+++ b/libmuscle/python/libmuscle/manager/test/test_snapshot_registry.py
@@ -27,7 +27,7 @@ from libmuscle.snapshot import SnapshotMetadata
 
 
 def make_snapshot(**msg_counts) -> SnapshotMetadata:
-    return SnapshotMetadata([], 0, 0, 0, {**msg_counts}, False, '')
+    return SnapshotMetadata([], 0, 0, 0, {**msg_counts}, False, "")
 
 
 @pytest.fixture(params=[True, False])
@@ -38,46 +38,50 @@ def micro_is_stateless(request: pytest.FixtureRequest) -> bool:
 @pytest.fixture
 def macro_micro(micro_is_stateless: bool) -> Configuration:
     components = [
-            Component('macro', Ports(), '', 'macro_impl'),
-            Component('micro', Ports(), '', 'micro_impl')]
-    conduits = [
-            Conduit('macro.o_i', 'micro.f_i'),
-            Conduit('micro.o_f', 'macro.s')]
-    model = Model('macro_micro', None, '', None, components, conduits)
+        Component("macro", Ports(), "", "macro_impl"),
+        Component("micro", Ports(), "", "micro_impl"),
+    ]
+    conduits = [Conduit("macro.o_i", "micro.f_i"), Conduit("micro.o_f", "macro.s")]
+    model = Model("macro_micro", None, "", None, components, conduits)
 
     if micro_is_stateless:
         micro_impl = Program(
-                'micro_impl',
-                keeps_state_for_next_use=KeepsStateForNextUse.NO,
-                executable='pass')
+            "micro_impl",
+            keeps_state_for_next_use=KeepsStateForNextUse.NO,
+            executable="pass",
+        )
     else:
-        micro_impl = Program('micro_impl', executable='pass')
+        micro_impl = Program("micro_impl", executable="pass")
 
-    programs = [
-            Program('macro_impl', executable='pass'),
-            micro_impl]
+    programs = [Program("macro_impl", executable="pass"), micro_impl]
 
-    return Configuration('macro_micro', [], [model], programs=programs)
+    return Configuration("macro_micro", [], [model], programs=programs)
 
 
 @pytest.fixture
 def uq(macro_micro: Configuration) -> Configuration:
-    model = macro_micro.models['macro_micro']
+    model = macro_micro.models["macro_micro"]
     for component in model.components.values():
         component.multiplicity = [5]
-    model.components[Reference('qmc')] = Component(
-            'qmc', Ports(o_i='parameters_out', s='states_in'), '', 'qmc_impl')
-    model.components[Reference('rr')] = Component(
-            'rr',
-            Ports(f_init='front_in', o_i='back_out', s='back_in', o_f='front_out'), '',
-            'rr_impl')
-    model.conduits.extend([
-            Conduit('qmc.parameters_out', 'rr.front_in'),
-            Conduit('rr.front_out', 'qmc.states_in'),
-            Conduit('rr.back_out', 'macro.muscle_settings_in'),
-            Conduit('macro.final_state_out', 'rr.back_in')])
-    macro_micro.programs[Reference('qmc_impl')] = Program('qmc_impl', executable='pass')
-    macro_micro.programs[Reference('rr_impl')] = Program('rr_impl', executable='pass')
+    model.components[Reference("qmc")] = Component(
+        "qmc", Ports(o_i="parameters_out", s="states_in"), "", "qmc_impl"
+    )
+    model.components[Reference("rr")] = Component(
+        "rr",
+        Ports(f_init="front_in", o_i="back_out", s="back_in", o_f="front_out"),
+        "",
+        "rr_impl",
+    )
+    model.conduits.extend(
+        [
+            Conduit("qmc.parameters_out", "rr.front_in"),
+            Conduit("rr.front_out", "qmc.states_in"),
+            Conduit("rr.back_out", "macro.muscle_settings_in"),
+            Conduit("macro.final_state_out", "rr.back_in"),
+        ]
+    )
+    macro_micro.programs[Reference("qmc_impl")] = Program("qmc_impl", executable="pass")
+    macro_micro.programs[Reference("rr_impl")] = Program("rr_impl", executable="pass")
     return macro_micro
 
 
@@ -122,16 +126,23 @@ def test_calc_consistency_list() -> None:
     for num_received in [[2, 3], [3, 2], [3, 5], [], [4, 4, 0, 0, 2]]:
         assert not calc_consistency_list(num_sent, num_received, True, False)
         assert not calc_consistency_list(num_received, num_sent, False, False)
-    for num_received in [[3, 3], [3, 4], [4, 3], [4, 4],
-                         [3, 3, 1], [4, 4, 0, 0, 0, 1, 0, 1]]:
+    for num_received in [
+        [3, 3],
+        [3, 4],
+        [4, 3],
+        [4, 4],
+        [3, 3, 1],
+        [4, 4, 0, 0, 0, 1, 0, 1],
+    ]:
         assert calc_consistency_list(num_sent, num_received, True, False)
         assert calc_consistency_list(num_received, num_sent, False, False)
 
 
 def test_write_ymmsl(tmp_path: Path):
-    configuration = Configuration('', [], [Model('empty', None, '')])
+    configuration = Configuration("", [], [Model("empty", None, "")])
     snapshot_registry = SnapshotRegistry(
-            configuration, tmp_path, TopologyStore(configuration))
+        configuration, tmp_path, TopologyStore(configuration)
+    )
     snapshot_registry._write_snapshot_ymmsl([])
 
     paths = list(tmp_path.iterdir())
@@ -142,56 +153,78 @@ def test_write_ymmsl(tmp_path: Path):
     now = datetime.now()
     for seconds in range(3):
         time = (now + timedelta(seconds=seconds)).strftime("%Y%m%d_%H%M%S")
-        (tmp_path / f'snapshot_{time}.ymmsl').touch()
+        (tmp_path / f"snapshot_{time}.ymmsl").touch()
     snapshot_registry._write_snapshot_ymmsl([])
     paths = list(tmp_path.iterdir())
     assert len(paths) == 4
-    paths = list(tmp_path.glob('*_1.ymmsl'))
+    paths = list(tmp_path.glob("*_1.ymmsl"))
     assert len(paths) == 1
 
 
 def test_snapshot_config():
-    configuration = Configuration('', [], [Model('empty', None, '')])
+    configuration = Configuration("", [], [Model("empty", None, "")])
     snapshot_registry = SnapshotRegistry(
-            configuration, None, TopologyStore(configuration))
+        configuration, None, TopologyStore(configuration)
+    )
     micro_metadata = SnapshotMetadata(
-            ['simulation_time >= 24.0', 'wallclocktime >= 10'],
-            10.123456789, 24.3456789, None, {}, False, 'micro_snapshot')
+        ["simulation_time >= 24.0", "wallclocktime >= 10"],
+        10.123456789,
+        24.3456789,
+        None,
+        {},
+        False,
+        "micro_snapshot",
+    )
     macro_metadata = SnapshotMetadata(
-            ['simulation_time >= 12.0', 'wallclocktime >= 10'],
-            10.123456789, 12.3456789, None, {}, False, 'macro_snapshot')
+        ["simulation_time >= 12.0", "wallclocktime >= 10"],
+        10.123456789,
+        12.3456789,
+        None,
+        {},
+        False,
+        "macro_snapshot",
+    )
     snapshots = [
-            SnapshotNode(1, Reference('micro'), micro_metadata, set()),
-            SnapshotNode(1, Reference('macro'), macro_metadata, set())]
+        SnapshotNode(1, Reference("micro"), micro_metadata, set()),
+        SnapshotNode(1, Reference("macro"), macro_metadata, set()),
+    ]
 
     now = datetime.now()
     config = snapshot_registry._generate_snapshot_config(snapshots, now)
     assert len(config.resume) == 2
-    assert config.resume[Reference('macro')] == Path('macro_snapshot')
-    assert config.resume[Reference('micro')] == Path('micro_snapshot')
+    assert config.resume[Reference("macro")] == Path("macro_snapshot")
+    assert config.resume[Reference("micro")] == Path("micro_snapshot")
     # note: no automatic testing for formatting, should verify by eye if this
     # looks okay..
     print(config.description)
 
     long_metadata = SnapshotMetadata(
-            ['simulation_time >= 24.0'], 1.23456789e-10, 1.23456789e10, None,
-            {}, False, '/this/is/a/long/path/to/the/snapshot/file.pack')
-    snapshots.append(SnapshotNode(
-            1, Reference('this.is.a.long.reference[10]'), long_metadata, set()))
+        ["simulation_time >= 24.0"],
+        1.23456789e-10,
+        1.23456789e10,
+        None,
+        {},
+        False,
+        "/this/is/a/long/path/to/the/snapshot/file.pack",
+    )
+    snapshots.append(
+        SnapshotNode(1, Reference("this.is.a.long.reference[10]"), long_metadata, set())
+    )
 
     config = snapshot_registry._generate_snapshot_config(snapshots, now)
     assert len(config.resume) == 3
-    assert config.resume[Reference('this.is.a.long.reference[10]')] == Path(
-            '/this/is/a/long/path/to/the/snapshot/file.pack')
+    assert config.resume[Reference("this.is.a.long.reference[10]")] == Path(
+        "/this/is/a/long/path/to/the/snapshot/file.pack"
+    )
     print(config.description)
 
 
 def test_peers(uq: Configuration) -> None:
     snapshot_registry = SnapshotRegistry(uq, None, TopologyStore(uq))
-    macro = Reference('macro')
-    micro = Reference('micro')
-    qmc = Reference('qmc')
-    rr = Reference('rr')
+    macro = Reference("macro")
+    micro = Reference("micro")
+    qmc = Reference("qmc")
+    rr = Reference("rr")
 
     all_instances = {qmc, rr} | {macro + i for i in range(5)}
     all_instances.update(micro + i for i in range(5))
@@ -207,10 +240,10 @@ def test_peers(uq: Configuration) -> None:
 
 def test_connections(uq: Configuration) -> None:
     snapshot_registry = SnapshotRegistry(uq, None, TopologyStore(uq))
-    macro = Reference('macro')
-    micro = Reference('micro')
-    qmc = Reference('qmc')
-    rr = Reference('rr')
+    macro = Reference("macro")
+    micro = Reference("micro")
+    qmc = Reference("qmc")
+    rr = Reference("rr")
 
     assert not snapshot_registry._get_connections(qmc, macro + 1)
     assert not snapshot_registry._get_connections(macro + 3, qmc)
@@ -222,10 +255,10 @@ def test_connections(uq: Configuration) -> None:
     connections = snapshot_registry._get_connections(rr, qmc)
     assert len(connections) == 2
     for rr_port, qmc_port, info in connections:
-        assert rr_port in (Reference('front_out'), Reference('front_in'))
-        assert qmc_port in (Reference('parameters_out'), Reference('states_in'))
+        assert rr_port in (Reference("front_out"), Reference("front_in"))
+        assert qmc_port in (Reference("parameters_out"), Reference("states_in"))
         is_sending = bool(info & _ConnectionInfo.SELF_IS_SENDING)
-        assert is_sending is (rr_port == Reference('front_out'))
+        assert is_sending is (rr_port == Reference("front_out"))
         # Note: actually both are vector ports, but this is undetectable from
         # the ymmsl configuration. Luckily we treat it the same as scalar-scalar
         assert not (info & _ConnectionInfo.SELF_IS_VECTOR)
@@ -235,42 +268,45 @@ def test_connections(uq: Configuration) -> None:
     assert len(connections) == 2
     for macro_port, rr_port, info in connections:
         assert macro_port in (
-                Reference('muscle_settings_in'), Reference('final_state_out'))
-        assert rr_port in (Reference('back_out'), Reference('back_in'))
+            Reference("muscle_settings_in"),
+            Reference("final_state_out"),
+        )
+        assert rr_port in (Reference("back_out"), Reference("back_in"))
         is_sending = bool(info & _ConnectionInfo.SELF_IS_SENDING)
-        assert is_sending is (macro_port == Reference('final_state_out'))
+        assert is_sending is (macro_port == Reference("final_state_out"))
         assert not (info & _ConnectionInfo.SELF_IS_VECTOR)
-        assert (info & _ConnectionInfo.PEER_IS_VECTOR)
+        assert info & _ConnectionInfo.PEER_IS_VECTOR
 
     connections = snapshot_registry._get_connections(rr, macro + 1)
     assert len(connections) == 2
     for rr_port, macro_port, info in connections:
         assert macro_port in (
-                Reference('muscle_settings_in'), Reference('final_state_out'))
-        assert rr_port in (Reference('back_out'), Reference('back_in'))
+            Reference("muscle_settings_in"),
+            Reference("final_state_out"),
+        )
+        assert rr_port in (Reference("back_out"), Reference("back_in"))
         is_sending = bool(info & _ConnectionInfo.SELF_IS_SENDING)
-        assert is_sending is (rr_port == Reference('back_out'))
-        assert (info & _ConnectionInfo.SELF_IS_VECTOR)
+        assert is_sending is (rr_port == Reference("back_out"))
+        assert info & _ConnectionInfo.SELF_IS_VECTOR
         assert not (info & _ConnectionInfo.PEER_IS_VECTOR)
 
 
 def test_implementation(uq: Configuration) -> None:
     snapshot_registry = SnapshotRegistry(uq, None, TopologyStore(uq))
 
-    qmc_impl = snapshot_registry._implementation(Reference('qmc'))
-    assert qmc_impl.name == 'qmc_impl'
+    qmc_impl = snapshot_registry._implementation(Reference("qmc"))
+    assert qmc_impl.name == "qmc_impl"
 
-    missing_impl = snapshot_registry._implementation(Reference('missing'))
+    missing_impl = snapshot_registry._implementation(Reference("missing"))
     assert missing_impl is None
 
 
 def test_macro_micro_snapshots(macro_micro: Configuration) -> None:
-    snapshot_registry = SnapshotRegistry(
-            macro_micro, None, TopologyStore(macro_micro))
+    snapshot_registry = SnapshotRegistry(macro_micro, None, TopologyStore(macro_micro))
     # prevent actually writing a ymmsl file, testing that separately
     snapshot_registry._write_snapshot_ymmsl = MagicMock()
-    macro = Reference('macro')
-    micro = Reference('micro')
+    macro = Reference("macro")
+    micro = Reference("micro")
 
     macro_snapshot = make_snapshot(o_i=[3], s=[3])
     snapshot_registry._add_snapshot(macro, macro_snapshot)
@@ -302,8 +338,7 @@ def test_macro_micro_snapshots(macro_micro: Configuration) -> None:
     assert len(snapshot_registry._snapshots[micro]) == 1
     micro_node = snapshot_registry._snapshots[micro][0]
     assert micro_node.consistent
-    snapshot_registry._write_snapshot_ymmsl.assert_called_once_with(
-            [micro_node, node])
+    snapshot_registry._write_snapshot_ymmsl.assert_called_once_with([micro_node, node])
     snapshot_registry._write_snapshot_ymmsl.reset_mock()
 
     # 3 micro snapshots in the same reuse:
@@ -315,8 +350,7 @@ def test_macro_micro_snapshots(macro_micro: Configuration) -> None:
     assert len(snapshot_registry._snapshots[micro]) == 1
     micro_node = snapshot_registry._snapshots[micro][-1]
     assert snapshot_registry._write_snapshot_ymmsl.call_count == 3
-    snapshot_registry._write_snapshot_ymmsl.assert_called_with(
-            [micro_node, node])
+    snapshot_registry._write_snapshot_ymmsl.assert_called_with([micro_node, node])
     snapshot_registry._write_snapshot_ymmsl.reset_mock()
 
     macro_snapshot = make_snapshot(o_i=[4], s=[4])
@@ -345,26 +379,28 @@ def test_uq(uq: Configuration) -> None:
     snapshot_registry = SnapshotRegistry(uq, None, TopologyStore(uq))
     # prevent actually writing a ymmsl file, testing that separately
     snapshot_registry._write_snapshot_ymmsl = MagicMock()
-    macro = Reference('macro')
-    micro = Reference('micro')
-    qmc = Reference('qmc')
-    rr = Reference('rr')
+    macro = Reference("macro")
+    micro = Reference("micro")
+    qmc = Reference("qmc")
+    rr = Reference("rr")
 
     qmc_snapshot = make_snapshot(parameters_out=[], states_in=[])
     snapshot_registry._add_snapshot(qmc, qmc_snapshot)
 
     rr_snapshot = make_snapshot(
-            front_in=[1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-            front_out=[0] * 10,
-            back_out=[1, 1, 1, 1, 1],
-            back_in=[0] * 5)
+        front_in=[1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+        front_out=[0] * 10,
+        back_out=[1, 1, 1, 1, 1],
+        back_in=[0] * 5,
+    )
     snapshot_registry._add_snapshot(rr, rr_snapshot)
     node = snapshot_registry._snapshots[rr][-1]
     assert qmc in node.consistent_peers
     snapshot_registry._write_snapshot_ymmsl.assert_not_called()
 
     macro_snapshot = make_snapshot(
-            muscle_settings_in=[1], final_state_out=[0], o_i=[0], s=[0])
+        muscle_settings_in=[1], final_state_out=[0], o_i=[0], s=[0]
+    )
     for i in range(5):
         snapshot_registry._add_snapshot(macro + i, macro_snapshot)
         node = snapshot_registry._snapshots[macro + i][-1]
@@ -393,14 +429,15 @@ def test_uq(uq: Configuration) -> None:
 
 def test_heuristic_rollbacks() -> None:
     components = [
-            Component(f'comp{i}', Ports(f_init='f_i', o_f='o_f'), '', f'impl{i}')
-            for i in range(4)]
-    conduits = [Conduit(f'comp{i}.o_f', f'comp{i+1}.f_i') for i in range(3)]
-    model = Model('linear', None, '', None, components, conduits)
-    programs = [Program(f'impl{i}', script='xyz') for i in range(4)]
-    config = Configuration('', [], [model], programs=programs)
+        Component(f"comp{i}", Ports(f_init="f_i", o_f="o_f"), "", f"impl{i}")
+        for i in range(4)
+    ]
+    conduits = [Conduit(f"comp{i}.o_f", f"comp{i + 1}.f_i") for i in range(3)]
+    model = Model("linear", None, "", None, components, conduits)
+    programs = [Program(f"impl{i}", script="xyz") for i in range(4)]
+    config = Configuration("", [], [model], programs=programs)
 
-    comp1, comp2, comp3, comp4 = (Reference(f'comp{i}') for i in range(4))
+    comp1, comp2, comp3, comp4 = (Reference(f"comp{i}") for i in range(4))
 
     snapshot_registry = SnapshotRegistry(config, None, TopologyStore(config))
     # prevent actually writing a ymmsl file, testing that separately
@@ -411,10 +448,8 @@ def test_heuristic_rollbacks() -> None:
     assert len(snapshot_registry._snapshots[comp1]) == 4
 
     for _ in range(10):
-        snapshot_registry._add_snapshot(
-                comp2, make_snapshot(f_i=[1], o_f=[0]))
-        snapshot_registry._add_snapshot(
-                comp3, make_snapshot(f_i=[1], o_f=[0]))
+        snapshot_registry._add_snapshot(comp2, make_snapshot(f_i=[1], o_f=[0]))
+        snapshot_registry._add_snapshot(comp3, make_snapshot(f_i=[1], o_f=[0]))
     assert len(snapshot_registry._snapshots[comp2]) == 10
     assert len(snapshot_registry._snapshots[comp3]) == 10
 
@@ -425,8 +460,7 @@ def test_heuristic_rollbacks() -> None:
 
     snapshot_registry._write_snapshot_ymmsl.assert_not_called()
 
-    snapshot_registry._add_snapshot(
-            comp4, make_snapshot(f_i=[1]))
+    snapshot_registry._add_snapshot(comp4, make_snapshot(f_i=[1]))
     snapshot_registry._write_snapshot_ymmsl.assert_called()
 
     assert len(snapshot_registry._snapshots[comp1]) == 2

--- a/libmuscle/python/libmuscle/manager/test/test_topology_store.py
+++ b/libmuscle/python/libmuscle/manager/test/test_topology_store.py
@@ -2,42 +2,42 @@ from ymmsl.v0_2 import Reference
 
 
 def test_create_topology_store(topology_store) -> None:
-    assert topology_store.model.conduits[0].sender == 'macro.out'
-    assert topology_store.model.conduits[0].receiver == 'micro.in'
-    assert topology_store.model.conduits[1].sender == 'micro.out'
-    assert topology_store.model.conduits[1].receiver == 'macro.in'
+    assert topology_store.model.conduits[0].sender == "macro.out"
+    assert topology_store.model.conduits[0].receiver == "micro.in"
+    assert topology_store.model.conduits[1].sender == "micro.out"
+    assert topology_store.model.conduits[1].receiver == "macro.in"
 
-    assert topology_store.model.components['macro'].multiplicity == []
-    assert topology_store.model.components['micro'].multiplicity == [10, 10]
+    assert topology_store.model.components["macro"].multiplicity == []
+    assert topology_store.model.components["micro"].multiplicity == [10, 10]
 
 
 def test_get_conduits(topology_store2) -> None:
-    conduits = topology_store2.get_conduits(Reference('macro'))
-    assert conduits[0].sender == 'macro.out'
-    assert conduits[0].receiver == 'meso.init'
-    assert conduits[1].sender == 'meso.final'
-    assert conduits[1].receiver == 'macro.in'
+    conduits = topology_store2.get_conduits(Reference("macro"))
+    assert conduits[0].sender == "macro.out"
+    assert conduits[0].receiver == "meso.init"
+    assert conduits[1].sender == "meso.final"
+    assert conduits[1].receiver == "macro.in"
 
-    conduits = topology_store2.get_conduits(Reference('meso'))
-    assert conduits[0].sender == 'macro.out'
-    assert conduits[0].receiver == 'meso.init'
-    assert conduits[1].sender == 'meso.out'
-    assert conduits[1].receiver == 'micro.init'
-    assert conduits[2].sender == 'micro.final'
-    assert conduits[2].receiver == 'meso.in'
-    assert conduits[3].sender == 'meso.final'
-    assert conduits[3].receiver == 'macro.in'
+    conduits = topology_store2.get_conduits(Reference("meso"))
+    assert conduits[0].sender == "macro.out"
+    assert conduits[0].receiver == "meso.init"
+    assert conduits[1].sender == "meso.out"
+    assert conduits[1].receiver == "micro.init"
+    assert conduits[2].sender == "micro.final"
+    assert conduits[2].receiver == "meso.in"
+    assert conduits[3].sender == "meso.final"
+    assert conduits[3].receiver == "macro.in"
 
 
 def test_get_peer_dimensions(topology_store) -> None:
-    macro_peer_dims = topology_store.get_peer_dimensions(Reference('macro'))
+    macro_peer_dims = topology_store.get_peer_dimensions(Reference("macro"))
 
     assert len(macro_peer_dims) == 1
-    assert Reference('micro') in macro_peer_dims
-    assert macro_peer_dims[Reference('micro')] == [10, 10]
+    assert Reference("micro") in macro_peer_dims
+    assert macro_peer_dims[Reference("micro")] == [10, 10]
 
-    micro_peer_dims = topology_store.get_peer_dimensions(Reference('micro'))
+    micro_peer_dims = topology_store.get_peer_dimensions(Reference("micro"))
 
     assert len(micro_peer_dims) == 1
-    assert Reference('macro') in micro_peer_dims
-    assert micro_peer_dims[Reference('macro')] == []
+    assert Reference("macro") in micro_peer_dims
+    assert micro_peer_dims[Reference("macro")] == []

--- a/libmuscle/python/libmuscle/manager/topology_store.py
+++ b/libmuscle/python/libmuscle/manager/topology_store.py
@@ -12,6 +12,7 @@ class TopologyStore:
     Attributes:
         conduits (list[Conduit]): A list of conduits.
     """
+
     def __init__(self, config: Configuration) -> None:
         """Creates a TopologyStore.
 
@@ -59,8 +60,7 @@ class TopologyStore:
         """
         return self.model.components[component].ports
 
-    def get_peer_dimensions(self, component: Reference
-                            ) -> dict[Reference, list[int]]:
+    def get_peer_dimensions(self, component: Reference) -> dict[Reference, list[int]]:
         """Returns the dimensions of peer components.
 
         For each component that the given component shares a conduit with,
@@ -105,6 +105,6 @@ class TopologyStore:
             if dims >= peer_dims:
                 peers.append(base)
             else:
-                for peer_indices in generate_indices(peer_dims[len(dims):]):
+                for peer_indices in generate_indices(peer_dims[len(dims) :]):
                     peers.append(base + peer_indices)
         return peers

--- a/libmuscle/python/libmuscle/mcp/protocol.py
+++ b/libmuscle/python/libmuscle/mcp/protocol.py
@@ -13,6 +13,7 @@ class RequestType(Enum):
     To distinguish different kinds of requests, a request type identifier is
     used, as represented by this class.
     """
+
     # MUSCLE Manager Protocol
     REGISTER_INSTANCE = 1
     GET_PEERS = 2
@@ -42,6 +43,7 @@ class ResponseType(Enum):
     MCP Responses may be of different kinds, as described by this class.
     These are currently only used by the MUSCLE Manager Protocol.
     """
+
     # MUSCLE Manager Protocol
     SUCCESS = 0
     ERROR = 1
@@ -54,6 +56,7 @@ class AgentCommandType(Enum):
     These are requested from the manager by the agent, and tell it what to do. Part
     of the MUSCLE Agent Protocol, used in the response to RequestType.GET_COMMAND.
     """
+
     START = 1
     CANCEL_ALL = 2
     SHUTDOWN = 3

--- a/libmuscle/python/libmuscle/mcp/session_state.py
+++ b/libmuscle/python/libmuscle/mcp/session_state.py
@@ -31,6 +31,7 @@ class SessionState:
     Objects of this class therefore store n, the most recently received request, and, if
     and only if we're in state 2), response n.
     """
+
     def __init__(self) -> None:
         """Create a SessionState object.
 
@@ -42,11 +43,11 @@ class SessionState:
         self._response_ready = threading.Condition()
 
         self._cur_request = 0
-        self._response: Optional[Buffer] = b''
+        self._response: Optional[Buffer] = b""
 
     def __str__(self) -> str:
         with self._response_ready:
-            return f'SessionState({self._cur_request}, {self._response is not None})'
+            return f"SessionState({self._cur_request}, {self._response is not None})"
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -103,7 +104,8 @@ class SessionState:
         """
         with self._response_ready:
             should_process = (
-                    self._response is not None and self._cur_request < request_nr)
+                self._response is not None and self._cur_request < request_nr
+            )
             if should_process:
                 self._cur_request = request_nr
                 self._response = None

--- a/libmuscle/python/libmuscle/mcp/tcp_transport_client.py
+++ b/libmuscle/python/libmuscle/mcp/tcp_transport_client.py
@@ -20,8 +20,8 @@ from libmuscle.util import Retrier
 _logger = logging.getLogger(__name__)
 
 
-_CONNECT_TIMEOUT = 3.0                      # seconds
-RECONNECT_TIMEOUT = 60.0                   # seconds
+_CONNECT_TIMEOUT = 3.0  # seconds
+RECONNECT_TIMEOUT = 60.0  # seconds
 
 
 class NoPendingResponse(RuntimeError):
@@ -30,6 +30,7 @@ class NoPendingResponse(RuntimeError):
 
 class TcpTransportClient(TransportClient):
     """A client that connects to a TCPTransport server."""
+
     @staticmethod
     def can_connect_to(location: str) -> bool:
         """Whether this client class can connect to the given location.
@@ -40,7 +41,7 @@ class TcpTransportClient(TransportClient):
         Returns:
             True iff this class can connect to this location.
         """
-        return location.startswith('tcp:')
+        return location.startswith("tcp:")
 
     def __init__(self, location: str) -> None:
         """Create a TcpClient for a given location.
@@ -51,15 +52,16 @@ class TcpTransportClient(TransportClient):
         Args:
             location: A location string for the peer.
         """
-        self._addresses = location[4:].split(',')
+        self._addresses = location[4:].split(",")
         self._socket: Optional[socket.SocketType] = None
         self._session = 0
         self._cur_request = 0
 
         self._reconnect(False)
 
-    def call(self, request: Buffer, timeout_handler: Optional[TimeoutHandler] = None
-             ) -> tuple[Buffer, ProfileData]:
+    def call(
+        self, request: Buffer, timeout_handler: Optional[TimeoutHandler] = None
+    ) -> tuple[Buffer, ProfileData]:
         """Send a request to the server and receive the response.
 
         This is a blocking call.
@@ -81,8 +83,8 @@ class TcpTransportClient(TransportClient):
             nonlocal deadline
             nonlocal did_timeout
 
-            assert timeout_handler is not None      # mypy
-            assert deadline is not None             # mypy
+            assert timeout_handler is not None  # mypy
+            assert deadline is not None  # mypy
 
             timeout_handler.on_timeout()
             deadline += timeout_handler.timeout
@@ -94,7 +96,7 @@ class TcpTransportClient(TransportClient):
                     handle_timeout()
 
                 if self._socket is None:
-                    raise ConnectionError('No connection could be established')
+                    raise ConnectionError("No connection could be established")
 
                 start_wait = ProfileTimestamp()
                 send_int64(self._socket, self._cur_request)
@@ -158,8 +160,8 @@ class TcpTransportClient(TransportClient):
             retrier: A Retrier that keeps track of timing any retries
         """
         _logger.warning(
-                f'The TCP network connection with {self._addresses} was lost'
-                ' unexpectedly.')
+            f"The TCP network connection with {self._addresses} was lost unexpectedly."
+        )
 
         try:
             self._close_connection()
@@ -169,13 +171,14 @@ class TcpTransportClient(TransportClient):
 
         if retrier.should_give_up():
             _logger.warning(
-                    f'I am unable to reconnect to {self._addresses} despite repeated'
-                    ' attempts, and I am giving up. Please check your network.')
+                f"I am unable to reconnect to {self._addresses} despite repeated"
+                " attempts, and I am giving up. Please check your network."
+            )
             raise
 
         retrier.sleep()
 
-        _logger.warning(f'Trying to reconnect to {self._addresses}')
+        _logger.warning(f"Trying to reconnect to {self._addresses}")
 
         self._reconnect()
 
@@ -193,15 +196,15 @@ class TcpTransportClient(TransportClient):
 
             if re:
                 _logger.warning(
-                        f'Reconnected to {self._addresses}, continuing the'
-                        ' simulation')
+                    f"Reconnected to {self._addresses}, continuing the simulation"
+                )
 
         except Exception as e:
             if is_disconnect(e):
                 self._close_connection()
                 _logger.warning(
-                        f'Failed to reconnect to {self._addresses}, will retry'
-                        ' later')
+                    f"Failed to reconnect to {self._addresses}, will retry later"
+                )
             else:
                 raise
 
@@ -219,32 +222,33 @@ class TcpTransportClient(TransportClient):
                 pass
 
         if sock is None:
-            raise ConnectionRefusedError('Failed to connect')
+            raise ConnectionRefusedError("Failed to connect")
 
-        if hasattr(socket, 'TCP_NODELAY'):
+        if hasattr(socket, "TCP_NODELAY"):
             sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
-        if hasattr(socket, 'TCP_QUICKACK'):
+        if hasattr(socket, "TCP_QUICKACK"):
             sock.setsockopt(socket.SOL_TCP, socket.TCP_QUICKACK, 1)
         self._socket = sock
 
-        if hasattr(select, 'poll'):
+        if hasattr(select, "poll"):
             self._poll_obj: Optional[select.poll] = select.poll()
             self._poll_obj.register(self._socket, select.POLLIN)
         else:
             self._poll_obj = None  # On platforms that don't support select.poll
 
     def _connect(self, address: str) -> socket.SocketType:
-        loc_parts = address.rsplit(':', 1)
+        loc_parts = address.rsplit(":", 1)
         host = loc_parts[0]
-        if host.startswith('['):
-            if host.endswith(']'):
+        if host.startswith("["):
+            if host.endswith("]"):
                 host = host[1:-1]
             else:
-                raise RuntimeError('Invalid address')
+                raise RuntimeError("Invalid address")
         port = int(loc_parts[1])
 
         addrinfo = socket.getaddrinfo(
-                host, port, 0, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+            host, port, 0, socket.SOCK_STREAM, socket.IPPROTO_TCP
+        )
 
         for family, socktype, proto, _, sockaddr in addrinfo:
             try:
@@ -254,16 +258,16 @@ class TcpTransportClient(TransportClient):
                 sock.settimeout(None)
                 return sock
             except (ConnectionRefusedError, ConnectionAbortedError):
-                _logger.info(f'Failed to connect to {sockaddr}')
+                _logger.info(f"Failed to connect to {sockaddr}")
                 sock.close()
                 break
 
             except Exception as e:
-                _logger.debug(f'Failed to connect socket: {e}')
+                _logger.debug(f"Failed to connect socket: {e}")
                 sock.close()
                 break
 
-        raise RuntimeError('Could not connect')
+        raise RuntimeError("Could not connect")
 
     def _end_session(self) -> None:
         try:
@@ -276,8 +280,9 @@ class TcpTransportClient(TransportClient):
                 raise
 
             _logger.warning(
-                    'Disconnected while trying to end session, shutdown will take'
-                    ' longer than usual because of this.')
+                "Disconnected while trying to end session, shutdown will take"
+                " longer than usual because of this."
+            )
 
     def _close_connection(self) -> None:
         if self._socket is not None:

--- a/libmuscle/python/libmuscle/mcp/tcp_transport_server.py
+++ b/libmuscle/python/libmuscle/mcp/tcp_transport_server.py
@@ -24,9 +24,12 @@ class TcpTransportServerImpl(ss.ThreadingMixIn, ss.TCPServer):
     daemon_threads = True
     allow_reuse_address = True
 
-    def __init__(self, host_port_tuple: tuple[str, int],
-                 streamhandler: type, transport_server: 'TcpTransportServer'
-                 ) -> None:
+    def __init__(
+        self,
+        host_port_tuple: tuple[str, int],
+        streamhandler: type,
+        transport_server: "TcpTransportServer",
+    ) -> None:
         super().__init__(host_port_tuple, streamhandler)
         self.transport_server = transport_server
         if hasattr(socket, "TCP_NODELAY"):
@@ -50,6 +53,7 @@ class TcpHandler(ss.BaseRequestHandler):
     doing Remote Procedure Call over that, and we call every RPC call we receive from
     the client a request also.
     """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
@@ -65,7 +69,8 @@ class TcpHandler(ss.BaseRequestHandler):
                 request = recv_frame(self.request)
 
                 should_process, should_send = self._session_state.triage_request(
-                        request_nr)
+                    request_nr
+                )
 
                 if should_process:
                     response = server.transport_server._handler.handle_request(request)
@@ -109,16 +114,17 @@ class TcpHandler(ss.BaseRequestHandler):
 
         else:
             _logger.warning(
-                    f'The TCP network connection for session {req_session_id} was lost')
+                f"The TCP network connection for session {req_session_id} was lost"
+            )
 
             with server.session_lock:
                 if req_session_id not in server.session_store:
-                    raise RuntimeError(f'Unknown session {req_session_id} requested')
+                    raise RuntimeError(f"Unknown session {req_session_id} requested")
                 self._session_state = server.session_store[req_session_id]
 
             session_id = req_session_id
             send_int64(self.request, session_id)
-            _logger.warning(f'Resuming session {session_id}')
+            _logger.warning(f"Resuming session {session_id}")
 
         return session_id
 
@@ -136,6 +142,7 @@ class TcpHandler(ss.BaseRequestHandler):
 
 class TcpTransportServer(TransportServer):
     """A TransportServer that uses TCP to communicate."""
+
     def __init__(self, handler: RequestHandler, port: int = 0) -> None:
         """Create a TCPServer.
 
@@ -149,9 +156,10 @@ class TcpTransportServer(TransportServer):
         """
         super().__init__(handler)
 
-        self._server = TcpTransportServerImpl(('', port), TcpHandler, self)
+        self._server = TcpTransportServerImpl(("", port), TcpHandler, self)
         self._server_thread = threading.Thread(
-                target=self._server.serve_forever, args=(0.1,), daemon=True)
+            target=self._server.serve_forever, args=(0.1,), daemon=True
+        )
         self._server_thread.start()
 
     def get_location(self) -> str:
@@ -165,8 +173,8 @@ class TcpTransportServer(TransportServer):
 
         locs: list[str] = []
         for address in self._get_if_addresses():
-            locs.append(f'{address}:{port}')
-        return 'tcp:{}'.format(','.join(locs))
+            locs.append(f"{address}:{port}")
+        return "tcp:{}".format(",".join(locs))
 
     def close(self, graceful: bool = True) -> None:
         """Closes this server.
@@ -203,11 +211,11 @@ class TcpTransportServer(TransportServer):
         for _, addresses in ifs.items():
             for addr in addresses:
                 if addr.family == socket.AF_INET:
-                    if not addr.address.startswith('127.'):
+                    if not addr.address.startswith("127."):
                         all_addresses.append(addr.address)
                 if addr.family == socket.AF_INET6:
                     # filter out link-local addresses with a scope id
-                    if '%' not in addr.address and addr.address != '::1':
-                        all_addresses.append('[' + addr.address + ']')
+                    if "%" not in addr.address and addr.address != "::1":
+                        all_addresses.append("[" + addr.address + "]")
 
         return all_addresses

--- a/libmuscle/python/libmuscle/mcp/tcp_util.py
+++ b/libmuscle/python/libmuscle/mcp/tcp_util.py
@@ -7,8 +7,8 @@ import libmuscle.mark as mark
 
 
 class SocketClosed(Exception):
-    """Raised when trying to read from a socket that was closed.
-    """
+    """Raised when trying to read from a socket that was closed."""
+
     pass
 
 
@@ -45,7 +45,8 @@ def recv_all(socket: SocketType, length: int) -> Buffer:
         mark.before_tcp_receive(socket)
         bytes_left = length - received_count
         received_now = socket.recv_into(
-            memoryview(databuf)[received_count:], bytes_left)
+            memoryview(databuf)[received_count:], bytes_left
+        )
 
         if received_now == 0:
             raise SocketClosed("Socket closed while receiving")
@@ -68,7 +69,7 @@ def send_int64(socket: SocketType, data: int) -> None:
     Raises:
         RuntimeError: If there was an error sending the data.
     """
-    buf = data.to_bytes(8, byteorder='little')
+    buf = data.to_bytes(8, byteorder="little")
     mark.before_tcp_send(socket)
     socket.sendall(buf)
 
@@ -85,7 +86,7 @@ def recv_int64(socket: SocketType) -> int:
     """
     mark.before_tcp_receive(socket)
     buf = recv_all(socket, 8)
-    return int.from_bytes(buf, 'little')
+    return int.from_bytes(buf, "little")
 
 
 def send_frame(socket: SocketType, data: Buffer) -> None:

--- a/libmuscle/python/libmuscle/mcp/test/conftest.py
+++ b/libmuscle/python/libmuscle/mcp/test/conftest.py
@@ -11,7 +11,7 @@ from libmuscle.post_office import PostOffice
 
 @pytest.fixture
 def receiver():
-    return Reference('test_receiver.test_port')
+    return Reference("test_receiver.test_port")
 
 
 @pytest.fixture

--- a/libmuscle/python/libmuscle/mcp/test/test_tcp_transport.py
+++ b/libmuscle/python/libmuscle/mcp/test/test_tcp_transport.py
@@ -5,11 +5,11 @@ from libmuscle.mcp.tcp_transport_server import TcpTransportServer
 
 
 def test_tcp_transport():
-    request = b'request'
-    response = b'response'
+    request = b"request"
+    response = b"response"
 
     def handle_request(request: bytes) -> bytes:
-        assert request == b'request'
+        assert request == b"request"
         return response
 
     handler = MagicMock()

--- a/libmuscle/python/libmuscle/mcp/test/test_tcp_transport_server.py
+++ b/libmuscle/python/libmuscle/mcp/test/test_tcp_transport_server.py
@@ -6,12 +6,12 @@ def test_create(tcp_transport_server):
 
 
 def test_location(tcp_transport_server):
-    assert tcp_transport_server.get_location().startswith('tcp:')
+    assert tcp_transport_server.get_location().startswith("tcp:")
 
 
 def test_request(tcp_transport_server):
-    request = b'testing'
-    response = b'response'
+    request = b"testing"
+    response = b"response"
 
     tcp_transport_server._handler.handle_request.return_value = response
 
@@ -20,24 +20,24 @@ def test_request(tcp_transport_server):
         sock.connect(location)
 
         # request a session
-        req_session = (0).to_bytes(8, byteorder='little')
+        req_session = (0).to_bytes(8, byteorder="little")
         sock.sendall(req_session)
         sesbuf = bytearray(8)
         sock.recv_into(sesbuf, 8)
-        session = int.from_bytes(sesbuf, 'little')
+        session = int.from_bytes(sesbuf, "little")
         assert session == 1
 
         # send a request
-        reqno = (1).to_bytes(8, byteorder='little')
+        reqno = (1).to_bytes(8, byteorder="little")
         sock.sendall(reqno)
-        length = len(request).to_bytes(8, byteorder='little')
+        length = len(request).to_bytes(8, byteorder="little")
         sock.sendall(length)
         sock.sendall(request)
 
         # receive the response
         lenbuf = bytearray(8)
         sock.recv_into(lenbuf, 8)
-        length = int.from_bytes(lenbuf, 'little')
+        length = int.from_bytes(lenbuf, "little")
         assert length == len(response)
 
         databuf = bytearray(length)
@@ -45,10 +45,11 @@ def test_request(tcp_transport_server):
         while received_count < length:
             bytes_left = length - received_count
             received_count += sock.recv_into(
-                    memoryview(databuf)[received_count:], bytes_left)
+                memoryview(databuf)[received_count:], bytes_left
+            )
 
         # close the session
-        reqno = (0).to_bytes(8, byteorder='little')
+        reqno = (0).to_bytes(8, byteorder="little")
         sock.sendall(reqno)
 
     assert databuf == response

--- a/libmuscle/python/libmuscle/mcp/transport_client.py
+++ b/libmuscle/python/libmuscle/mcp/transport_client.py
@@ -13,20 +13,20 @@ class TimeoutHandler:
     @property
     def timeout(self) -> float:
         """Timeout (in seconds) after which :meth:`on_timeout` is called."""
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
     def on_timeout(self) -> None:
         """Callback when :attr:`timeout` seconds have passed without a response from the
         peer.
         """
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
     def on_receive(self) -> None:
         """Callback when receiving a response from the peer.
 
         Note: this method is only called when the request has timed out.
         """
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
 
 class TransportClient:
@@ -36,6 +36,7 @@ class TransportClient:
     Client connects to an MCP Transport Server over some communication
     protocol, requests messages from it, and returns responses.
     """
+
     @staticmethod
     def can_connect_to(location: str) -> bool:
         """Whether this client class can connect to the given location.
@@ -46,10 +47,11 @@ class TransportClient:
         Returns:
             True iff this class can connect to this location.
         """
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
-    def call(self, request: Buffer, timeout_handler: Optional[TimeoutHandler] = None
-             ) -> tuple[Buffer, ProfileData]:
+    def call(
+        self, request: Buffer, timeout_handler: Optional[TimeoutHandler] = None
+    ) -> tuple[Buffer, ProfileData]:
         """Send a request to the server and receive the response.
 
         This is a blocking call. Besides the result, this function
@@ -66,7 +68,7 @@ class TransportClient:
         Returns:
             The received response, and the timestamps
         """
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
     def close(self) -> None:
         """Closes this client.
@@ -74,4 +76,4 @@ class TransportClient:
         This closes any connections this client has and/or performs
         other shutdown activities as needed.
         """
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover

--- a/libmuscle/python/libmuscle/mcp/transport_server.py
+++ b/libmuscle/python/libmuscle/mcp/transport_server.py
@@ -9,6 +9,7 @@ class RequestHandler:
     handle the request, and return a chunk of bytes containing an
     encoded response.
     """
+
     def handle_request(self, request: Buffer) -> Buffer:
         """Handle a request.
 
@@ -18,7 +19,7 @@ class RequestHandler:
         Returns:
             An encoded response
         """
-        raise NotImplementedError()     # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
     def close(self) -> None:
         """Free per-thread resources.
@@ -40,6 +41,7 @@ class TransportServer:
     connections over some lower-level communication protocol, receives
     requests and returns responses from a RequestHandler.
     """
+
     def __init__(self, handler: RequestHandler) -> None:
         """Create a TransportServer.
 

--- a/libmuscle/python/libmuscle/mmp_client.py
+++ b/libmuscle/python/libmuscle/mmp_client.py
@@ -35,8 +35,7 @@ PEER_TIMEOUT = 600
 PEER_INTERVAL_MIN = 5.0
 PEER_INTERVAL_MAX = 10.0
 
-_CheckpointInfoType = tuple[
-        float, Checkpoints, Optional[Path], Optional[Path]]
+_CheckpointInfoType = tuple[float, Checkpoints, Optional[Path], Optional[Path]]
 
 
 def encode_operator(op: Operator) -> str:
@@ -60,32 +59,38 @@ def encode_profile_event(event: ProfileEvent) -> Any:
     """
     if event.start_time is None or event.stop_time is None:
         raise RuntimeError(
-                'Incomplete ProfileEvent sent. This is a bug, please'
-                ' report it.')
+            "Incomplete ProfileEvent sent. This is a bug, please report it."
+        )
 
     encoded_port = encode_port(event.port) if event.port else None
     return [
-            event.event_type.value,
-            event.start_time.nanoseconds, event.stop_time.nanoseconds,
-            encoded_port, event.port_length, event.slot,
-            event.message_number, event.message_size, event.message_timestamp]
+        event.event_type.value,
+        event.start_time.nanoseconds,
+        event.stop_time.nanoseconds,
+        encoded_port,
+        event.port_length,
+        event.slot,
+        event.message_number,
+        event.message_size,
+        event.message_timestamp,
+    ]
 
 
 def decode_checkpoint_rule(rule: dict[str, Any]) -> CheckpointRule:
     """Decode a checkpoint rule from a MsgPack-compatible value."""
-    if rule.keys() == {'at'}:
+    if rule.keys() == {"at"}:
         return CheckpointAtRule(**rule)
-    if rule.keys() == {'start', 'stop', 'every'}:
+    if rule.keys() == {"start", "stop", "every"}:
         return CheckpointRangeRule(**rule)
-    raise ValueError(f'Cannot convert {rule} to a checkpoint rule.')
+    raise ValueError(f"Cannot convert {rule} to a checkpoint rule.")
 
 
 def decode_checkpoint_info(
-        elapsed_time: float,
-        checkpoints_dict: dict[str, Any],
-        resume: Optional[str],
-        snapshot_dir: Optional[str]
-        ) -> _CheckpointInfoType:
+    elapsed_time: float,
+    checkpoints_dict: dict[str, Any],
+    resume: Optional[str],
+    snapshot_dir: Optional[str],
+) -> _CheckpointInfoType:
     """Decode checkpoint info from a MsgPack-compatible value.
 
     Args:
@@ -101,11 +106,14 @@ def decode_checkpoint_info(
         snapshot_dir: path to the directory to store new snapshots in
     """
     checkpoints = Checkpoints(
-            at_end=checkpoints_dict["at_end"],
-            wallclock_time=[decode_checkpoint_rule(rule)
-                            for rule in checkpoints_dict["wallclock_time"]],
-            simulation_time=[decode_checkpoint_rule(rule)
-                             for rule in checkpoints_dict["simulation_time"]])
+        at_end=checkpoints_dict["at_end"],
+        wallclock_time=[
+            decode_checkpoint_rule(rule) for rule in checkpoints_dict["wallclock_time"]
+        ],
+        simulation_time=[
+            decode_checkpoint_rule(rule) for rule in checkpoints_dict["simulation_time"]
+        ],
+    )
     resume_path = None if resume is None else Path(resume)
     snapshot_path = None if snapshot_dir is None else Path(snapshot_dir)
     return (elapsed_time, checkpoints, resume_path, snapshot_path)
@@ -127,6 +135,7 @@ class MMPClient:
     Communication is protected by an internal lock, so this class can
     be called simultaneously from different threads.
     """
+
     def __init__(self, instance_id: Reference, location: str) -> None:
         """Create an MMPClient
 
@@ -177,9 +186,12 @@ class MMPClient:
                 already.
         """
         request = [
-                RequestType.SUBMIT_LOG_MESSAGE.value,
-                message.instance_id, message.timestamp.seconds,
-                message.level.value, message.text]
+            RequestType.SUBMIT_LOG_MESSAGE.value,
+            message.instance_id,
+            message.timestamp.seconds,
+            message.level.value,
+            message.text,
+        ]
         self._call_manager(request, True)
 
     def submit_profile_events(self, events: Iterable[ProfileEvent]) -> None:
@@ -189,22 +201,23 @@ class MMPClient:
             events: The events to send.
         """
         request = [
-                RequestType.SUBMIT_PROFILE_EVENTS.value,
-                str(self._instance_id),
-                [encode_profile_event(e) for e in events]]
+            RequestType.SUBMIT_PROFILE_EVENTS.value,
+            str(self._instance_id),
+            [encode_profile_event(e) for e in events],
+        ]
         self._call_manager(request)
 
-    def submit_snapshot_metadata(
-            self, snapshot_metadata: SnapshotMetadata) -> None:
+    def submit_snapshot_metadata(self, snapshot_metadata: SnapshotMetadata) -> None:
         """Send snapshot metadata to the manager.
 
         Args:
             snapshot_metadata: Snapshot metadata to supply to the manager.
         """
         request = [
-                RequestType.SUBMIT_SNAPSHOT.value,
-                str(self._instance_id),
-                dataclasses.asdict(snapshot_metadata)]
+            RequestType.SUBMIT_SNAPSHOT.value,
+            str(self._instance_id),
+            dataclasses.asdict(snapshot_metadata),
+        ]
         self._call_manager(request)
 
     def get_settings(self) -> Settings:
@@ -230,8 +243,7 @@ class MMPClient:
         response = self._call_manager(request)
         return decode_checkpoint_info(*response[1:])
 
-    def register_instance(
-            self, locations: list[str], ports: list[Port]) -> None:
+    def register_instance(self, locations: list[str], ports: list[Port]) -> None:
         """Register a component instance with the manager.
 
         Args:
@@ -240,14 +252,15 @@ class MMPClient:
             ports: List of ports of this instance.
         """
         request = [
-                RequestType.REGISTER_INSTANCE.value,
-                str(self._instance_id), locations,
-                [encode_port(p) for p in ports],
-                libmuscle.__version__]
+            RequestType.REGISTER_INSTANCE.value,
+            str(self._instance_id),
+            locations,
+            [encode_port(p) for p in ports],
+            libmuscle.__version__,
+        ]
         response = self._call_manager(request)
         if response[0] == ResponseType.ERROR.value:
-            raise RuntimeError(
-                    f'Error registering instance: {response[1]}')
+            raise RuntimeError(f"Error registering instance: {response[1]}")
 
     def request_peers(self) -> PeerInfo:
         """Request connection information about peers.
@@ -266,75 +279,80 @@ class MMPClient:
         request = [RequestType.GET_PEERS.value, str(self._instance_id)]
         response = self._call_manager(request)
 
-        while (response[0] == ResponseType.PENDING.value and
-               perf_counter() < start_time + PEER_TIMEOUT and
-               sleep_time < PEER_INTERVAL_MIN):
+        while (
+            response[0] == ResponseType.PENDING.value
+            and perf_counter() < start_time + PEER_TIMEOUT
+            and sleep_time < PEER_INTERVAL_MIN
+        ):
             sleep(sleep_time)
             response = self._call_manager(request)
             sleep_time *= 1.5
 
-        while (response[0] == ResponseType.PENDING.value and
-               perf_counter() < start_time + PEER_TIMEOUT):
+        while (
+            response[0] == ResponseType.PENDING.value
+            and perf_counter() < start_time + PEER_TIMEOUT
+        ):
             sleep(uniform(PEER_INTERVAL_MIN, PEER_INTERVAL_MAX))
             response = self._call_manager(request)
 
         if response[0] == ResponseType.PENDING.value:
-            raise RuntimeError('Timeout waiting for peers to appear')
+            raise RuntimeError("Timeout waiting for peers to appear")
 
         if response[0] == ResponseType.ERROR.value:
-            raise RuntimeError(f'Error getting peers from manager: {response[1]}')
+            raise RuntimeError(f"Error getting peers from manager: {response[1]}")
 
         conduits = [Conduit(snd, recv) for snd, recv in response[1]]
 
         peer_dimensions = {
-                Reference(component): dims
-                for component, dims in response[2].items()}
+            Reference(component): dims for component, dims in response[2].items()
+        }
 
         peer_locations = {
-                Reference(instance): locs
-                for instance, locs in response[3].items()}
+            Reference(instance): locs for instance, locs in response[3].items()
+        }
 
-        ports = [
-            Port(Identifier(name), Operator[op]) for name, op in response[4]
-        ]
+        ports = [Port(Identifier(name), Operator[op]) for name, op in response[4]]
         name = instance_to_kernel(self._instance_id)
         index = instance_indices(self._instance_id)
         return PeerInfo(name, index, conduits, peer_dimensions, peer_locations, ports)
 
     def deregister_instance(self) -> None:
-        """Deregister a component instance with the manager.
-        """
-        request = [
-                RequestType.DEREGISTER_INSTANCE.value, str(self._instance_id)]
+        """Deregister a component instance with the manager."""
+        request = [RequestType.DEREGISTER_INSTANCE.value, str(self._instance_id)]
         response = self._call_manager(request)
 
         if response[0] == ResponseType.ERROR.value:
-            raise RuntimeError(f'Error deregistering instance: {response[1]}')
+            raise RuntimeError(f"Error deregistering instance: {response[1]}")
 
     def waiting_for_receive(
-            self, peer_instance_id: Reference, port_name: str, slot: Optional[int]
-            ) -> None:
+        self, peer_instance_id: Reference, port_name: str, slot: Optional[int]
+    ) -> None:
         """Notify the manager that we're waiting to receive a message."""
         request = [
-                RequestType.WAITING_FOR_RECEIVE.value,
-                str(self._instance_id),
-                str(peer_instance_id), port_name, slot]
+            RequestType.WAITING_FOR_RECEIVE.value,
+            str(self._instance_id),
+            str(peer_instance_id),
+            port_name,
+            slot,
+        ]
         self._call_manager(request)
 
     def waiting_for_receive_done(
-            self, peer_instance_id: Reference, port_name: str, slot: Optional[int]
-            ) -> None:
+        self, peer_instance_id: Reference, port_name: str, slot: Optional[int]
+    ) -> None:
         """Notify the manager that we're done waiting to receive a message."""
         request = [
-                RequestType.WAITING_FOR_RECEIVE_DONE.value,
-                str(self._instance_id),
-                str(peer_instance_id), port_name, slot]
+            RequestType.WAITING_FOR_RECEIVE_DONE.value,
+            str(self._instance_id),
+            str(peer_instance_id),
+            port_name,
+            slot,
+        ]
         self._call_manager(request)
 
     def is_deadlocked(self) -> bool:
         """Ask the manager if we're part of a deadlock."""
-        request = [
-                RequestType.IS_DEADLOCKED.value, str(self._instance_id)]
+        request = [RequestType.IS_DEADLOCKED.value, str(self._instance_id)]
         response = self._call_manager(request)
         return bool(response[1])
 

--- a/libmuscle/python/libmuscle/mmsf_validator.py
+++ b/libmuscle/python/libmuscle/mmsf_validator.py
@@ -35,36 +35,40 @@ class MMSFValidator:
         Checks on vector ports are not implemented. When the instance uses vector ports,
         the MMSF Validator will be disabled.
     """
+
     def __init__(self, port_manager: PortManager) -> None:
         self._port_manager = port_manager
 
         port_names = port_manager.list_ports()
         port_objects = {
-                operator: [port_manager.get_port(name) for name in names]
-                for operator, names in port_names.items()}
+            operator: [port_manager.get_port(name) for name in names]
+            for operator, names in port_names.items()
+        }
         self._connected_ports = {
-                operator: [str(port.name) for port in ports if port.is_connected()]
-                for operator, ports in port_objects.items()}
+            operator: [str(port.name) for port in ports if port.is_connected()]
+            for operator, ports in port_objects.items()
+        }
         self._port_operators = {
-                port: operator
-                for operator, ports in port_names.items()
-                for port in ports}
+            port: operator for operator, ports in port_names.items() for port in ports
+        }
 
         if self._connected_ports.get(Operator.NONE, []):
             _logger.warning(
-                    "This instance is using ports with Operator.NONE. This does not "
-                    "adhere to the Multiscale Modelling and Simulation Framework "
-                    "and may lead to deadlocks. You can disable this warning by "
-                    "setting the flag InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS "
-                    "when creating the libmuscle.Instance.")
+                "This instance is using ports with Operator.NONE. This does not "
+                "adhere to the Multiscale Modelling and Simulation Framework "
+                "and may lead to deadlocks. You can disable this warning by "
+                "setting the flag InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS "
+                "when creating the libmuscle.Instance."
+            )
 
         # Allowed operator transitions, the following are unconditionally allowed:
         self._allowed_transitions = {
-                Operator.NONE: [Operator.NONE, Operator.F_INIT],
-                Operator.F_INIT: [Operator.O_I, Operator.O_F],
-                Operator.O_I: [Operator.S],
-                Operator.S: [Operator.O_I, Operator.O_F],
-                Operator.O_F: [Operator.NONE]}
+            Operator.NONE: [Operator.NONE, Operator.F_INIT],
+            Operator.F_INIT: [Operator.O_I, Operator.O_F],
+            Operator.O_I: [Operator.S],
+            Operator.S: [Operator.O_I, Operator.O_F],
+            Operator.O_F: [Operator.NONE],
+        }
         # If there are operators without connected ports, we can skip over those
         # This logic is transitive, i.e. when there are no connected ports for both
         # F_INIT and O_I, we will also add NONE -> S to self._allowed_transition:
@@ -86,13 +90,15 @@ class MMSFValidator:
         # Disable this validator when the instance uses vector ports to keep this class
         # simpler. Support for vector ports may be added in the future.
         self._enabled = not any(
-                port.is_vector() for ports in port_objects.values() for port in ports)
+            port.is_vector() for ports in port_objects.values() for port in ports
+        )
         if self._enabled:
             _logger.debug("MMSF Validator is enabled")
         else:
             _logger.debug(
-                    "MMSF Validator is disabled: this instance uses vector ports, "
-                    "which are not supported by the MMSF Validator.")
+                "MMSF Validator is disabled: this instance uses vector ports, "
+                "which are not supported by the MMSF Validator."
+            )
 
         # State tracking
         self._current_ports_used: list[str] = []
@@ -118,8 +124,7 @@ class MMSFValidator:
         self._current_operator = Operator.F_INIT
         self._current_ports_used = self._connected_ports.get(Operator.F_INIT, [])
 
-    def _check_send_receive(
-            self, port_name: str, slot: Optional[int]) -> None:
+    def _check_send_receive(self, port_name: str, slot: Optional[int]) -> None:
         """Actual implementation of check_send/check_receive."""
         if not self._enabled:
             return
@@ -152,8 +157,8 @@ class MMSFValidator:
         expected: str = ""
 
         unused_ports = [
-                port for port in connected_ports
-                if port not in self._current_ports_used]
+            port for port in connected_ports if port not in self._current_ports_used
+        ]
         if unused_ports:
             # We didn't complete the current phase
             if self._current_operator.allows_receiving():
@@ -161,15 +166,16 @@ class MMSFValidator:
             else:
                 expected = "a send"
             expected += (
-                    f" on any of these {self._current_operator.name} ports: "
-                    + ", ".join(unused_ports))
+                f" on any of these {self._current_operator.name} ports: "
+                + ", ".join(unused_ports)
+            )
 
         elif operator not in self._allowed_transitions[self._current_operator]:
             # Transition to the operator is not allowed.
             # Build the message we want to display to users:
             expected_lst = []
             for to_op in self._allowed_transitions[self._current_operator]:
-                ports = ', '.join(map(repr, self._connected_ports.get(to_op, [])))
+                ports = ", ".join(map(repr, self._connected_ports.get(to_op, [])))
                 if to_op is Operator.NONE:
                     expected_lst.append("a call to reuse_instance()")
                 elif not ports:
@@ -195,8 +201,9 @@ class MMSFValidator:
                 frame: Optional[types.FrameType] = sys._getframe()
             except Exception:
                 frame = None  # sys._getframe() is not guaranteed available
-            while (frame
-                    and frame.f_globals.get("__name__", "").startswith("libmuscle.")):
+            while frame and frame.f_globals.get("__name__", "").startswith(
+                "libmuscle."
+            ):
                 # This frame is still part of a libmuscle module, step up:
                 frame = frame.f_back
             loc = f" ({frame.f_code.co_filename}:{frame.f_lineno})" if frame else ""
@@ -207,7 +214,10 @@ class MMSFValidator:
                 "may lead to deadlocks. You can disable this warning by "
                 "setting the flag InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS "
                 "when creating the libmuscle.Instance.",
-                action, loc, expected)
+                action,
+                loc,
+                expected,
+            )
 
         self._current_operator = operator
         self._current_ports_used = []

--- a/libmuscle/python/libmuscle/mpp_client.py
+++ b/libmuscle/python/libmuscle/mpp_client.py
@@ -15,6 +15,7 @@ class MPPClient:
     This client connects to a peer to retrieve messages. It uses an MCP
     Transport to connect.
     """
+
     def __init__(self, locations: list[str]) -> None:
         """Create an MPPClient for the given peer.
 
@@ -37,12 +38,13 @@ class MPPClient:
             if client:
                 break
         else:
-            raise RuntimeError('Failed to connect')
+            raise RuntimeError("Failed to connect")
 
         self._transport_client = client
 
-    def receive(self, receiver: Reference, timeout_handler: Optional[TimeoutHandler]
-                ) -> tuple[Buffer, ProfileData]:
+    def receive(
+        self, receiver: Reference, timeout_handler: Optional[TimeoutHandler]
+    ) -> tuple[Buffer, ProfileData]:
         """Receive a message from a port this client connects to.
 
         Args:

--- a/libmuscle/python/libmuscle/mpp_message.py
+++ b/libmuscle/python/libmuscle/mpp_message.py
@@ -16,6 +16,7 @@ class ExtTypeId(IntEnum):
     built-in ones. These are distinguished by a number from 0 to 127.
     This class is our registry of extension type ids.
     """
+
     CLOSE_PORT = 0
     SETTINGS = 1
     GRID_INT32 = 2
@@ -26,11 +27,12 @@ class ExtTypeId(IntEnum):
 
 
 _grid_types = {
-        ExtTypeId.GRID_INT32,
-        ExtTypeId.GRID_INT64,
-        ExtTypeId.GRID_FLOAT32,
-        ExtTypeId.GRID_FLOAT64,
-        ExtTypeId.GRID_BOOL}
+    ExtTypeId.GRID_INT32,
+    ExtTypeId.GRID_INT64,
+    ExtTypeId.GRID_FLOAT32,
+    ExtTypeId.GRID_FLOAT64,
+    ExtTypeId.GRID_BOOL,
+}
 
 
 class ClosePort:
@@ -42,26 +44,27 @@ class ClosePort:
 
     All information is carried by the type, this has no attributes.
     """
+
     pass
 
 
 def _encode_grid(grid: Grid) -> msgpack.ExtType:
-    """Encodes a Grid object into the wire format.
-    """
+    """Encodes a Grid object into the wire format."""
     ext_type_map = {
-            'int32': ExtTypeId.GRID_INT32,
-            'int64': ExtTypeId.GRID_INT64,
-            'float32': ExtTypeId.GRID_FLOAT32,
-            'float64': ExtTypeId.GRID_FLOAT64,
-            'bool': ExtTypeId.GRID_BOOL}
+        "int32": ExtTypeId.GRID_INT32,
+        "int64": ExtTypeId.GRID_INT64,
+        "float32": ExtTypeId.GRID_FLOAT32,
+        "float64": ExtTypeId.GRID_FLOAT64,
+        "bool": ExtTypeId.GRID_BOOL,
+    }
 
     array = grid.array
     if array.flags.f_contiguous:
         # indexes that differ in the first place are adjacent
-        order = 'fa'
+        order = "fa"
     else:
         # indexes that differ in the last place are adjacent
-        order = 'la'
+        order = "la"
 
     # dtype is a bit weird, but this seems to be consistent
     if isinstance(array.dtype, np.dtype):
@@ -70,41 +73,40 @@ def _encode_grid(grid: Grid) -> msgpack.ExtType:
         array_type = str(np.dtype(array_type))
 
     if array_type not in ext_type_map:
-        raise RuntimeError('Unsupported array data type')
+        raise RuntimeError("Unsupported array data type")
 
-    buf = array.tobytes(order='A')
+    buf = array.tobytes(order="A")
 
     # array_type is redundant, but useful metadata.
     grid_dict = {
-            'type': array_type,
-            'shape': list(array.shape),
-            'order': order,
-            'data': buf,
-            'indexes': grid.indexes}
+        "type": array_type,
+        "shape": list(array.shape),
+        "order": order,
+        "data": buf,
+        "indexes": grid.indexes,
+    }
     packed_data = msgpack.packb(grid_dict, use_bin_type=True)
     return msgpack.ExtType(ext_type_map[array_type], packed_data)
 
 
 def _decode_grid(code: int, data: Buffer) -> Grid:
-    """Creates a Grid from serialised data.
-    """
+    """Creates a Grid from serialised data."""
     type_map = {
-            ExtTypeId.GRID_INT32: np.int32,
-            ExtTypeId.GRID_INT64: np.int64,
-            ExtTypeId.GRID_FLOAT32: np.float32,
-            ExtTypeId.GRID_FLOAT64: np.float64,
-            ExtTypeId.GRID_BOOL: np.bool_}
+        ExtTypeId.GRID_INT32: np.int32,
+        ExtTypeId.GRID_INT64: np.int64,
+        ExtTypeId.GRID_FLOAT32: np.float32,
+        ExtTypeId.GRID_FLOAT64: np.float64,
+        ExtTypeId.GRID_BOOL: np.bool_,
+    }
 
-    order_map = {
-            'fa': 'F',
-            'la': 'C'}
+    order_map = {"fa": "F", "la": "C"}
 
     grid_dict = msgpack.unpackb(data, raw=False)
-    order = order_map[grid_dict['order']]
-    shape = tuple(grid_dict['shape'])
+    order = order_map[grid_dict["order"]]
+    shape = tuple(grid_dict["shape"])
     dtype = type_map[ExtTypeId(code)]
-    array = np.ndarray(shape, dtype, grid_dict['data'], order=order)  # type: ignore
-    indexes = grid_dict['indexes']
+    array = np.ndarray(shape, dtype, grid_dict["data"], order=order)  # type: ignore
+    indexes = grid_dict["indexes"]
     if indexes == []:
         indexes = None
     return Grid(array, indexes)
@@ -117,10 +119,9 @@ def _data_encoder(obj: Any) -> Any:
     numpy.ndarray objects the user may want to send.
     """
     if isinstance(obj, ClosePort):
-        return msgpack.ExtType(ExtTypeId.CLOSE_PORT, b'')
+        return msgpack.ExtType(ExtTypeId.CLOSE_PORT, b"")
     elif isinstance(obj, Settings):
-        packed_data = msgpack.packb(obj.as_ordered_dict(),
-                                    use_bin_type=True)
+        packed_data = msgpack.packb(obj.as_ordered_dict(), use_bin_type=True)
         return msgpack.ExtType(ExtTypeId.SETTINGS, packed_data)
     elif isinstance(obj, np.ndarray):
         return _encode_grid(Grid(obj))
@@ -147,12 +148,19 @@ class MPPMessage:
     they can be routed by a MUSCLE Transport Overlay when we get to
     multi-site running in the future.
     """
-    def __init__(self, sender: Reference, receiver: Reference,
-                 port_length: Optional[int],
-                 timestamp: float, next_timestamp: Optional[float],
-                 settings_overlay: Settings, message_number: int,
-                 saved_until: float, data: Any
-                 ) -> None:
+
+    def __init__(
+        self,
+        sender: Reference,
+        receiver: Reference,
+        port_length: Optional[int],
+        timestamp: float,
+        next_timestamp: Optional[float],
+        settings_overlay: Settings,
+        message_number: int,
+        saved_until: float,
+        data: Any,
+    ) -> None:
         """Create an MPPMessage.
 
         Senders and receivers are refered to by a Reference, which
@@ -193,14 +201,13 @@ class MPPMessage:
             self.data = data
 
     @staticmethod
-    def from_bytes(message: Buffer) -> 'MPPMessage':
+    def from_bytes(message: Buffer) -> "MPPMessage":
         """Create an MPP Message from an encoded buffer.
 
         Args:
             message: MessagePack encoded message data.
         """
-        message_dict = msgpack.unpackb(
-                message, ext_hook=_ext_decoder, raw=False)
+        message_dict = msgpack.unpackb(message, ext_hook=_ext_decoder, raw=False)
         sender = Reference(message_dict["sender"])
         receiver = Reference(message_dict["receiver"])
         port_length = message_dict["port_length"]
@@ -212,23 +219,32 @@ class MPPMessage:
 
         data = message_dict["data"]
         return MPPMessage(
-                sender, receiver, port_length, timestamp, next_timestamp,
-                settings_overlay, message_number, saved_until, data)
+            sender,
+            receiver,
+            port_length,
+            timestamp,
+            next_timestamp,
+            settings_overlay,
+            message_number,
+            saved_until,
+            data,
+        )
 
     def encoded(self) -> Buffer:
-        """Encode the message and return as a bytes buffer.
-        """
+        """Encode the message and return as a bytes buffer."""
         message_dict = {
-                'sender': str(self.sender),
-                'receiver': str(self.receiver),
-                'port_length': self.port_length,
-                'timestamp': self.timestamp,
-                'next_timestamp': self.next_timestamp,
-                'settings_overlay': self.settings_overlay,
-                'message_number': self.message_number,
-                'saved_until': self.saved_until,
-                'data': self.data
-                }
+            "sender": str(self.sender),
+            "receiver": str(self.receiver),
+            "port_length": self.port_length,
+            "timestamp": self.timestamp,
+            "next_timestamp": self.next_timestamp,
+            "settings_overlay": self.settings_overlay,
+            "message_number": self.message_number,
+            "saved_until": self.saved_until,
+            "data": self.data,
+        }
 
-        return cast(Buffer, msgpack.packb(
-            message_dict, default=_data_encoder, use_bin_type=True))
+        return cast(
+            Buffer,
+            msgpack.packb(message_dict, default=_data_encoder, use_bin_type=True),
+        )

--- a/libmuscle/python/libmuscle/mpp_server.py
+++ b/libmuscle/python/libmuscle/mpp_server.py
@@ -14,6 +14,7 @@ class MPPRequestHandler(RequestHandler):
     This accepts peer protocol message requests and responds to them by
     getting messages from a PostOffice.
     """
+
     def __init__(self, post_office: PostOffice) -> None:
         """Create an MPPRequestHandler.
 
@@ -36,8 +37,7 @@ class MPPRequestHandler(RequestHandler):
         """
         req = msgpack.unpackb(request, raw=False)
         if len(req) != 2 or req[0] != RequestType.GET_NEXT_MESSAGE.value:
-            raise RuntimeError(
-                    'Invalid request type. Did the streams get crossed?')
+            raise RuntimeError("Invalid request type. Did the streams get crossed?")
         recv_port = Reference(req[1])
         return self._post_office.get_message(recv_port)
 
@@ -48,6 +48,7 @@ class MPPServer:
     This manages a collection of servers for different protocols and a
     PostOffice that stores outgoing messages.
     """
+
     def __init__(self) -> None:
         self._post_office = PostOffice()
         self._handler = MPPRequestHandler(self._post_office)

--- a/libmuscle/python/libmuscle/native_instantiator/agent/__main__.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent/__main__.py
@@ -20,6 +20,7 @@ _logger = logging.getLogger(__name__)
 
 class Agent:
     """Runs on a compute node and starts processes there."""
+
     def __init__(self, node_name: str, server_location: str) -> None:
         """Create an Agent.
 
@@ -27,45 +28,50 @@ class Agent:
             node_name: Name (hostname) of this node
             server_location: MAP server of the manager to connect to
         """
-        _logger.info(f'Agent at {node_name} starting')
+        _logger.info(f"Agent at {node_name} starting")
 
         self._process_manager = ProcessManager()
 
         self._node_name = node_name
 
-        _logger.info(f'Connecting to manager at {server_location}')
+        _logger.info(f"Connecting to manager at {server_location}")
         self._server = MAPClient(self._node_name, server_location)
-        _logger.info('Connected to manager')
+        _logger.info("Connected to manager")
 
     def run(self) -> None:
         """Execute commands and monitor processes."""
-        _logger.info('Reporting resources')
+        _logger.info("Reporting resources")
         self._server.report_resources(self._inspect_resources())
 
         shutting_down = False
         while not shutting_down:
             command = self._server.get_command()
             if isinstance(command, StartCommand):
-                _logger.info(f'Starting process {command.name}')
-                _logger.debug(f'Args: {command.args}')
-                _logger.debug(f'Env: {command.env}')
+                _logger.info(f"Starting process {command.name}")
+                _logger.debug(f"Args: {command.args}")
+                _logger.debug(f"Env: {command.env}")
 
                 self._process_manager.start(
-                        command.name, command.work_dir, command.args, command.env,
-                        command.stdout, command.stderr)
+                    command.name,
+                    command.work_dir,
+                    command.args,
+                    command.env,
+                    command.stdout,
+                    command.stderr,
+                )
             elif isinstance(command, CancelAllCommand):
-                _logger.info('Cancelling all instances')
+                _logger.info("Cancelling all instances")
                 self._process_manager.cancel_all()
 
             elif isinstance(command, ShutdownCommand):
                 # check that nothing is running
                 shutting_down = True
-                _logger.info('Agent shutting down')
+                _logger.info("Agent shutting down")
 
             finished = self._process_manager.get_finished()
             if finished:
                 for name, exit_code in finished:
-                    _logger.info(f'Process {name} finished with exit code {exit_code}')
+                    _logger.info(f"Process {name} finished with exit code {exit_code}")
                 self._server.report_result(finished)
 
             sleep(0.1)
@@ -83,18 +89,18 @@ class Agent:
         Returns:
             A dict mapping resource types to resource descriptions.
         """
-        if hasattr(os, 'sched_getaffinity'):
+        if hasattr(os, "sched_getaffinity"):
             hwthreads_by_core_tuple: dict[tuple[int, int], set[int]] = dict()
 
             # these are the logical hwthread ids that we can use
             hwthread_ids = list(os.sched_getaffinity(0))
 
             for hwthread_id in hwthread_ids:
-                topdir = f'/sys/devices/system/cpu/cpu{hwthread_id}/topology'
-                with open(f'{topdir}/core_id') as f:
+                topdir = f"/sys/devices/system/cpu/cpu{hwthread_id}/topology"
+                with open(f"{topdir}/core_id") as f:
                     # this gets the logical core id for the hwthread
                     core_id = int(f.read())
-                with open(f'{topdir}/physical_package_id') as f:
+                with open(f"{topdir}/physical_package_id") as f:
                     # this gets the die/socket id for the hwthread
                     package_id = int(f.read())
 
@@ -102,13 +108,16 @@ class Agent:
                 hwthreads_by_core_tuple.setdefault(core_tuple, set()).add(hwthread_id)
 
             core_lgid_hwthreads = [
-                    (i, hwthreads_by_core_tuple[core_tuple])
-                    for i, core_tuple in enumerate(
-                        sorted(hwthreads_by_core_tuple.keys()))]
+                (i, hwthreads_by_core_tuple[core_tuple])
+                for i, core_tuple in enumerate(sorted(hwthreads_by_core_tuple.keys()))
+            ]
 
-            cores = CoreSet((
+            cores = CoreSet(
+                (
                     Core(core_lgid, hwthreads)
-                    for core_lgid, hwthreads in core_lgid_hwthreads))
+                    for core_lgid, hwthreads in core_lgid_hwthreads
+                )
+            )
 
         else:
             # MacOS doesn't support thread affinity, but older Macs with Intel
@@ -123,17 +132,17 @@ class Agent:
             if nhwthreads is None:
                 if ncores is not None:
                     _logger.warning(
-                            'Could not determine number of hwthreads, assuming no SMT')
+                        "Could not determine number of hwthreads, assuming no SMT"
+                    )
                     nhwthreads = ncores
                 else:
                     _logger.warning(
-                            'Could not determine CPU configuration, assuming a single'
-                            ' core')
+                        "Could not determine CPU configuration, assuming a single core"
+                    )
                     ncores = 1
                     nhwthreads = 1
             elif ncores is None:
-                _logger.warning(
-                        'Could not determine number of cores, assuming no SMT')
+                _logger.warning("Could not determine number of cores, assuming no SMT")
                 ncores = nhwthreads
 
             hwthreads_per_core = nhwthreads // ncores
@@ -142,34 +151,35 @@ class Agent:
                 # As far as I know, there are no Macs with heterogeneous SMT, like in
                 # the latest Intel CPUs.
                 _logger.warning(
-                        'Only some cores seem to have SMT, core ids are probably'
-                        ' wrong. If this is a cluster then this will cause problems,'
-                        ' please report an issue on GitHub and report the machine and'
-                        ' what kind of OS and hardware it has. If we\'re running on a'
-                        ' local machine, then this won\'t affect the run, but I\'d'
-                        ' still appreciate an issue, because it is unexpected for sure.'
-                        )
+                    "Only some cores seem to have SMT, core ids are probably"
+                    " wrong. If this is a cluster then this will cause problems,"
+                    " please report an issue on GitHub and report the machine and"
+                    " what kind of OS and hardware it has. If we're running on a"
+                    " local machine, then this won't affect the run, but I'd"
+                    " still appreciate an issue, because it is unexpected for sure."
+                )
 
             cores = CoreSet(
-                    Core(
-                        cid,
-                        set(range(
-                            cid * hwthreads_per_core, (cid + 1) * hwthreads_per_core))
-                        )
-                    for cid in range(ncores)
-                    )
+                Core(
+                    cid,
+                    set(
+                        range(cid * hwthreads_per_core, (cid + 1) * hwthreads_per_core)
+                    ),
+                )
+                for cid in range(ncores)
+            )
 
         resources = OnNodeResources(self._node_name, cores)
-        _logger.info(f'Found resources: {resources}')
+        _logger.info(f"Found resources: {resources}")
         return resources
 
 
 def configure_logging(node_name: str, log_level: int) -> None:
     """Make us output logs to a custom log file."""
-    fmt = '%(asctime)s %(levelname)s %(message)s'
+    fmt = "%(asctime)s %(levelname)s %(message)s"
     formatter = logging.Formatter(fmt)
 
-    handler = logging.FileHandler(f'muscle3_agent_{node_name}.log', mode='w')
+    handler = logging.FileHandler(f"muscle3_agent_{node_name}.log", mode="w")
     handler.setFormatter(formatter)
 
     # Find and remove default handler to disable automatic console output
@@ -177,15 +187,15 @@ def configure_logging(node_name: str, log_level: int) -> None:
     # seems reliable, and doesn't mess up pytest's caplog mechanism while
     # it also doesn't introduce a runtime dependency on pytest.
     logging.getLogger().handlers = [
-            h for h in logging.getLogger().handlers
-            if 'stderr' not in str(h)]
+        h for h in logging.getLogger().handlers if "stderr" not in str(h)
+    ]
 
     logging.getLogger().addHandler(handler)
 
     logging.getLogger().setLevel(log_level)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     node_name = gethostname()
     server_location = sys.argv[1]
     log_level = int(sys.argv[2])

--- a/libmuscle/python/libmuscle/native_instantiator/agent/map_client.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent/map_client.py
@@ -19,6 +19,7 @@ class MAPClient:
 
     This class connects to the AgentManager and communicates with it.
     """
+
     def __init__(self, node_name: str, location: str) -> None:
         """Create a MAPClient
 
@@ -44,8 +45,10 @@ class MAPClient:
         """
         enc_cpu_resources = [[c.cid] + list(c.hwthreads) for c in resources.cpu_cores]
         request = [
-                RequestType.REPORT_RESOURCES.value,
-                resources.node_name, {'cpu': enc_cpu_resources}]
+            RequestType.REPORT_RESOURCES.value,
+            resources.node_name,
+            {"cpu": enc_cpu_resources},
+        ]
         self._call_agent_manager(request)
 
     def get_command(self) -> Optional[AgentCommand]:
@@ -78,7 +81,7 @@ class MAPClient:
         elif command[0] == AgentCommandType.SHUTDOWN.value:
             return ShutdownCommand()
 
-        raise Exception('Unknown AgentCommand')
+        raise Exception("Unknown AgentCommand")
 
     def report_result(self, names_exit_codes: list[tuple[str, int]]) -> None:
         """Report results of finished processes.

--- a/libmuscle/python/libmuscle/native_instantiator/agent_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/agent_manager.py
@@ -30,6 +30,7 @@ class AgentManager(IAgentManager):
     cancel processes on nodes, and it gets called by MAPServer with requests from the
     agents.
     """
+
     def __init__(self, agent_dir: Path) -> None:
         """Create an AgentManager.
 
@@ -42,7 +43,7 @@ class AgentManager(IAgentManager):
         self._expected_nodes = global_resources().nodes
         self._nodes: dict[str, str] = dict()
         self._resources: Resources = Resources([])
-        self._resources_lock = Lock()   # protects _nodes and _resources
+        self._resources_lock = Lock()  # protects _nodes and _resources
 
         self._finished_processes: list[tuple[str, int]] = list()
         self._finished_processes_lock = Lock()
@@ -61,8 +62,15 @@ class AgentManager(IAgentManager):
         return self._resources
 
     def start(
-            self, node_name: str, name: str, work_dir: Path, args: list[str],
-            env: dict[str, str], stdout: Path, stderr: Path) -> None:
+        self,
+        node_name: str,
+        name: str,
+        work_dir: Path,
+        args: list[str],
+        env: dict[str, str],
+        stdout: Path,
+        stderr: Path,
+    ) -> None:
         """Start a process on a node.
 
         The files that the output is directed to will be overwritten if they already
@@ -116,7 +124,8 @@ class AgentManager(IAgentManager):
             self._agents_process.wait(60)
         except TimeoutExpired:
             _logger.warning(
-                    'Agents did not shut down within one minute, sending signal...')
+                "Agents did not shut down within one minute, sending signal..."
+            )
             self._agents_process.kill()
 
         try:
@@ -124,7 +133,7 @@ class AgentManager(IAgentManager):
             self._agents_stdout.close()
             self._agents_stderr.close()
         except TimeoutExpired:
-            _logger.warning('Agents still not down, continuing shutdown anyway.')
+            _logger.warning("Agents still not down, continuing shutdown anyway.")
 
         self._server.stop()
 
@@ -136,7 +145,7 @@ class AgentManager(IAgentManager):
         Args:
             resources: Description of a node's resources
         """
-        _logger.debug(f'Agent reported {resources}')
+        _logger.debug(f"Agent reported {resources}")
 
         # The agent reports a hostname, which we assume contains the node name
         agent_hostname = resources.node_name
@@ -146,9 +155,10 @@ class AgentManager(IAgentManager):
                 break
         else:
             _logger.warning(
-                    f'Agent reported hostname {resources.node_name}, which could not'
-                    ' be matched against any expected node name from'
-                    f' {self._expected_nodes}.')
+                f"Agent reported hostname {resources.node_name}, which could not"
+                " be matched against any expected node name from"
+                f" {self._expected_nodes}."
+            )
 
         with self._resources_lock:
             self._nodes[resources.node_name] = agent_hostname
@@ -176,28 +186,33 @@ class AgentManager(IAgentManager):
             server_location: MAPServer network location string for the agents to
                 connect to
         """
-        _logger.info('Launching MUSCLE agents...')
+        _logger.info("Launching MUSCLE agents...")
 
         python = sys.executable
         if not python:
             raise RuntimeError(
-                    'Could not launch agents because sys.executable is not set.')
+                "Could not launch agents because sys.executable is not set."
+            )
 
-        log_level = logging.getLogger('libmuscle').getEffectiveLevel()
+        log_level = logging.getLogger("libmuscle").getEffectiveLevel()
 
         args = [
-                sys.executable, '-m', 'libmuscle.native_instantiator.agent',
-                server_location, str(log_level)]
+            sys.executable,
+            "-m",
+            "libmuscle.native_instantiator.agent",
+            server_location,
+            str(log_level),
+        ]
 
         args = global_resources().agent_launch_command(args)
 
-        self._agents_stdout = (agent_dir / 'agent_launch.out').open('a')
-        self._agents_stderr = (agent_dir / 'agent_launch.err').open('a')
+        self._agents_stdout = (agent_dir / "agent_launch.out").open("a")
+        self._agents_stderr = (agent_dir / "agent_launch.err").open("a")
 
-        _logger.debug(f'Launching agents using {args}')
+        _logger.debug(f"Launching agents using {args}")
         self._agents_process = Popen(
-                args, cwd=agent_dir, stdout=self._agents_stdout,
-                stderr=self._agents_stderr)
+            args, cwd=agent_dir, stdout=self._agents_stdout, stderr=self._agents_stderr
+        )
 
         num_expected = len(self._expected_nodes)
 
@@ -208,23 +223,25 @@ class AgentManager(IAgentManager):
                 resources_complete = len(self._nodes) == num_expected
                 too_many_agents = len(self._nodes) > num_expected
 
-            _logger.debug(f'{len(self._nodes)} agents up of {num_expected}')
+            _logger.debug(f"{len(self._nodes)} agents up of {num_expected}")
 
             if self._agents_process.poll() is not None:
                 msg = (
-                        'Agents unexpectedly stopped running. This is not supposed'
-                        ' to happen. Please see the agent log for more information,'
-                        ' and please file an issue on GitHub.')
+                    "Agents unexpectedly stopped running. This is not supposed"
+                    " to happen. Please see the agent log for more information,"
+                    " and please file an issue on GitHub."
+                )
                 _logger.error(msg)
                 raise RuntimeError(msg)
 
             if too_many_agents:
                 msg = (
-                        'More agents were started than MUSCLE3 asked for. This is not'
-                        ' supposed to happen. Please file an issue on GitHub, with the'
-                        ' SLURM version (use "sbatch -V") and the sbatch command used'
-                        ' to submit the job.')
+                    "More agents were started than MUSCLE3 asked for. This is not"
+                    " supposed to happen. Please file an issue on GitHub, with the"
+                    ' SLURM version (use "sbatch -V") and the sbatch command used'
+                    " to submit the job."
+                )
                 _logger.error(msg)
                 raise RuntimeError(msg)
 
-        _logger.info(f'All agents running on {self._nodes}')
+        _logger.info(f"All agents running on {self._nodes}")

--- a/libmuscle/python/libmuscle/native_instantiator/global_resources.py
+++ b/libmuscle/python/libmuscle/native_instantiator/global_resources.py
@@ -28,6 +28,7 @@ class GlobalResources:
         logical_cpus_per_node: Number of cores available on each node.
                 List alongside nodes.
     """
+
     def __init__(self) -> None:
         """Create a GlobalResources.
 
@@ -35,20 +36,22 @@ class GlobalResources:
         queried.
         """
         if slurm().in_slurm_allocation():
-            _logger.info('Detected a SLURM allocation')
+            _logger.info("Detected a SLURM allocation")
             self.scheduler = Scheduler.SLURM
             self.nodes = slurm().get_nodes()
             self.logical_cpus_per_node = slurm().get_logical_cpus_per_node()
             _logger.info(
-                    f'We have {len(self.nodes)} nodes and a total of'
-                    f' {sum(self.logical_cpus_per_node)} logical CPUs available')
+                f"We have {len(self.nodes)} nodes and a total of"
+                f" {sum(self.logical_cpus_per_node)} logical CPUs available"
+            )
         else:
-            _logger.info('Running locally without a cluster scheduler')
+            _logger.info("Running locally without a cluster scheduler")
             self.scheduler = Scheduler.NONE
             self.nodes = [gethostname()]
             self.logical_cpus_per_node = [psutil.cpu_count(logical=True) or 0]
             _logger.info(
-                    f'We have {self.logical_cpus_per_node[0]} logical CPUS available')
+                f"We have {self.logical_cpus_per_node[0]} logical CPUS available"
+            )
 
     def on_cluster(self) -> bool:
         """Return whether we're running on a cluster."""

--- a/libmuscle/python/libmuscle/native_instantiator/iagent_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/iagent_manager.py
@@ -7,6 +7,7 @@ class IAgentManager:
     Only implemented by AgentManager, and only exists to avoid a circular dependency
     between AgentManager, MAPServer, and MAPRequestHandler. Ugh.
     """
+
     def report_resources(self, resources: OnNodeResources) -> None:
         """Report resources found on a node.
 

--- a/libmuscle/python/libmuscle/native_instantiator/map_server.py
+++ b/libmuscle/python/libmuscle/native_instantiator/map_server.py
@@ -24,6 +24,7 @@ _logger = logging.getLogger(__name__)
 
 class MAPRequestHandler(RequestHandler):
     """Handles Agent requests."""
+
     def __init__(self, agent_manager: IAgentManager, post_office: PostOffice) -> None:
         """Create a MAPRequestHandler.
 
@@ -55,8 +56,7 @@ class MAPRequestHandler(RequestHandler):
 
         return cast(Buffer, msgpack.packb(response, use_bin_type=True))
 
-    def _report_resources(
-            self, node_name: str, data: dict[str, Any]) -> Any:
+    def _report_resources(self, node_name: str, data: dict[str, Any]) -> Any:
         """Handle a report resources request.
 
         This is used by the agent to report available resources on its node when
@@ -69,7 +69,7 @@ class MAPRequestHandler(RequestHandler):
                 id at index [0] followed by the hwthread ids of all hwthreads in this
                 core.
         """
-        cores = CoreSet(Core(ids[0], set(ids[1:])) for ids in data['cpu'])
+        cores = CoreSet(Core(ids[0], set(ids[1:])) for ids in data["cpu"])
         node_resources = OnNodeResources(node_name, cores)
         self._agent_manager.report_resources(node_resources)
         return [ResponseType.SUCCESS.value]
@@ -87,7 +87,7 @@ class MAPRequestHandler(RequestHandler):
         Args:
             node_name: Hostname (name) of the agent's node
         """
-        node_ref = Reference('_' + node_name.replace('-', '_'))
+        node_ref = Reference("_" + node_name.replace("-", "_"))
         next_request: Optional[Buffer] = None
         if self._post_office.have_message(node_ref):
             next_request = self._post_office.get_message(node_ref)
@@ -117,6 +117,7 @@ class MAPServer:
     This class accepts connections from the agents and services them using a
     MAPRequestHandler.
     """
+
     def __init__(self, agent_manager: IAgentManager) -> None:
         """Create a MAPServer.
 
@@ -162,13 +163,18 @@ class MAPServer:
             node_name: Name of the node whose agent should execute the command
             command: The command to send
         """
-        agent = Reference('_' + node_name.replace('-', '_'))
+        agent = Reference("_" + node_name.replace("-", "_"))
 
         if isinstance(command, StartCommand):
             command_obj = [
-                    AgentCommandType.START.value, command.name, str(command.work_dir),
-                    command.args, command.env, str(command.stdout), str(command.stderr)
-                    ]
+                AgentCommandType.START.value,
+                command.name,
+                str(command.work_dir),
+                command.args,
+                command.env,
+                str(command.stdout),
+                str(command.stderr),
+            ]
         elif isinstance(command, CancelAllCommand):
             command_obj = [AgentCommandType.CANCEL_ALL.value]
         elif isinstance(command, ShutdownCommand):

--- a/libmuscle/python/libmuscle/native_instantiator/native_instantiator.py
+++ b/libmuscle/python/libmuscle/native_instantiator/native_instantiator.py
@@ -35,9 +35,15 @@ _logger = logging.getLogger(__name__)
 
 class NativeInstantiator(mp.Process):
     """Instantiates instances on the local machine."""
+
     def __init__(
-            self, resources: mp.Queue, requests: mp.Queue, results: mp.Queue,
-            log_records: mp.Queue, run_dir: Path) -> None:
+        self,
+        resources: mp.Queue,
+        requests: mp.Queue,
+        results: mp.Queue,
+        log_records: mp.Queue,
+        run_dir: Path,
+    ) -> None:
         """Create a NativeInstantiator
 
         Args:
@@ -47,7 +53,7 @@ class NativeInstantiator(mp.Process):
             log_messages: Queue to push log messages to
             run_dir: Run directory for the current run
         """
-        super().__init__(name='NativeInstantiator')
+        super().__init__(name="NativeInstantiator")
         self._resources_out = resources
         self._requests_in = requests
         self._results_out = results
@@ -59,7 +65,7 @@ class NativeInstantiator(mp.Process):
     def run(self) -> None:
         """Entry point for the process"""
         try:
-            logs_dir = self._run_dir / 'logs'
+            logs_dir = self._run_dir / "logs"
             logs_dir.mkdir(exist_ok=True)
 
             self._agent_manager = AgentManager(logs_dir)
@@ -71,7 +77,7 @@ class NativeInstantiator(mp.Process):
         except ConfigurationError as e:
             self._results_out.put(CrashedResult(e))
 
-        except:     # noqa
+        except:  # noqa
             for line in traceback.format_exception(*sys.exc_info()):
                 _logger.error(line)
 
@@ -92,15 +98,15 @@ class NativeInstantiator(mp.Process):
                 try:
                     request = self._requests_in.get_nowait()
                     if isinstance(request, ShutdownRequest):
-                        _logger.debug('Got ShutdownRequest')
+                        _logger.debug("Got ShutdownRequest")
                         shutting_down = True
 
                     elif isinstance(request, CancelAllRequest):
-                        _logger.debug('Got CancelAllRequest')
+                        _logger.debug("Got CancelAllRequest")
                         self._agent_manager.cancel_all()
 
                     elif isinstance(request, InstantiationRequest):
-                        _logger.debug('Got InstantiationRequest')
+                        _logger.debug("Got InstantiationRequest")
                         if not shutting_down:
                             self._instantiate(request)
 
@@ -111,7 +117,7 @@ class NativeInstantiator(mp.Process):
             self._report_finished_processes()
 
             if shutting_down:
-                _logger.debug(f'Remaining processes: {self._processes}')
+                _logger.debug(f"Remaining processes: {self._processes}")
                 done = not self._processes
 
             if not done:
@@ -134,15 +140,17 @@ class NativeInstantiator(mp.Process):
         agent_res = self._agent_manager.get_resources()
 
         env_ncpus = dict(
-                zip(global_resources().nodes, global_resources().logical_cpus_per_node)
-                )
+            zip(global_resources().nodes, global_resources().logical_cpus_per_node)
+        )
 
         for node_name in env_ncpus:
             if node_name not in agent_res.nodes():
                 _logger.warning(
-                        f'The environment suggests we should have node {node_name},'
-                        ' but no agent reported running on it. We won''t be able'
-                        ' to use this node.')
+                    f"The environment suggests we should have node {node_name},"
+                    " but no agent reported running on it. We won"
+                    "t be able"
+                    " to use this node."
+                )
             else:
                 env_nncpus = env_ncpus[node_name]
                 ag_nncores = len(agent_res[node_name].cpu_cores)
@@ -151,33 +159,37 @@ class NativeInstantiator(mp.Process):
                 if ag_nncores != ag_nnthreads and ag_nnthreads == env_nncpus:
                     if not already_logged_smt:
                         _logger.info(
-                                'Detected SMT (hyperthreading) as available and'
-                                ' enabled. Note that MUSCLE3 will assign whole cores to'
-                                ' each thread or MPI process.')
+                            "Detected SMT (hyperthreading) as available and"
+                            " enabled. Note that MUSCLE3 will assign whole cores to"
+                            " each thread or MPI process."
+                        )
                         already_logged_smt = True
 
                     resources.add_node(agent_res[node_name])
 
                 elif ag_nncores < env_nncpus:
                     _logger.warning(
-                            f'Node {node_name} should have {env_nncpus} cores'
-                            f' available, but the agent reports only {ag_nncores}'
-                            f' available to it. We\'ll use the {ag_nncores} we seem to'
-                            ' have.')
+                        f"Node {node_name} should have {env_nncpus} cores"
+                        f" available, but the agent reports only {ag_nncores}"
+                        f" available to it. We'll use the {ag_nncores} we seem to"
+                        " have."
+                    )
 
                     resources.add_node(agent_res[node_name])
 
                 elif env_nncpus < ag_nncores:
                     _logger.warning(
-                            f'Node {node_name} should have {env_nncpus} cores'
-                            f' available, but the agent reports {ag_nncores} available'
-                            ' to it. Maybe the cluster does not constrain resources?'
-                            f' We\'ll use the {env_nncpus} that we should have got.')
+                        f"Node {node_name} should have {env_nncpus} cores"
+                        f" available, but the agent reports {ag_nncores} available"
+                        " to it. Maybe the cluster does not constrain resources?"
+                        f" We'll use the {env_nncpus} that we should have got."
+                    )
                     resources.add_node(
-                            OnNodeResources(
-                                node_name,
-                                agent_res[node_name].cpu_cores.get_first_cores(
-                                    env_nncpus)))
+                        OnNodeResources(
+                            node_name,
+                            agent_res[node_name].cpu_cores.get_first_cores(env_nncpus),
+                        )
+                    )
 
                 else:
                     # no SMT, agent matches environment
@@ -186,12 +198,12 @@ class NativeInstantiator(mp.Process):
         for node in agent_res:
             if node.node_name not in env_ncpus:
                 _logger.warning(
-                        f'An agent is running on node {node.node_name} but the'
-                        ' environment does not list it as ours. It seems that the'
-                        ' node\'s hostname does not match what SLURM calls it. We will'
-                        ' not use this node, because we\'re not sure it\'s really ours'
-                        ' or if it is, how many resources on it we can use.'
-                        )
+                    f"An agent is running on node {node.node_name} but the"
+                    " environment does not list it as ours. It seems that the"
+                    " node's hostname does not match what SLURM calls it. We will"
+                    " not use this node, because we're not sure it's really ours"
+                    " or if it is, how many resources on it we can use."
+                )
 
         self._resources_out.put(resources)
 
@@ -200,19 +212,21 @@ class NativeInstantiator(mp.Process):
         name = str(request.instance)
 
         env = create_instance_env(
-                request.instance, request.program.base_env, request.program.env)
+            request.instance, request.program.base_env, request.program.env
+        )
         self._add_resources(env, request.res_req)
 
-        rankfile = request.instance_dir / 'rankfile'
+        rankfile = request.instance_dir / "rankfile"
 
         if global_resources().on_cluster():
             rankfile_contents, resource_env = prep_resources(
-                  request.program.execution_model, request.resources, rankfile)
+                request.program.execution_model, request.resources, rankfile
+            )
 
             if rankfile_contents:
-                with rankfile.open('w') as f:
+                with rankfile.open("w") as f:
                     f.write(rankfile_contents)
-                env['MUSCLE_RANKFILE'] = str(rankfile)
+                env["MUSCLE_RANKFILE"] = str(rankfile)
 
             env.update(resource_env)
 
@@ -221,48 +235,59 @@ class NativeInstantiator(mp.Process):
 
         self._processes[name] = Process(request.instance, request.resources)
 
-        _logger.debug(f'Instantiating {name} on {request.resources}')
+        _logger.debug(f"Instantiating {name} on {request.resources}")
         try:
             self._agent_manager.start(
-                    request.resources.by_rank[0].node_name,
-                    name, request.work_dir, args, env,
-                    request.stdout_path, request.stderr_path)
+                request.resources.by_rank[0].node_name,
+                name,
+                request.work_dir,
+                args,
+                env,
+                request.stdout_path,
+                request.stderr_path,
+            )
             self._processes[name].status = ProcessStatus.RUNNING
 
         except Exception as e:
-            _logger.warning(f'Instance {name} failed to start: {e}')
+            _logger.warning(f"Instance {name} failed to start: {e}")
             self._processes[name].status = ProcessStatus.ERROR
-            self._processes[name].error_msg = f'Instance failed to start: {e}'
+            self._processes[name].error_msg = f"Instance failed to start: {e}"
 
     def _write_run_script(
-            self, request: InstantiationRequest, rankfile: Optional[Path]) -> Path:
+        self, request: InstantiationRequest, rankfile: Optional[Path]
+    ) -> Path:
         """Create and write out the run script and return its location."""
         # TODO: Only write out once for each program
         if request.program.script:
             run_script = request.program.script
         else:
             run_script = make_script(
-                    request.program, request.res_req, request.work_dir,
-                    not global_resources().on_cluster(), rankfile)
+                request.program,
+                request.res_req,
+                request.work_dir,
+                not global_resources().on_cluster(),
+                rankfile,
+            )
 
-        run_script_file = request.instance_dir / 'run_script.sh'
+        run_script_file = request.instance_dir / "run_script.sh"
 
-        with run_script_file.open('w') as f:
+        with run_script_file.open("w") as f:
             f.write(run_script)
 
         run_script_file.chmod(0o700)
         return run_script_file
 
     def _add_resources(
-            self, env: dict[str, str], res_req: ResourceRequirements) -> None:
+        self, env: dict[str, str], res_req: ResourceRequirements
+    ) -> None:
         """Add resource env vars to the given env."""
         if isinstance(res_req, ThreadedResReq):
             num_threads = res_req.threads
         elif isinstance(res_req, (MPICoresResReq, MPINodesResReq)):
             num_threads = res_req.threads_per_mpi_process
 
-        env['MUSCLE_THREADS'] = str(num_threads)
-        env['OMP_NUM_THREADS'] = str(num_threads)
+        env["MUSCLE_THREADS"] = str(num_threads)
+        env["OMP_NUM_THREADS"] = str(num_threads)
 
         num_mpi_processes: Optional[int] = None
         if isinstance(res_req, MPICoresResReq):
@@ -271,7 +296,7 @@ class NativeInstantiator(mp.Process):
             num_mpi_processes = res_req.nodes * res_req.mpi_processes_per_node
 
         if num_mpi_processes is not None:
-            env['MUSCLE_MPI_PROCESSES'] = str(num_mpi_processes)
+            env["MUSCLE_MPI_PROCESSES"] = str(num_mpi_processes)
 
     def _report_failed_processes(self) -> None:
         """Get processes that failed to start and report their status."""
@@ -294,7 +319,7 @@ class NativeInstantiator(mp.Process):
                     process.status = ProcessStatus.SUCCESS
                 else:
                     process.status = ProcessStatus.ERROR
-                    process.error_msg = 'Instance returned a non-zero exit code'
+                    process.error_msg = "Instance returned a non-zero exit code"
             process.exit_code = exit_code
             self._results_out.put(process)
             del self._processes[name]

--- a/libmuscle/python/libmuscle/native_instantiator/process_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/process_manager.py
@@ -7,13 +7,20 @@ _logger = logging.getLogger(__name__)
 
 class ProcessManager:
     """Manages a set of running processes."""
+
     def __init__(self) -> None:
         """Create a ProcessManager."""
         self._processes: dict[str, Popen] = dict()
 
     def start(
-            self, name: str, work_dir: Path, args: list[str], env: dict[str, str],
-            stdout: Path, stderr: Path) -> None:
+        self,
+        name: str,
+        work_dir: Path,
+        args: list[str],
+        env: dict[str, str],
+        stdout: Path,
+        stderr: Path,
+    ) -> None:
         """Start a process.
 
         The files that the output is directed to will be overwritten if they already
@@ -32,11 +39,12 @@ class ProcessManager:
             OSError: If the process could not be started.
         """
         if name in self._processes:
-            raise RuntimeError(f'Process {name} already exists')
-        _logger.debug(f'Starting process {args} with env {env} in {work_dir}')
-        with stdout.open('w') as out, stderr.open('w') as err:
+            raise RuntimeError(f"Process {name} already exists")
+        _logger.debug(f"Starting process {args} with env {env} in {work_dir}")
+        with stdout.open("w") as out, stderr.open("w") as err:
             self._processes[name] = Popen(
-                    args, cwd=work_dir, env=env, stdout=out, stderr=err)
+                args, cwd=work_dir, env=env, stdout=out, stderr=err
+            )
 
     def cancel_all(self) -> None:
         """Stops all running processes.

--- a/libmuscle/python/libmuscle/native_instantiator/run_script.py
+++ b/libmuscle/python/libmuscle/native_instantiator/run_script.py
@@ -34,12 +34,12 @@ def direct_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str,
     env: dict[str, str] = dict()
     only_node_hwthreads_list = list(resources.by_rank[0].hwthreads())
 
-    env['MUSCLE_BIND_LIST'] = ','.join(map(str, only_node_hwthreads_list))
+    env["MUSCLE_BIND_LIST"] = ",".join(map(str, only_node_hwthreads_list))
 
     mask_int = sum(1 << c for c in only_node_hwthreads_list)
-    env['MUSCLE_BIND_MASK'] = format(mask_int, 'X')
+    env["MUSCLE_BIND_MASK"] = format(mask_int, "X")
 
-    return '', env
+    return "", env
 
 
 def openmpi_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, str]]:
@@ -53,13 +53,14 @@ def openmpi_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str
     """
     ranklines: list[str] = list()
     all_cores = (
-            (node_res, ','.join(map(str, sorted(node_res.hwthreads()))))
-            for node_res in resources.by_rank)
+        (node_res, ",".join(map(str, sorted(node_res.hwthreads()))))
+        for node_res in resources.by_rank
+    )
 
     for i, (node_res, hwthreads) in enumerate(all_cores):
-        ranklines.append(f'rank {i}={node_res.node_name} slot={hwthreads}')
+        ranklines.append(f"rank {i}={node_res.node_name} slot={hwthreads}")
 
-    rankfile = '\n'.join(ranklines) + '\n'
+    rankfile = "\n".join(ranklines) + "\n"
 
     return rankfile, dict()
 
@@ -85,23 +86,24 @@ def impi_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, s
     proc_counts = [1] * len(machine_nodes)
     i = 1
     while i < len(machine_nodes):
-        if machine_nodes[i-1] == machine_nodes[i]:
+        if machine_nodes[i - 1] == machine_nodes[i]:
             del machine_nodes[i]
-            proc_counts[i-1] += proc_counts[i]
+            proc_counts[i - 1] += proc_counts[i]
             del proc_counts[i]
         else:
             i += 1
 
-    machinefile = '\n'.join(
-            (f'{m}:{c}' for m, c in zip(machine_nodes, proc_counts))) + '\n'
+    machinefile = (
+        "\n".join((f"{m}:{c}" for m, c in zip(machine_nodes, proc_counts))) + "\n"
+    )
 
     # disable pinning to SLURM-specified resources
     # env['I_MPI_PIN_RESPECT_CPUSET'] = '0'
-    env['I_MPI_JOB_RESPECT_PROCESS_PLACEMENT'] = 'off'
+    env["I_MPI_JOB_RESPECT_PROCESS_PLACEMENT"] = "off"
 
     # which cores to bind each rank to
-    pin_masks_str = ','.join(format(mask, '#x') for mask in pin_masks)
-    env['I_MPI_PIN_DOMAIN'] = f'[{pin_masks_str}]'
+    pin_masks_str = ",".join(format(mask, "#x") for mask in pin_masks)
+    env["I_MPI_PIN_DOMAIN"] = f"[{pin_masks_str}]"
 
     # I_MPI_PIN_DOMAIN=[55,aa]
     # pins the first rank to 0,2,16,18 and the second to 1,3,17,19
@@ -128,8 +130,8 @@ def mpich_prep_resources(resources: ResourceAssignment) -> tuple[str, dict[str, 
 
 
 def srun_prep_resources(
-        resources: ResourceAssignment, rankfile_location: Path
-        ) -> tuple[str, dict[str, str]]:
+    resources: ResourceAssignment, rankfile_location: Path
+) -> tuple[str, dict[str, str]]:
     """Create resource description for srun
 
     Args:
@@ -139,27 +141,30 @@ def srun_prep_resources(
     Return:
         The contents of the hostfile, and a set of environment variables
     """
-    hostfile = '\n'.join(
-        node_res.node_name for node_res in resources.by_rank
-        for _ in node_res.hwthreads())
+    hostfile = "\n".join(
+        node_res.node_name
+        for node_res in resources.by_rank
+        for _ in node_res.hwthreads()
+    )
 
-    env = {'SLURM_HOSTFILE': str(rankfile_location)}
+    env = {"SLURM_HOSTFILE": str(rankfile_location)}
 
     def core_mask(hwthreads: Iterable[int]) -> str:
         mask = sum((1 << hwthread) for hwthread in hwthreads)
-        return format(mask, '#x')
+        return format(mask, "#x")
 
-    bind_str = ','.join([
-        core_mask(node_res.hwthreads()) for node_res in resources.by_rank])
+    bind_str = ",".join(
+        [core_mask(node_res.hwthreads()) for node_res in resources.by_rank]
+    )
 
-    env['SLURM_CPU_BIND'] = f'verbose,mask_cpu:{bind_str}'
+    env["SLURM_CPU_BIND"] = f"verbose,mask_cpu:{bind_str}"
 
     return hostfile, env
 
 
 def prep_resources(
-        model: ExecutionModel, resources: ResourceAssignment, rankfile_location: Path
-        ) -> tuple[str, dict[str, str]]:
+    model: ExecutionModel, resources: ResourceAssignment, rankfile_location: Path
+) -> tuple[str, dict[str, str]]:
     """Create resource description for the given execution model.
 
     Args:
@@ -181,7 +186,8 @@ def prep_resources(
     # elif model == ExecutionModel.MPICH:
     #     return mpich_prep_resources(resources)
     raise RuntimeError(
-            f'Impossible execution model {model}, please create an issue on GitHub')
+        f"Impossible execution model {model}, please create an issue on GitHub"
+    )
 
 
 def num_mpi_tasks(res_req: ResourceRequirements) -> int:
@@ -198,7 +204,7 @@ def num_mpi_tasks(res_req: ResourceRequirements) -> int:
         return res_req.mpi_processes
     elif isinstance(res_req, MPINodesResReq):
         return res_req.nodes * res_req.mpi_processes_per_node
-    raise RuntimeError('Invalid ResourceRequirements')
+    raise RuntimeError("Invalid ResourceRequirements")
 
 
 def local_command(program: Program, enable_debug: bool) -> str:
@@ -216,46 +222,41 @@ def local_command(program: Program, enable_debug: bool) -> str:
         A format string with embedded {ntasks} and {rankfile}.
     """
     if program.execution_model == ExecutionModel.DIRECT:
-        fstr = 'exec {command} {args}'
+        fstr = "exec {command} {args}"
     elif program.execution_model == ExecutionModel.OPENMPI:
         # Native name is orterun for older and prterun for newer OpenMPI.
         # So we go with mpirun, which works for either.
-        fargs = [
-                'exec mpirun -np $MUSCLE_MPI_PROCESSES',
-                '--oversubscribe'
-                ]
+        fargs = ["exec mpirun -np $MUSCLE_MPI_PROCESSES", "--oversubscribe"]
 
         if enable_debug:
-            fargs.append('-v --debug-daemons --display-map --display-allocation')
+            fargs.append("-v --debug-daemons --display-map --display-allocation")
 
-        fargs.append('{command} {args}')
+        fargs.append("{command} {args}")
 
-        fstr = ' '.join(fargs)
+        fstr = " ".join(fargs)
 
     elif program.execution_model == ExecutionModel.INTELMPI:
-        fstr = 'exec mpirun -n $MUSCLE_MPI_PROCESSES {command} {args}'
+        fstr = "exec mpirun -n $MUSCLE_MPI_PROCESSES {command} {args}"
     elif program.execution_model == ExecutionModel.SRUNMPI:
         raise ConfigurationError(
-                f'Could not start {program.name} because the SRUNMPI execution'
-                ' method only works in a SLURM allocation, and we are running locally.'
-                ' Please switch this program to a different execution method'
-                ' in the configuration file. You will probably want OPENMPI or'
-                ' INTELMPI depending on which MPI program this code was'
-                ' compiled with.')
+            f"Could not start {program.name} because the SRUNMPI execution"
+            " method only works in a SLURM allocation, and we are running locally."
+            " Please switch this program to a different execution method"
+            " in the configuration file. You will probably want OPENMPI or"
+            " INTELMPI depending on which MPI program this code was"
+            " compiled with."
+        )
     # elif program.execution_model == ExecutionModel.MPICH
     #    fstr = 'mpiexec -n {{ntasks}} {command} {args}'
 
     if program.args is None:
-        args = ''
+        args = ""
     elif isinstance(program.args, str):
         args = program.args
     elif isinstance(program.args, list):
-        args = ' '.join(program.args)
+        args = " ".join(program.args)
 
-    return fstr.format(
-            command=program.executable,
-            args=args
-            )
+    return fstr.format(command=program.executable, args=args)
 
 
 def cluster_command(program: Program, enable_debug: bool) -> str:
@@ -274,25 +275,25 @@ def cluster_command(program: Program, enable_debug: bool) -> str:
     """
     if program.execution_model == ExecutionModel.DIRECT:
         fargs = [
-                'if ! taskset -V >/dev/null 2>&1 ; then',
-                '    exec {command} {args}',
-                'else',
-                '    exec taskset $MUSCLE_BIND_MASK {command} {args}',
-                'fi'
-                ]
-        fstr = '\n'.join(fargs)
+            "if ! taskset -V >/dev/null 2>&1 ; then",
+            "    exec {command} {args}",
+            "else",
+            "    exec taskset $MUSCLE_BIND_MASK {command} {args}",
+            "fi",
+        ]
+        fstr = "\n".join(fargs)
 
     elif program.execution_model == ExecutionModel.OPENMPI:
         fargs = [
-                # Native name is orterun for older and prterun for newer OpenMPI.
-                # So we go with mpirun, which works for either.
-                'exec mpirun -np $MUSCLE_MPI_PROCESSES',
-                '--rankfile $MUSCLE_RANKFILE --use-hwthread-cpus --bind-to hwthread',
-                '--oversubscribe'
-                ]
+            # Native name is orterun for older and prterun for newer OpenMPI.
+            # So we go with mpirun, which works for either.
+            "exec mpirun -np $MUSCLE_MPI_PROCESSES",
+            "--rankfile $MUSCLE_RANKFILE --use-hwthread-cpus --bind-to hwthread",
+            "--oversubscribe",
+        ]
 
         if enable_debug:
-            fargs.append('-v --display-allocation --display-map --report-bindings')
+            fargs.append("-v --display-allocation --display-map --report-bindings")
 
         if slurm().quirks.overlap:
             # This adds the given option to the srun command used by mpirun to launch
@@ -302,54 +303,56 @@ def cluster_command(program: Program, enable_debug: bool) -> str:
             # overrides the --exclusive and it works.
             fargs.append('-mca plm_slurm_args "--overlap"')
 
-        fargs.append('{command} {args}')
+        fargs.append("{command} {args}")
 
-        fstr = ' '.join(fargs)
+        fstr = " ".join(fargs)
 
     elif program.execution_model == ExecutionModel.INTELMPI:
         fargs = [
-                'exec mpirun -n $MUSCLE_MPI_PROCESSES',
-                '-machinefile $MUSCLE_RANKFILE']
+            "exec mpirun -n $MUSCLE_MPI_PROCESSES",
+            "-machinefile $MUSCLE_RANKFILE",
+        ]
 
         if enable_debug:
-            fargs.append('-genv I_MPI_DEBUG=4')
+            fargs.append("-genv I_MPI_DEBUG=4")
 
-        fargs.append('{command} {args}')
+        fargs.append("{command} {args}")
 
-        fstr = ' '.join(fargs)
+        fstr = " ".join(fargs)
 
     elif program.execution_model == ExecutionModel.SRUNMPI:
-        fargs = ['exec srun -n $MUSCLE_MPI_PROCESSES -m arbitrary']
+        fargs = ["exec srun -n $MUSCLE_MPI_PROCESSES -m arbitrary"]
 
         if slurm().quirks.overlap:
-            fargs.append('--overlap')
+            fargs.append("--overlap")
 
-        verbose = 'verbose,' if enable_debug else ''
+        verbose = "verbose," if enable_debug else ""
 
-        fargs.append(f'{slurm().quirks.cpu_bind}={verbose}$SLURM_CPU_BIND')
-        fargs.append('{command} {args}')
+        fargs.append(f"{slurm().quirks.cpu_bind}={verbose}$SLURM_CPU_BIND")
+        fargs.append("{command} {args}")
 
-        fstr = ' '.join(fargs)
+        fstr = " ".join(fargs)
 
     # elif program.execution_model == ExecutionModel.MPICH
     #    fstr = 'mpiexec -n $MUSCLE_MPI_PROCESSES -f $MUSCLE_RANKFILE {command} {args}'
 
     if program.args is None:
-        args = ''
+        args = ""
     elif isinstance(program.args, str):
         args = program.args
     elif isinstance(program.args, list):
-        args = ' '.join(program.args)
+        args = " ".join(program.args)
 
-    return fstr.format(
-            command=program.executable,
-            args=args
-            )
+    return fstr.format(command=program.executable, args=args)
 
 
 def make_script(
-        program: Program, res_req: ResourceRequirements,
-        work_dir: Path, local: bool, rankfile: Optional[Path] = None) -> str:
+    program: Program,
+    res_req: ResourceRequirements,
+    work_dir: Path,
+    local: bool,
+    rankfile: Optional[Path] = None,
+) -> str:
     """Make a run script for a given program.
 
     Args:
@@ -362,7 +365,7 @@ def make_script(
     Return:
         A string with embedded newlines containing the shell script.
     """
-    enable_debug = logging.getLogger('libmuscle').getEffectiveLevel() <= logging.DEBUG
+    enable_debug = logging.getLogger("libmuscle").getEffectiveLevel() <= logging.DEBUG
 
     lines: list[str] = list()
 
@@ -371,57 +374,57 @@ def make_script(
         # non-interactive login shell and manually loading the configuration files that
         # an interactive one would load. This avoids a confusing warning on stderr that
         # we get from /bin/bash -il because it can't find a controlling terminal.
-        lines.append('#!/bin/bash --norc')
-        lines.append('')
-        lines.append('if [ -f /etc/environment ] ; then')
-        lines.append('    . /etc/environment')
-        lines.append('fi')
-        lines.append('')
-        lines.append('if [ -f /etc/profile ] ; then')
-        lines.append('    . /etc/profile')
-        lines.append('fi')
-        lines.append('')
-        lines.append('if [ -f ~/.bash_profile ] ; then')
-        lines.append('    . ~/.bash_profile')
-        lines.append('elif [ -f ~/.bash_login ] ; then')
-        lines.append('    . ~/.bash_login')
-        lines.append('elif [ -f ~/.profile ] ; then')
-        lines.append('    . ~/.profile')
-        lines.append('fi')
+        lines.append("#!/bin/bash --norc")
+        lines.append("")
+        lines.append("if [ -f /etc/environment ] ; then")
+        lines.append("    . /etc/environment")
+        lines.append("fi")
+        lines.append("")
+        lines.append("if [ -f /etc/profile ] ; then")
+        lines.append("    . /etc/profile")
+        lines.append("fi")
+        lines.append("")
+        lines.append("if [ -f ~/.bash_profile ] ; then")
+        lines.append("    . ~/.bash_profile")
+        lines.append("elif [ -f ~/.bash_login ] ; then")
+        lines.append("    . ~/.bash_login")
+        lines.append("elif [ -f ~/.profile ] ; then")
+        lines.append("    . ~/.profile")
+        lines.append("fi")
     else:
-        lines.append('#!/bin/bash')
+        lines.append("#!/bin/bash")
 
-    lines.append('')
+    lines.append("")
 
     # The environment is passed when starting the script, rather than as a set of
     # export statements here.
 
     if program.base_env == BaseEnv.CLEAN:
-        lines.append('module purge')
-        lines.append('')
+        lines.append("module purge")
+        lines.append("")
 
     if program.modules:
         if isinstance(program.modules, str):
-            lines.append(f'module load {program.modules}')
+            lines.append(f"module load {program.modules}")
         else:
             for module in program.modules:
-                lines.append(f'module load {module}')
-        lines.append('')
+                lines.append(f"module load {module}")
+        lines.append("")
 
     if program.virtual_env:
-        lines.append(f'. {program.virtual_env}/bin/activate')
-        lines.append('')
+        lines.append(f". {program.virtual_env}/bin/activate")
+        lines.append("")
 
     if program.base_env == BaseEnv.LOGIN:
         # config files may change the work directory from what we set, so we add this to
         # ensure it's correct.
-        lines.append(f'cd {work_dir}')
+        lines.append(f"cd {work_dir}")
 
     if local:
         lines.append(local_command(program, enable_debug))
     else:
         lines.append(cluster_command(program, enable_debug))
 
-    lines.append('')
+    lines.append("")
 
-    return '\n'.join(lines)
+    return "\n".join(lines)

--- a/libmuscle/python/libmuscle/native_instantiator/slurm.py
+++ b/libmuscle/python/libmuscle/native_instantiator/slurm.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 
 _node_range_expression_grammar = Grammar(
-        """
+    """
         nre = nre_parts ("," nre_parts)*
         nre_parts = nre_part+
         nre_part = identifier ("[" index_set "]")?
@@ -23,7 +23,7 @@ _node_range_expression_grammar = Grammar(
         int = ~"[0-9]+"
         padded_int = ~"0[0-9]+"
         """
-        )
+)
 
 
 class NREVisitor(NodeVisitor):
@@ -32,10 +32,12 @@ class NREVisitor(NodeVisitor):
     Node range expressions are used by SLURM to describe collections of nodes. See
     parse_slurm_nodelist() below.
     """
+
     def visit_nre(
-            self, node: Node,
-            visited_children: tuple[list[str], Sequence[tuple[Any, list[str]]]]
-            ) -> list[str]:
+        self,
+        node: Node,
+        visited_children: tuple[list[str], Sequence[tuple[Any, list[str]]]],
+    ) -> list[str]:
         """Return a list of nodes corresponding to the NRE."""
         nodes = visited_children[0].copy()
         for _, more_nodes in visited_children[1]:
@@ -43,29 +45,31 @@ class NREVisitor(NodeVisitor):
         return nodes
 
     def visit_nre_parts(
-            self, node: Node, visited_children: Sequence[tuple[str, list[str]]]
-            ) -> list[str]:
+        self, node: Node, visited_children: Sequence[tuple[str, list[str]]]
+    ) -> list[str]:
         """Return a list of node ids for the part."""
-        fmt = ''.join([c[0] + '{}' for c in visited_children])
+        fmt = "".join([c[0] + "{}" for c in visited_children])
         index_lists = [c[1] for c in visited_children]
         return [fmt.format(*idxs) for idxs in product(*index_lists)]
 
     def visit_nre_part(
-            self, node: Node, visited_children: tuple[
-                str, Sequence[tuple[Any, list[str], Any]]]
-            ) -> tuple[str, list[str]]:
+        self,
+        node: Node,
+        visited_children: tuple[str, Sequence[tuple[Any, list[str], Any]]],
+    ) -> tuple[str, list[str]]:
         """Return the identifier part and a list of indexes for the set."""
         identifier = visited_children[0]
         if not visited_children[1]:
-            index_set = ['']
+            index_set = [""]
         else:
             index_set = visited_children[1][0][1]
         return identifier, index_set
 
     def visit_index_set(
-            self, node: Node,
-            visited_children: tuple[list[str], Sequence[tuple[Any, list[str]]]]
-            ) -> list[str]:
+        self,
+        node: Node,
+        visited_children: tuple[list[str], Sequence[tuple[Any, list[str]]]],
+    ) -> list[str]:
         """Return a list of indexes corresponding to the set."""
         indexes = visited_children[0].copy()
         for _, more_indexes in visited_children[1]:
@@ -73,19 +77,16 @@ class NREVisitor(NodeVisitor):
         return indexes
 
     def visit_index_range(
-            self, node: Node,
-            visited_children: tuple[
-                tuple[int, int],
-                Sequence[
-                    tuple[Any, tuple[int, int]]
-                    ]]
-            ) -> list[str]:
+        self,
+        node: Node,
+        visited_children: tuple[tuple[int, int], Sequence[tuple[Any, tuple[int, int]]]],
+    ) -> list[str]:
         """Return a list of indexes corresponding to the range."""
 
         def format_str(width: int) -> str:
             if width == -1:
-                return '{}'
-            return f'{{:0{width}}}'
+                return "{}"
+            return f"{{:0{width}}}"
 
         start_value, width = visited_children[0]
         if visited_children[1]:
@@ -100,8 +101,8 @@ class NREVisitor(NodeVisitor):
         return node.text
 
     def visit_integer(
-            self, node: Node, visited_children: Sequence[tuple[int, int]]
-            ) -> tuple[int, int]:
+        self, node: Node, visited_children: Sequence[tuple[int, int]]
+    ) -> tuple[int, int]:
         """Returns the value of the int, and a field width or -1."""
         return visited_children[0]
 
@@ -114,7 +115,8 @@ class NREVisitor(NodeVisitor):
         return int(node.text), len(node.text)
 
     def generic_visit(
-            self, node: Node, visited_children: Sequence[Any]) -> Sequence[Any]:
+        self, node: Node, visited_children: Sequence[Any]
+    ) -> Sequence[Any]:
         return visited_children
 
 
@@ -152,13 +154,13 @@ def parse_slurm_nodelist(s: str) -> list[str]:
 
 
 _nodes_cores_expression_grammar = Grammar(
-        """
+    """
         nce = nce_run ("," nce_run)*
         nce_run = int ("(" run_length ")")?
         run_length = "x" int
         int = ~"[0-9]+"
         """
-        )
+)
 
 
 class NCEVisitor(NodeVisitor):
@@ -167,10 +169,12 @@ class NCEVisitor(NodeVisitor):
     Nodes cores expressions are used by SLURM to describe cores on a collection of
     nodes.  See parse_slurm_nodes_cores() below.
     """
+
     def visit_nce(
-            self, node: Node,
-            visited_children: tuple[list[int], Sequence[tuple[Any, list[int]]]]
-            ) -> list[int]:
+        self,
+        node: Node,
+        visited_children: tuple[list[int], Sequence[tuple[Any, list[int]]]],
+    ) -> list[int]:
         """Return a list of nodes corresponding to the NRE."""
         nodes_cores = visited_children[0].copy()
         for _, more_nodes_cores in visited_children[1]:
@@ -178,9 +182,8 @@ class NCEVisitor(NodeVisitor):
         return nodes_cores
 
     def visit_nce_run(
-            self, node: Node,
-            visited_children: tuple[int, Sequence[tuple[Any, int, Any]]]
-            ) -> list[int]:
+        self, node: Node, visited_children: tuple[int, Sequence[tuple[Any, int, Any]]]
+    ) -> list[int]:
         """Return a list of core counts produced by this run."""
         num_cores = visited_children[0]
         result = [num_cores]
@@ -190,8 +193,7 @@ class NCEVisitor(NodeVisitor):
 
         return result
 
-    def visit_run_length(
-            self, node: Node, visited_children: tuple[str, int]) -> int:
+    def visit_run_length(self, node: Node, visited_children: tuple[str, int]) -> int:
         """Return the number of repetitions."""
         return visited_children[1]
 
@@ -200,7 +202,8 @@ class NCEVisitor(NodeVisitor):
         return int(node.text)
 
     def generic_visit(
-            self, node: Node, visited_children: Sequence[Any]) -> Sequence[Any]:
+        self, node: Node, visited_children: Sequence[Any]
+    ) -> Sequence[Any]:
         return visited_children
 
 
@@ -226,6 +229,7 @@ def parse_slurm_nodes_cores(s: str) -> list[int]:
 
 class SlurmQuirks:
     """Collects features of the present SLURM."""
+
     overlap: bool
     """True iff --overlap must be specified for srun."""
     cpu_bind: str
@@ -234,6 +238,7 @@ class SlurmQuirks:
 
 class SlurmInfo:
     """Detects and holds information about the present SLURM scheduler."""
+
     def __init__(self) -> None:
         if self.in_slurm_allocation():
             self.version = self._slurm_version()
@@ -241,14 +246,15 @@ class SlurmInfo:
 
             self.quirks.overlap = self.version > (20, 2)
             self.quirks.cpu_bind = (
-                    '--cpu-bind' if self.version > (17, 2) else '--cpu_bind')
+                "--cpu-bind" if self.version > (17, 2) else "--cpu_bind"
+            )
 
     def in_slurm_allocation(self) -> bool:
         """Check whether we're in a SLURM allocation.
 
         Returns true iff SLURM was detected.
         """
-        return 'SLURM_JOB_ID' in os.environ
+        return "SLURM_JOB_ID" in os.environ
 
     def get_nodes(self) -> list[str]:
         """Get a list of node names from SLURM_JOB_NODELIST.
@@ -259,13 +265,13 @@ class SlurmInfo:
         If SLURM_JOB_NODELIST is "node[020-023]" then this returns
         ["node020", "node021", "node022", "node023"].
         """
-        nodelist = os.environ.get('SLURM_JOB_NODELIST')
+        nodelist = os.environ.get("SLURM_JOB_NODELIST")
         if not nodelist:
-            nodelist = os.environ.get('SLURM_NODELIST')
+            nodelist = os.environ.get("SLURM_NODELIST")
         if not nodelist:
-            raise RuntimeError('SLURM_(JOB_)NODELIST not set, are we running locally?')
+            raise RuntimeError("SLURM_(JOB_)NODELIST not set, are we running locally?")
 
-        _logger.debug(f'SLURM node list: {nodelist}')
+        _logger.debug(f"SLURM node list: {nodelist}")
 
         return parse_slurm_nodelist(nodelist)
 
@@ -275,28 +281,29 @@ class SlurmInfo:
         This returns a list with the number of cores of each node in the result of
         get_nodes(), which gets read from SLURM_JOB_CPUS_PER_NODE.
         """
-        sjcpn = os.environ.get('SLURM_JOB_CPUS_PER_NODE')
-        _logger.debug(f'SLURM_JOB_CPUS_PER_NODE: {sjcpn}')
+        sjcpn = os.environ.get("SLURM_JOB_CPUS_PER_NODE")
+        _logger.debug(f"SLURM_JOB_CPUS_PER_NODE: {sjcpn}")
 
         if sjcpn:
             return parse_slurm_nodes_cores(sjcpn)
         else:
-            scon = os.environ.get('SLURM_CPUS_ON_NODE')
-            _logger.debug(f'SLURM_CPUS_ON_NODE: {scon}')
+            scon = os.environ.get("SLURM_CPUS_ON_NODE")
+            _logger.debug(f"SLURM_CPUS_ON_NODE: {scon}")
 
-            snn = os.environ.get('SLURM_JOB_NUM_NODES')
+            snn = os.environ.get("SLURM_JOB_NUM_NODES")
             if not snn:
-                snn = os.environ.get('SLURM_NNODES')
-            _logger.debug(f'SLURM num nodes: {snn}')
+                snn = os.environ.get("SLURM_NNODES")
+            _logger.debug(f"SLURM num nodes: {snn}")
 
             if scon and snn:
                 return [int(scon)] * int(snn)
 
         raise RuntimeError(
-                'SLURM_JOB_CPUS_PER_NODE is not set in the environment, and also'
-                ' SLURM_CPUS_ON_NODE is missing or neither SLURM_JOB_NUM_NODES nor'
-                ' SLURM_NNODES is set. Please create an issue on GitHub with the output'
-                ' of "sbatch --version" on this cluster.')
+            "SLURM_JOB_CPUS_PER_NODE is not set in the environment, and also"
+            " SLURM_CPUS_ON_NODE is missing or neither SLURM_JOB_NUM_NODES nor"
+            " SLURM_NNODES is set. Please create an issue on GitHub with the output"
+            ' of "sbatch --version" on this cluster.'
+        )
 
     def agent_launch_command(self, agent_cmd: list[str], nnodes: int) -> list[str]:
         """Return a command for launching one agent on each node.
@@ -312,12 +319,14 @@ class SlurmInfo:
         # than calculated anew from --nodes and --ntasks-per-node, so we specify it
         # explicitly to avoid getting an agent per logical cpu rather than per node.
         srun_cmd = [
-                'srun', f'--nodes={nnodes}', f'--ntasks={nnodes}',
-                '--ntasks-per-node=1'
-                ]
+            "srun",
+            f"--nodes={nnodes}",
+            f"--ntasks={nnodes}",
+            "--ntasks-per-node=1",
+        ]
 
         if self.quirks.overlap:
-            srun_cmd.append('--overlap')
+            srun_cmd.append("--overlap")
 
         return srun_cmd + agent_cmd
 
@@ -328,25 +337,30 @@ class SlurmInfo:
         behaviour within a release series.
         """
         proc = subprocess.run(
-                ['srun', '--version'], check=True, capture_output=True, text=True,
-                encoding='utf-8'
-                )
+            ["srun", "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
 
         output = proc.stdout.strip().split()
         if len(output) < 2:
             raise RuntimeError(
-                    f'Unexpected srun version output "{output}". MUSCLE3 does not know'
-                    ' how to run on this version of SLURM. Please file an issue on'
-                    ' GitHub.')
+                f'Unexpected srun version output "{output}". MUSCLE3 does not know'
+                " how to run on this version of SLURM. Please file an issue on"
+                " GitHub."
+            )
 
         version_str = output[1]
-        version = version_str.split('.')
+        version = version_str.split(".")
         if len(version) < 2:
-            _logger.error(f'srun produced unexpected version {version_str}')
+            _logger.error(f"srun produced unexpected version {version_str}")
             raise RuntimeError(
-                    f'Unexpected srun version output "{output}". MUSCLE3 does not know'
-                    ' how to run on this version of SLURM. Please file an issue on'
-                    ' GitHub.')
+                f'Unexpected srun version output "{output}". MUSCLE3 does not know'
+                " how to run on this version of SLURM. Please file an issue on"
+                " GitHub."
+            )
         return int(version[0]), int(version[1])
 
 

--- a/libmuscle/python/libmuscle/native_instantiator/test/test_process_manager.py
+++ b/libmuscle/python/libmuscle/native_instantiator/test/test_process_manager.py
@@ -23,60 +23,90 @@ def _poll_completion(lpm, num_jobs):
 
 def test_run_process(lpm, tmp_path):
     lpm.start(
-            'test', tmp_path, ['bash', '-c', 'exit 0'], {},
-            tmp_path / 'out', tmp_path / 'err')
+        "test",
+        tmp_path,
+        ["bash", "-c", "exit 0"],
+        {},
+        tmp_path / "out",
+        tmp_path / "err",
+    )
     completed_jobs = _poll_completion(lpm, 1)
-    assert completed_jobs[0] == ('test', 0)
+    assert completed_jobs[0] == ("test", 0)
 
 
 def test_existing_process(lpm, tmp_path):
     lpm.start(
-            'test', tmp_path, ['bash', '-c', 'exit 0'], {},
-            tmp_path / 'out', tmp_path / 'err')
+        "test",
+        tmp_path,
+        ["bash", "-c", "exit 0"],
+        {},
+        tmp_path / "out",
+        tmp_path / "err",
+    )
     with pytest.raises(RuntimeError):
         lpm.start(
-                'test', tmp_path, ['bash', '-c', 'exit 0'], {},
-                tmp_path / 'out', tmp_path / 'err')
+            "test",
+            tmp_path,
+            ["bash", "-c", "exit 0"],
+            {},
+            tmp_path / "out",
+            tmp_path / "err",
+        )
 
     completed_jobs = _poll_completion(lpm, 1)
 
-    assert completed_jobs[0] == ('test', 0)
+    assert completed_jobs[0] == ("test", 0)
 
 
 def test_env(lpm, tmp_path):
-    env = {'ENVVAR': 'TESTING123'}
+    env = {"ENVVAR": "TESTING123"}
     lpm.start(
-            'test', tmp_path, ['bash', '-c', 'echo ${ENVVAR}'], env,
-            tmp_path / 'out', tmp_path / 'err')
+        "test",
+        tmp_path,
+        ["bash", "-c", "echo ${ENVVAR}"],
+        env,
+        tmp_path / "out",
+        tmp_path / "err",
+    )
     _poll_completion(lpm, 1)
 
-    with (tmp_path / 'out').open('r') as f:
+    with (tmp_path / "out").open("r") as f:
         lines = f.readlines()
 
-    assert lines[0] == 'TESTING123\n'
+    assert lines[0] == "TESTING123\n"
 
 
 def test_exit_code(lpm, tmp_path):
     lpm.start(
-            'test_exit_code', tmp_path, ['bash', '-c', 'exit 3'], {},
-            tmp_path / 'out', tmp_path / 'err')
+        "test_exit_code",
+        tmp_path,
+        ["bash", "-c", "exit 3"],
+        {},
+        tmp_path / "out",
+        tmp_path / "err",
+    )
     done = lpm.get_finished()
     while not done:
         sleep(0.02)
         done = lpm.get_finished()
 
-    assert done[0] == ('test_exit_code', 3)
+    assert done[0] == ("test_exit_code", 3)
 
 
 def test_multiple(lpm, tmp_path):
     for i in range(3):
         lpm.start(
-                f'test_{i}', tmp_path, ['bash', '-c', 'sleep 1'], {},
-                tmp_path / f'out{i}', tmp_path / f'err{i}')
+            f"test_{i}",
+            tmp_path,
+            ["bash", "-c", "sleep 1"],
+            {},
+            tmp_path / f"out{i}",
+            tmp_path / f"err{i}",
+        )
 
     completed_jobs = _poll_completion(lpm, 3)
 
-    assert sorted(completed_jobs) == [('test_0', 0), ('test_1', 0), ('test_2', 0)]
+    assert sorted(completed_jobs) == [("test_0", 0), ("test_1", 0), ("test_2", 0)]
 
 
 def test_cancel_all(lpm, tmp_path):
@@ -84,8 +114,13 @@ def test_cancel_all(lpm, tmp_path):
 
     for i in range(2):
         lpm.start(
-                f'test_{i}', tmp_path, ['bash', '-c', 'sleep 1'], {},
-                tmp_path / f'out{i}', tmp_path / f'err{i}')
+            f"test_{i}",
+            tmp_path,
+            ["bash", "-c", "sleep 1"],
+            {},
+            tmp_path / f"out{i}",
+            tmp_path / f"err{i}",
+        )
 
     lpm.cancel_all()
 
@@ -93,27 +128,32 @@ def test_cancel_all(lpm, tmp_path):
 
     end_time = monotonic()
 
-    assert sorted(completed_jobs) == [('test_0', -9), ('test_1', -9)]
+    assert sorted(completed_jobs) == [("test_0", -9), ("test_1", -9)]
     assert end_time - begin_time < 1.0
 
 
 def test_output_redirect(lpm, tmp_path):
     lpm.start(
-            'test', tmp_path, ['bash', '-c', 'ls'], {},
-            tmp_path / 'out', tmp_path / 'err')
+        "test", tmp_path, ["bash", "-c", "ls"], {}, tmp_path / "out", tmp_path / "err"
+    )
     _poll_completion(lpm, 1)
-    with (tmp_path / 'out').open('r') as f:
+    with (tmp_path / "out").open("r") as f:
         assert f.readlines()
-    with (tmp_path / 'err').open('r') as f:
+    with (tmp_path / "err").open("r") as f:
         assert f.readlines() == []
 
 
 def test_error_redirect(lpm, tmp_path):
     lpm.start(
-            'test', tmp_path, ['bash', '-c', 'ls 1>&2'], {},
-            tmp_path / 'out', tmp_path / 'err')
+        "test",
+        tmp_path,
+        ["bash", "-c", "ls 1>&2"],
+        {},
+        tmp_path / "out",
+        tmp_path / "err",
+    )
     _poll_completion(lpm, 1)
-    with (tmp_path / 'out').open('r') as f:
+    with (tmp_path / "out").open("r") as f:
         assert f.readlines() == []
-    with (tmp_path / 'err').open('r') as f:
+    with (tmp_path / "err").open("r") as f:
         assert f.readlines()

--- a/libmuscle/python/libmuscle/native_instantiator/test/test_slurm.py
+++ b/libmuscle/python/libmuscle/native_instantiator/test/test_slurm.py
@@ -5,68 +5,168 @@ from libmuscle.native_instantiator.slurm import (
 )
 
 NRES_ = [
-        # from various bits of SLURM documentation
+    # from various bits of SLURM documentation
+    (
+        "linux[00-17]",
+        [
+            "linux00",
+            "linux01",
+            "linux02",
+            "linux03",
+            "linux04",
+            "linux05",
+            "linux06",
+            "linux07",
+            "linux08",
+            "linux09",
+            "linux10",
+            "linux11",
+            "linux12",
+            "linux13",
+            "linux14",
+            "linux15",
+            "linux16",
+            "linux17",
+        ],
+    ),
+    (
+        "lx[10-20]",
+        [
+            "lx10",
+            "lx11",
+            "lx12",
+            "lx13",
+            "lx14",
+            "lx15",
+            "lx16",
+            "lx17",
+            "lx18",
+            "lx19",
+            "lx20",
+        ],
+    ),
+    ("tux[2,1-2]", ["tux2", "tux1", "tux2"]),
+    ("tux[1-2,2]", ["tux1", "tux2", "tux2"]),
+    ("tux[1-3]", ["tux1", "tux2", "tux3"]),
+    (
+        "linux[0-64,128]",
+        [
+            "linux0",
+            "linux1",
+            "linux2",
+            "linux3",
+            "linux4",
+            "linux5",
+            "linux6",
+            "linux7",
+            "linux8",
+            "linux9",
+            "linux10",
+            "linux11",
+            "linux12",
+            "linux13",
+            "linux14",
+            "linux15",
+            "linux16",
+            "linux17",
+            "linux18",
+            "linux19",
+            "linux20",
+            "linux21",
+            "linux22",
+            "linux23",
+            "linux24",
+            "linux25",
+            "linux26",
+            "linux27",
+            "linux28",
+            "linux29",
+            "linux30",
+            "linux31",
+            "linux32",
+            "linux33",
+            "linux34",
+            "linux35",
+            "linux36",
+            "linux37",
+            "linux38",
+            "linux39",
+            "linux40",
+            "linux41",
+            "linux42",
+            "linux43",
+            "linux44",
+            "linux45",
+            "linux46",
+            "linux47",
+            "linux48",
+            "linux49",
+            "linux50",
+            "linux51",
+            "linux52",
+            "linux53",
+            "linux54",
+            "linux55",
+            "linux56",
+            "linux57",
+            "linux58",
+            "linux59",
+            "linux60",
+            "linux61",
+            "linux62",
+            "linux63",
+            "linux64",
+            "linux128",
+        ],
+    ),
+    ("alpha,beta,gamma", ["alpha", "beta", "gamma"]),
+    ("lx[15,18,32-33]", ["lx15", "lx18", "lx32", "lx33"]),
+    ("linux[0000-1023]", [f"linux{i:04}" for i in range(1024)]),
+    (
+        "rack[0-63]_blade[0-41]",
+        [f"rack{i}_blade{j}" for i in range(64) for j in range(42)],
+    ),
+    # my additions
+    ("linux", ["linux"]),
+    ("linux[0]", ["linux0"]),
+    ("linux[0,1]", ["linux0", "linux1"]),
+    ("linux[0-2]", ["linux0", "linux1", "linux2"]),
+    (
+        "rack[00-12,14]_blade[0-2],alpha,tux[1-3,6]",
         (
-            'linux[00-17]', [
-                'linux00', 'linux01', 'linux02', 'linux03', 'linux04', 'linux05',
-                'linux06', 'linux07', 'linux08', 'linux09', 'linux10', 'linux11',
-                'linux12', 'linux13', 'linux14', 'linux15', 'linux16', 'linux17']),
-        (
-            'lx[10-20]', [
-                'lx10', 'lx11', 'lx12', 'lx13', 'lx14', 'lx15', 'lx16', 'lx17', 'lx18',
-                'lx19', 'lx20']),
-        ('tux[2,1-2]', ['tux2', 'tux1', 'tux2']),
-        ('tux[1-2,2]', ['tux1', 'tux2', 'tux2']),
-        ('tux[1-3]', ['tux1', 'tux2', 'tux3']),
-        (
-            'linux[0-64,128]', [
-                'linux0', 'linux1', 'linux2', 'linux3', 'linux4', 'linux5', 'linux6',
-                'linux7', 'linux8', 'linux9', 'linux10', 'linux11', 'linux12',
-                'linux13', 'linux14', 'linux15', 'linux16', 'linux17', 'linux18',
-                'linux19', 'linux20', 'linux21', 'linux22', 'linux23', 'linux24',
-                'linux25', 'linux26', 'linux27', 'linux28', 'linux29', 'linux30',
-                'linux31', 'linux32', 'linux33', 'linux34', 'linux35', 'linux36',
-                'linux37', 'linux38', 'linux39', 'linux40', 'linux41', 'linux42',
-                'linux43', 'linux44', 'linux45', 'linux46', 'linux47', 'linux48',
-                'linux49', 'linux50', 'linux51', 'linux52', 'linux53', 'linux54',
-                'linux55', 'linux56', 'linux57', 'linux58', 'linux59', 'linux60',
-                'linux61', 'linux62', 'linux63', 'linux64', 'linux128']),
-        ('alpha,beta,gamma', ['alpha', 'beta', 'gamma']),
-        ('lx[15,18,32-33]', ['lx15', 'lx18', 'lx32', 'lx33']),
-        ('linux[0000-1023]', [f'linux{i:04}' for i in range(1024)]),
-        (
-            'rack[0-63]_blade[0-41]', [
-                f'rack{i}_blade{j}' for i in range(64) for j in range(42)]),
-        # my additions
-        ('linux', ['linux']),
-        ('linux[0]', ['linux0']),
-        ('linux[0,1]', ['linux0', 'linux1']),
-        ('linux[0-2]', ['linux0', 'linux1', 'linux2']),
-        (
-            'rack[00-12,14]_blade[0-2],alpha,tux[1-3,6]', (
-                [f'rack{i:02}_blade{j}' for i in range(13) for j in range(3)] + [
-                    'rack14_blade0', 'rack14_blade1', 'rack14_blade2', 'alpha',
-                    'tux1', 'tux2', 'tux3', 'tux6'])),
-        ('node-0', ['node-0']),
-        ('node-[0-3]', ['node-0', 'node-1', 'node-2', 'node-3']),
-        ]
+            [f"rack{i:02}_blade{j}" for i in range(13) for j in range(3)]
+            + [
+                "rack14_blade0",
+                "rack14_blade1",
+                "rack14_blade2",
+                "alpha",
+                "tux1",
+                "tux2",
+                "tux3",
+                "tux6",
+            ]
+        ),
+    ),
+    ("node-0", ["node-0"]),
+    ("node-[0-3]", ["node-0", "node-1", "node-2", "node-3"]),
+]
 
 
-@pytest.mark.parametrize('nre,expected', NRES_)
+@pytest.mark.parametrize("nre,expected", NRES_)
 def test_parse_slurm_nodelist(nre, expected):
     assert parse_slurm_nodelist(nre) == expected
 
 
 NCES_ = [
-        ('8', [8]),
-        ('8(x2)', [8, 8]),
-        ('16,24', [16, 24]),
-        ('16,24(x3)', [16, 24, 24, 24]),
-        ('1(x1),2', [1, 2]),
-        ('72(x2),36', [72, 72, 36])
-        ]
+    ("8", [8]),
+    ("8(x2)", [8, 8]),
+    ("16,24", [16, 24]),
+    ("16,24(x3)", [16, 24, 24, 24]),
+    ("1(x1),2", [1, 2]),
+    ("72(x2),36", [72, 72, 36]),
+]
 
 
-@pytest.mark.parametrize('nce,expected', NCES_)
+@pytest.mark.parametrize("nce,expected", NCES_)
 def test_parse_slurm_nodes_cores(nce, expected):
     assert parse_slurm_nodes_cores(nce) == expected

--- a/libmuscle/python/libmuscle/outbox.py
+++ b/libmuscle/python/libmuscle/outbox.py
@@ -9,14 +9,13 @@ class Outbox:
     An Outbox is a queue of messages, which may be deposited and
     then retrieved in the same order.
     """
+
     def __init__(self) -> None:
-        """Create an empty Outbox.
-        """
+        """Create an empty Outbox."""
         self.__queue: Queue[Buffer] = Queue()
 
     def is_empty(self) -> bool:
-        """Returns True iff the outbox is empty.
-        """
+        """Returns True iff the outbox is empty."""
         return self.__queue.empty()
 
     def deposit(self, message: Buffer) -> None:

--- a/libmuscle/python/libmuscle/peer_info.py
+++ b/libmuscle/python/libmuscle/peer_info.py
@@ -6,13 +6,17 @@ from libmuscle.endpoint import Endpoint
 
 
 class PeerInfo:
-    """Interprets information about peers for a Communicator
-    """
-    def __init__(self, kernel: Reference, index: list[int],
-                 conduits: list[Conduit],
-                 peer_dims: dict[Reference, list[int]],
-                 peer_locations: dict[Reference, list[str]],
-                 ymmsl_ports: list[Port]) -> None:
+    """Interprets information about peers for a Communicator"""
+
+    def __init__(
+        self,
+        kernel: Reference,
+        index: list[int],
+        conduits: list[Conduit],
+        peer_dims: dict[Reference, list[int]],
+        peer_locations: dict[Reference, list[str]],
+        ymmsl_ports: list[Port],
+    ) -> None:
         """Create a PeerInfo.
 
         Peers here are instances, and peer_dims and peer_locations are
@@ -48,19 +52,19 @@ class PeerInfo:
                 # we send on the port this conduit attaches to
                 if conduit.sender not in self._outgoing_ports:
                     self._outgoing_ports.append(conduit.sender)
-                self._peers.setdefault(conduit.sender, []).append(
-                        conduit.receiver)
+                self._peers.setdefault(conduit.sender, []).append(conduit.receiver)
 
             if str(conduit.receiving_component()) == str(kernel):
                 # we receive on the port this conduit attaches to
                 if conduit.receiver in self._peers:
                     raise RuntimeError(
-                            f'Receiving port "{conduit.receiving_port()}" is connected'
-                            ' by multiple conduits, but at most one is allowed.')
+                        f'Receiving port "{conduit.receiving_port()}" is connected'
+                        " by multiple conduits, but at most one is allowed."
+                    )
                 self._incoming_ports.append(conduit.receiver)
                 self._peers[conduit.receiver] = [conduit.sender]
 
-        self._peer_dims = peer_dims    # indexed by kernel id
+        self._peer_dims = peer_dims  # indexed by kernel id
         self._peer_locations = peer_locations  # indexed by instance id
         self._ymmsl_ports = ymmsl_ports
 
@@ -76,8 +80,9 @@ class PeerInfo:
             peer endpoint.
         """
         return [
-                (cast(Identifier, port_ref[-1]), self._peers[port_ref][0])
-                for port_ref in self._incoming_ports]
+            (cast(Identifier, port_ref[-1]), self._peers[port_ref][0])
+            for port_ref in self._incoming_ports
+        ]
 
     def list_outgoing_ports(self) -> list[tuple[Identifier, list[Reference]]]:
         """list outgoing ports.
@@ -87,8 +92,9 @@ class PeerInfo:
             to the peer endpoint(s).
         """
         return [
-                (cast(Identifier, port_ref[-1]), self._peers[port_ref])
-                for port_ref in self._outgoing_ports]
+            (cast(Identifier, port_ref[-1]), self._peers[port_ref])
+            for port_ref in self._outgoing_ports
+        ]
 
     def is_connected(self, port: Identifier) -> bool:
         """Determine whether the given port is connected.
@@ -126,8 +132,7 @@ class PeerInfo:
         """
         return self._peer_locations[peer_instance]
 
-    def get_peer_endpoints(self, port: Identifier, slot: list[int]
-                           ) -> list[Endpoint]:
+    def get_peer_endpoints(self, port: Identifier, slot: list[int]) -> list[Endpoint]:
         """Determine the peer endpoints for the given port and slot.
 
         Args:
@@ -150,8 +155,7 @@ class PeerInfo:
             peer_dim = len(self._peer_dims[peer_kernel])
             peer_index = total_index[0:peer_dim]
             peer_slot = total_index[peer_dim:]
-            endpoints.append(
-                    Endpoint(peer_kernel, peer_index, peer_port, peer_slot))
+            endpoints.append(Endpoint(peer_kernel, peer_index, peer_port, peer_slot))
 
         return endpoints
 

--- a/libmuscle/python/libmuscle/planner/planner.py
+++ b/libmuscle/python/libmuscle/planner/planner.py
@@ -51,6 +51,7 @@ class ModelGraph:
     - Micros are components that are both a subsuccessor and a subpredecessor of the
       current component.
     """
+
     def __init__(self, model: Model) -> None:
         """Create a ModelGraph.
 
@@ -163,9 +164,11 @@ class ModelGraph:
         return self._subsuccs[component] & self._subpreds[component]
 
     def _propagate(
-            self, from_set: set[tuple[Component, int]],
-            to_set: set[tuple[Component, int]], shared_dims: int
-            ) -> None:
+        self,
+        from_set: set[tuple[Component, int]],
+        to_set: set[tuple[Component, int]],
+        shared_dims: int,
+    ) -> None:
         """Propagates from_set into to_set.
 
         Note: Modifies to_set.
@@ -175,9 +178,7 @@ class ModelGraph:
             to_set: Set to propagate them into
             shared_dims: Maximum shared dimensions to carry
         """
-        to_set.update({
-            (cmp, min(sd, shared_dims))
-            for cmp, sd in from_set})
+        to_set.update({(cmp, min(sd, shared_dims)) for cmp, sd in from_set})
 
     def _calc_predecessors(self) -> None:
         """Calculates predecessors of each component in the model.
@@ -199,13 +200,12 @@ class ModelGraph:
         self._subpreds = {c: set() for c in self._model.components.values()}
 
         num_remaining_preds = {
-                c: (
-                    len(self._direct_predecessors[c]) +
-                    len(self._direct_superpreds[c]))
-                for c in self._model.components.values()}
+            c: (len(self._direct_predecessors[c]) + len(self._direct_superpreds[c]))
+            for c in self._model.components.values()
+        }
         num_remaining_subpreds = {
-                c: len(self._direct_subpreds[c])
-                for c in self._model.components.values()}
+            c: len(self._direct_subpreds[c]) for c in self._model.components.values()
+        }
 
         todo = set(self._model.components.values())
         started: set[Component] = set()
@@ -219,12 +219,16 @@ class ModelGraph:
                     for subsucc, shared_dims in self._direct_subsuccs[component]:
                         self._superpreds[subsucc].add((component, shared_dims))
                         self._propagate(
-                                self._predecessors[component],
-                                self._predecessors[subsucc], shared_dims)
+                            self._predecessors[component],
+                            self._predecessors[subsucc],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._superpreds[component],
-                                self._superpreds[subsucc], shared_dims)
+                            self._superpreds[component],
+                            self._superpreds[subsucc],
+                            shared_dims,
+                        )
 
                         num_remaining_preds[subsucc] -= 1
                     started.add(component)
@@ -238,16 +242,22 @@ class ModelGraph:
                     for succ, shared_dims in self._direct_successors[component]:
                         self._predecessors[succ].add((component, shared_dims))
                         self._propagate(
-                                self._subpreds[component],
-                                self._predecessors[succ], shared_dims)
+                            self._subpreds[component],
+                            self._predecessors[succ],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._predecessors[component],
-                                self._predecessors[succ], shared_dims)
+                            self._predecessors[component],
+                            self._predecessors[succ],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._superpreds[component],
-                                self._superpreds[succ], shared_dims)
+                            self._superpreds[component],
+                            self._superpreds[succ],
+                            shared_dims,
+                        )
 
                         num_remaining_preds[succ] -= 1
 
@@ -255,12 +265,16 @@ class ModelGraph:
                         self._subpreds[supersucc].add((component, shared_dims))
 
                         self._propagate(
-                                self._subpreds[component],
-                                self._subpreds[supersucc], shared_dims)
+                            self._subpreds[component],
+                            self._subpreds[supersucc],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._predecessors[component],
-                                self._subpreds[supersucc], shared_dims)
+                            self._predecessors[component],
+                            self._subpreds[supersucc],
+                            shared_dims,
+                        )
 
                         num_remaining_subpreds[supersucc] -= 1
 
@@ -271,10 +285,11 @@ class ModelGraph:
 
             if not started and not finished:
                 raise RuntimeError(
-                        'Could not plan resource allocation for this model.'
-                        ' Do you have a cycle of O_F -> F_INIT conduits?'
-                        ' That does not work, because the models will all be'
-                        ' waiting for each other to start.')
+                    "Could not plan resource allocation for this model."
+                    " Do you have a cycle of O_F -> F_INIT conduits?"
+                    " That does not work, because the models will all be"
+                    " waiting for each other to start."
+                )
 
     def _calc_successors(self) -> None:
         """Calculates successors of each component in the model.
@@ -296,14 +311,13 @@ class ModelGraph:
         self._subsuccs = {c: set() for c in self._model.components.values()}
 
         num_remaining_succs = {
-                c: (
-                    len(self._direct_successors[c]) +
-                    len(self._direct_supersuccs[c]))
-                for c in self._model.components.values()}
+            c: (len(self._direct_successors[c]) + len(self._direct_supersuccs[c]))
+            for c in self._model.components.values()
+        }
 
         num_remaining_subsuccs = {
-                c: len(self._direct_subsuccs[c])
-                for c in self._model.components.values()}
+            c: len(self._direct_subsuccs[c]) for c in self._model.components.values()
+        }
 
         todo = set(self._model.components.values())
         started: set[Component] = set()
@@ -317,12 +331,16 @@ class ModelGraph:
                     for subpred, shared_dims in self._direct_subpreds[component]:
                         self._supersuccs[subpred].add((component, shared_dims))
                         self._propagate(
-                                self._successors[component],
-                                self._successors[subpred], shared_dims)
+                            self._successors[component],
+                            self._successors[subpred],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._supersuccs[component],
-                                self._supersuccs[subpred], shared_dims)
+                            self._supersuccs[component],
+                            self._supersuccs[subpred],
+                            shared_dims,
+                        )
                         num_remaining_succs[subpred] -= 1
 
                     started.add(component)
@@ -336,27 +354,37 @@ class ModelGraph:
                     for pred, shared_dims in self._direct_predecessors[component]:
                         self._successors[pred].add((component, shared_dims))
                         self._propagate(
-                                self._successors[component],
-                                self._successors[pred], shared_dims)
+                            self._successors[component],
+                            self._successors[pred],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._supersuccs[component],
-                                self._supersuccs[pred], shared_dims)
+                            self._supersuccs[component],
+                            self._supersuccs[pred],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._subsuccs[component],
-                                self._successors[pred], shared_dims)
+                            self._subsuccs[component],
+                            self._successors[pred],
+                            shared_dims,
+                        )
                         num_remaining_succs[pred] -= 1
 
                     for superpred, shared_dims in self._direct_superpreds[component]:
                         self._subsuccs[superpred].add((component, shared_dims))
                         self._propagate(
-                                self._successors[component],
-                                self._subsuccs[superpred], shared_dims)
+                            self._successors[component],
+                            self._subsuccs[superpred],
+                            shared_dims,
+                        )
 
                         self._propagate(
-                                self._subsuccs[component],
-                                self._subsuccs[superpred], shared_dims)
+                            self._subsuccs[component],
+                            self._subsuccs[superpred],
+                            shared_dims,
+                        )
                         num_remaining_subsuccs[superpred] -= 1
                     finished.add(component)
 
@@ -404,7 +432,7 @@ class ModelGraph:
             receiver = self._model.components[conduit.receiving_component()]
             recv_port = conduit.receiving_port()
             recv_op = None
-            if recv_port == 'muscle_settings_in':
+            if recv_port == "muscle_settings_in":
                 recv_op = Operator.F_INIT
             elif receiver.ports:
                 if recv_port in receiver.ports:
@@ -439,6 +467,7 @@ class ResourceAssignment:
         by_rank: List of OnNodeResources objects containing assigned resources,
         indexed by rank.
     """
+
     def __init__(self, by_rank: list[OnNodeResources]) -> None:
         """Create a ResourceAssignment.
 
@@ -452,19 +481,17 @@ class ResourceAssignment:
         if not isinstance(other, ResourceAssignment):
             return NotImplemented
 
-        return (
-                len(self.by_rank) == len(other.by_rank) and
-                all([
-                    snr == onr
-                    for snr, onr in zip(self.by_rank, other.by_rank)]))
+        return len(self.by_rank) == len(other.by_rank) and all(
+            [snr == onr for snr, onr in zip(self.by_rank, other.by_rank)]
+        )
 
     def __str__(self) -> str:
         # str(list()) uses repr() on the elements, we want str()
-        str_rbr = ', '.join([str(nr) for nr in self.by_rank])
-        return f'[{str_rbr}]'
+        str_rbr = ", ".join([str(nr) for nr in self.by_rank])
+        return f"[{str_rbr}]"
 
     def __repr__(self) -> str:
-        return f'ResourceAssignment({repr(self.by_rank)})'
+        return f"ResourceAssignment({repr(self.by_rank)})"
 
     def as_resources(self) -> Resources:
         """Return a Resources representing the combined assigned resources."""
@@ -480,6 +507,7 @@ class InsufficientResourcesAvailable(RuntimeError):
 
 class Planner:
     """Allocates resources and keeps track of allocations."""
+
     def __init__(self, all_resources: Resources) -> None:
         """Create a Planner.
 
@@ -493,8 +521,8 @@ class Planner:
         self._next_virtual_node = 1
 
     def allocate_all(
-            self, configuration: Configuration, virtual: bool = False
-            ) -> dict[Reference, ResourceAssignment]:
+        self, configuration: Configuration, virtual: bool = False
+    ) -> dict[Reference, ResourceAssignment]:
         """Allocates resources for the given components.
 
         Allocation can occur either on a fixed set of available
@@ -519,60 +547,68 @@ class Planner:
         """
         result: dict[Reference, ResourceAssignment] = {}
 
-        _logger.debug(f'Planning on resources {self._all_resources}')
+        _logger.debug(f"Planning on resources {self._all_resources}")
 
         # Analyse model
         root_model = configuration.root_model()
         model = ModelGraph(root_model)
         programs = configuration.programs
         exclusive = {
-                i for c in model.components() for i in c.instances()
-                if (c.implementation and
-                    not programs[c.implementation].can_share_resources)}
+            i
+            for c in model.components()
+            for i in c.instances()
+            if (c.implementation and not programs[c.implementation].can_share_resources)
+        }
 
         requirements: dict[Reference, ResourceRequirements] = {
-            root_model.name + component.name:
-                configuration.get_resources(root_model.name + component.name)
+            root_model.name + component.name: configuration.get_resources(
+                root_model.name + component.name
+            )
             for component in model.components()
         }
 
         # Allocate
-        unallocated_instances = [
-                i for c in model.components() for i in c.instances()]
+        unallocated_instances = [i for c in model.components() for i in c.instances()]
         leftover_instances: list[Reference] = []
         while unallocated_instances:
             leftover_instances.clear()
 
             to_allocate = self._sort_instances(
-                    root_model.name, unallocated_instances, requirements)
+                root_model.name, unallocated_instances, requirements
+            )
 
             for instance in to_allocate:
-                _logger.debug(f'Placing {instance}')
+                _logger.debug(f"Placing {instance}")
                 component = model.component(instance.without_trailing_ints())
                 conflicting_names = self._conflicting_names(
-                        model, exclusive, component, instance)
+                    model, exclusive, component, instance
+                )
 
                 done = False
                 while not done:
                     try:
                         result[instance] = self._assign_instance(
-                                instance, component,
-                                requirements[root_model.name + component.name],
-                                conflicting_names, virtual)
+                            instance,
+                            component,
+                            requirements[root_model.name + component.name],
+                            conflicting_names,
+                            virtual,
+                        )
                         done = True
                     except InsufficientResourcesAvailable:
                         if virtual:
                             self._expand_resources(
-                                    component.name,
-                                    requirements[root_model.name + component.name])
+                                component.name,
+                                requirements[root_model.name + component.name],
+                            )
                         else:
                             leftover_instances.append(instance)
                             done = True
 
             if leftover_instances:
                 _logger.warning(
-                    'Planner ran out of resources, oversubscribing remaining'
-                    ' instances.')
+                    "Planner ran out of resources, oversubscribing remaining instances."
+                )
                 self._oversubscribed.update(self._allocations)
                 self._allocations.clear()
 
@@ -582,9 +618,11 @@ class Planner:
         return result
 
     def _sort_instances(
-            self, model_name: Reference, instances: list[Reference],
-            requirements: Mapping[Reference, ResourceRequirements]
-            ) -> list[Reference]:
+        self,
+        model_name: Reference,
+        instances: list[Reference],
+        requirements: Mapping[Reference, ResourceRequirements],
+    ) -> list[Reference]:
         """Return to be allocated components in optimal order.
 
         This is a heuristic, it's not actually optimal but it should
@@ -600,22 +638,28 @@ class Planner:
         reqs = map(lambda n: requirements[model_name + n], cmp_names)
         instances_reqs = list(zip(instances, reqs))
         threaded = [
-                (i, r.threads) for i, r in instances_reqs
-                if isinstance(r, ThreadedResReq)]
+            (i, r.threads) for i, r in instances_reqs if isinstance(r, ThreadedResReq)
+        ]
         sorted_threaded = sorted(threaded, key=lambda x: x[1], reverse=True)
         sorted_threaded_instances = [x[0] for x in sorted_threaded]
 
         mpi = [
-                (i, r.mpi_processes) for i, r in instances_reqs
-                if isinstance(r, MPICoresResReq)]
+            (i, r.mpi_processes)
+            for i, r in instances_reqs
+            if isinstance(r, MPICoresResReq)
+        ]
         sorted_mpi = sorted(mpi, key=lambda x: x[1], reverse=True)
         sorted_mpi_instances = [x[0] for x in sorted_mpi]
 
         return sorted_threaded_instances + sorted_mpi_instances
 
     def _conflicting_names(
-            self, model: ModelGraph, exclusive: set[Reference],
-            component: Component, instance: Reference) -> set[Reference]:
+        self,
+        model: ModelGraph,
+        exclusive: set[Reference],
+        component: Component,
+        instance: Reference,
+    ) -> set[Reference]:
         """Find conflicting components.
 
         This returns the names of instances that cannot share resources
@@ -628,20 +672,23 @@ class Planner:
             component: Component to find conflicts for
             instance: Instance (of component) to find conflicts for
         """
+
         def indices_match(
-                instance1: Reference, instance2: Reference, dims: int) -> bool:
+            instance1: Reference, instance2: Reference, dims: int
+        ) -> bool:
             idx1 = instance_indices(instance1)
             idx2 = instance_indices(instance2)
             return idx1[:dims] == idx2[:dims]
 
-        def matching_instances(
-                others: set[tuple[Component, int]]) -> set[Reference]:
+        def matching_instances(others: set[tuple[Component, int]]) -> set[Reference]:
             return {
-                    i for c, d in others for i in c.instances()
-                    if indices_match(i, instance, d)}
+                i
+                for c, d in others
+                for i in c.instances()
+                if indices_match(i, instance, d)
+            }
 
-        conflicting_instances = {
-                i for c in model.components() for i in c.instances()}
+        conflicting_instances = {i for c in model.components() for i in c.instances()}
 
         if instance in exclusive:
             return conflicting_instances
@@ -657,12 +704,11 @@ class Planner:
 
         return conflicting_instances
 
-    def _expand_resources(
-            self, name: Reference, req: ResourceRequirements) -> None:
+    def _expand_resources(self, name: Reference, req: ResourceRequirements) -> None:
         """Adds an extra virtual node to the available resources."""
         taken = True
         while taken:
-            new_node_name = f'node{self._next_virtual_node:06d}'
+            new_node_name = f"node{self._next_virtual_node:06d}"
             taken = new_node_name in self._all_resources.nodes()
             self._next_virtual_node += 1
 
@@ -673,24 +719,29 @@ class Planner:
         if isinstance(req, ThreadedResReq):
             if req.threads > num_cores:
                 raise InsufficientResourcesAvailable(
-                        f'Instance {name} requires {req.threads} threads,'
-                        f' which is impossible with {num_cores} cores per'
-                        ' node.')
+                    f"Instance {name} requires {req.threads} threads,"
+                    f" which is impossible with {num_cores} cores per"
+                    " node."
+                )
         if isinstance(req, MPICoresResReq):
             if req.threads_per_mpi_process > num_cores:
                 raise InsufficientResourcesAvailable(
-                        f'Instance {name} requires'
-                        f' {req.threads_per_mpi_process} threads per process,'
-                        f' which is impossible with {num_cores} cores per'
-                        ' node.')
+                    f"Instance {name} requires"
+                    f" {req.threads_per_mpi_process} threads per process,"
+                    f" which is impossible with {num_cores} cores per"
+                    " node."
+                )
 
         self._all_resources.add_node(new_node)
 
     def _assign_instance(
-            self, instance: Reference, component: Component,
-            requirements: ResourceRequirements,
-            simultaneous_instances: set[Reference], virtual: bool
-            ) -> ResourceAssignment:
+        self,
+        instance: Reference,
+        component: Component,
+        requirements: ResourceRequirements,
+        simultaneous_instances: set[Reference],
+        virtual: bool,
+    ) -> ResourceAssignment:
         """Allocates resources for the given instance.
 
         If we are on real resources, and the instance requires more
@@ -717,27 +768,31 @@ class Planner:
             if other in simultaneous_instances:
                 free_resources -= self._allocations[other]
 
-        _logger.debug(f'Free resources: {free_resources}')
+        _logger.debug(f"Free resources: {free_resources}")
         try:
             if isinstance(requirements, ThreadedResReq):
-                assignment.by_rank.append(self._assign_thread_block(
-                        free_resources, requirements.threads))
+                assignment.by_rank.append(
+                    self._assign_thread_block(free_resources, requirements.threads)
+                )
 
             elif isinstance(requirements, MPICoresResReq):
                 if requirements.threads_per_mpi_process != 1:
                     raise RuntimeError(
-                            'Multiple threads per MPI process is not supported'
-                            ' yet. Please make an issue on GitHub.')
+                        "Multiple threads per MPI process is not supported"
+                        " yet. Please make an issue on GitHub."
+                    )
                 for _ in range(requirements.mpi_processes):
                     block = self._assign_thread_block(
-                                free_resources, requirements.threads_per_mpi_process)
+                        free_resources, requirements.threads_per_mpi_process
+                    )
                     assignment.by_rank.append(block)
                     free_resources -= Resources([block])
 
             elif isinstance(requirements, MPINodesResReq):
                 raise RuntimeError(
-                        'Node-based MPI resource requirements are not'
-                        ' supported yet. Please make an issue on GitHub.')
+                    "Node-based MPI resource requirements are not"
+                    " supported yet. Please make an issue on GitHub."
+                )
 
         except InsufficientResourcesAvailable:
             if not self._allocations and not virtual:
@@ -751,7 +806,8 @@ class Planner:
         return assignment
 
     def _assign_thread_block(
-            self, free_resources: Resources, num_threads: int) -> OnNodeResources:
+        self, free_resources: Resources, num_threads: int
+    ) -> OnNodeResources:
         """Assign resources for a group of threads.
 
         This chooses a set of <num_threads> cores on the same node. It returns the
@@ -767,15 +823,15 @@ class Planner:
         for node in free_resources:
             if len(node.cpu_cores) >= num_threads:
                 available_cores = node.cpu_cores
-                _logger.debug(f'available cores: {available_cores}')
+                _logger.debug(f"available cores: {available_cores}")
                 to_reserve = available_cores.get_first_cores(num_threads)
-                _logger.debug(f'assigned {to_reserve}')
+                _logger.debug(f"assigned {to_reserve}")
                 return OnNodeResources(node.node_name, to_reserve)
         raise InsufficientResourcesAvailable()
 
     def _oversubscribe_instance(
-            self, instance: Reference, requirements: ResourceRequirements
-            ) -> ResourceAssignment:
+        self, instance: Reference, requirements: ResourceRequirements
+    ) -> ResourceAssignment:
         """Oversubscribe an instance.
 
         This is called when all resources are available and we still cannot fit an
@@ -795,8 +851,9 @@ class Planner:
             An oversubscribed resource assignment
         """
         _logger.warning(
-                f'Instance {instance} requires more resources than are available in'
-                ' total. Oversubscribing this instance.')
+            f"Instance {instance} requires more resources than are available in"
+            " total. Oversubscribing this instance."
+        )
 
         res_by_rank: list[OnNodeResources] = list()
 
@@ -806,8 +863,9 @@ class Planner:
         elif isinstance(requirements, MPICoresResReq):
             if requirements.threads_per_mpi_process != 1:
                 raise RuntimeError(
-                        'Multiple threads per MPI process is not supported yet. Please'
-                        ' make an issue on GitHub.')
+                    "Multiple threads per MPI process is not supported yet. Please"
+                    " make an issue on GitHub."
+                )
 
             free_resources = copy(self._all_resources)
             for _ in range(requirements.mpi_processes):
@@ -815,7 +873,8 @@ class Planner:
                     free_resources = copy(self._all_resources)
 
                 block = self._assign_thread_block(
-                            free_resources, requirements.threads_per_mpi_process)
+                    free_resources, requirements.threads_per_mpi_process
+                )
 
                 res_by_rank.append(block)
                 free_resources -= Resources([block])

--- a/libmuscle/python/libmuscle/planner/resources.py
+++ b/libmuscle/python/libmuscle/planner/resources.py
@@ -186,6 +186,7 @@ psutil      physical        counted by psutil.cpu_count(logical=False)
 ```
 
 """
+
 from collections.abc import Iterable, Iterator
 from copy import copy, deepcopy
 from typing import Optional
@@ -225,6 +226,7 @@ class Core:
         cid: ID of this core, to be used to refer to it
         hwthreads: Ids of hwthreads (logical CPUs) belonging to this core
     """
+
     def __init__(self, cid: int, hwthreads: set[int]) -> None:
         """Create a Core"""
         self.cid = cid
@@ -239,50 +241,50 @@ class Core:
     def __len__(self) -> int:
         return len(self.hwthreads)
 
-    def __copy__(self) -> 'Core':
+    def __copy__(self) -> "Core":
         return Core(self.cid, self.hwthreads)
 
-    def __or__(self, other: object) -> 'Core':
+    def __or__(self, other: object) -> "Core":
         if not isinstance(other, Core):
             return NotImplemented
 
         if other.cid != self.cid:
-            raise ValueError('Cannot merge hwthreads on different cores')
+            raise ValueError("Cannot merge hwthreads on different cores")
 
         return Core(self.cid, self.hwthreads | other.hwthreads)
 
-    def __ior__(self, other: object) -> 'Core':
+    def __ior__(self, other: object) -> "Core":
         if not isinstance(other, Core):
             return NotImplemented
 
         if other.cid != self.cid:
-            raise ValueError('Cannot merge hwthreads on different cores')
+            raise ValueError("Cannot merge hwthreads on different cores")
 
         self.hwthreads |= other.hwthreads
         return self
 
-    def __isub__(self, other: object) -> 'Core':
+    def __isub__(self, other: object) -> "Core":
         if not isinstance(other, Core):
             return NotImplemented
 
         if other.cid != self.cid:
-            raise ValueError('Cannot merge hwthreads on different cores')
+            raise ValueError("Cannot merge hwthreads on different cores")
 
         self.hwthreads -= other.hwthreads
         return self
 
     def __str__(self) -> str:
-        hwthreads = ','.join(map(str, sorted(self.hwthreads)))
-        return f'{self.cid}({hwthreads})'
+        hwthreads = ",".join(map(str, sorted(self.hwthreads)))
+        return f"{self.cid}({hwthreads})"
 
     def __repr__(self) -> str:
-        hwthreads = ','.join(map(str, sorted(self.hwthreads)))
-        return f'Core({self.cid}, {{{hwthreads}}})'
+        hwthreads = ",".join(map(str, sorted(self.hwthreads)))
+        return f"Core({self.cid}, {{{hwthreads}}})"
 
-    def isdisjoint(self, other: 'Core') -> bool:
+    def isdisjoint(self, other: "Core") -> bool:
         """Returns whether we share resources with other."""
         if self.cid != other.cid:
-            raise ValueError('Cannot compare hwthreads on different cores')
+            raise ValueError("Cannot compare hwthreads on different cores")
 
         return self.hwthreads.isdisjoint(other.hwthreads)
 
@@ -297,6 +299,7 @@ class CoreSet:
     make a copy using copy.copy() and modify that copy anywhere without changing the
     original.
     """
+
     def __init__(self, cores: Iterable[Core]) -> None:
         """Create a CoreSet
 
@@ -326,10 +329,10 @@ class CoreSet:
     def __iter__(self) -> Iterator[Core]:
         return iter(self._cores.values())
 
-    def __copy__(self) -> 'CoreSet':
+    def __copy__(self) -> "CoreSet":
         return CoreSet(deepcopy(list(self._cores.values())))
 
-    def __ior__(self, other: object) -> 'CoreSet':
+    def __ior__(self, other: object) -> "CoreSet":
         if not isinstance(other, CoreSet):
             return NotImplemented
 
@@ -341,7 +344,7 @@ class CoreSet:
 
         return self
 
-    def __isub__(self, other: object) -> 'CoreSet':
+    def __isub__(self, other: object) -> "CoreSet":
         if not isinstance(other, CoreSet):
             return NotImplemented
 
@@ -356,33 +359,33 @@ class CoreSet:
     def __str__(self) -> str:
         def collapse_ranges(ids: list[int]) -> str:
             if len(ids) == 0:
-                return ''
+                return ""
 
             result = list()
             start = 0
             i = 1
             while i <= len(ids):
-                if (i == len(ids)) or (ids[i-1] != ids[i] - 1):
+                if (i == len(ids)) or (ids[i - 1] != ids[i] - 1):
                     if start == i - 1:
                         # run of one
-                        result.append(str(ids[i-1]))
+                        result.append(str(ids[i - 1]))
                     else:
                         # run of at least two
-                        result.append(f'{ids[start]}-{ids[i-1]}')
+                        result.append(f"{ids[start]}-{ids[i - 1]}")
                     start = i
                 i += 1
-            return ','.join(result)
+            return ",".join(result)
 
         cores = sorted(c.cid for c in self._cores.values())
         hwthreads = sorted(t for c in self._cores.values() for t in c.hwthreads)
 
-        return f'{collapse_ranges(cores)}({collapse_ranges(hwthreads)})'
+        return f"{collapse_ranges(cores)}({collapse_ranges(hwthreads)})"
 
     def __repr__(self) -> str:
-        cores = ', '.join(map(repr, sorted(self._cores.values(), key=lambda c: c.cid)))
-        return f'CoreSet({{{cores}}})'
+        cores = ", ".join(map(repr, sorted(self._cores.values(), key=lambda c: c.cid)))
+        return f"CoreSet({{{cores}}})"
 
-    def isdisjoint(self, other: 'CoreSet') -> bool:
+    def isdisjoint(self, other: "CoreSet") -> bool:
         """Returns whether we share resources with other."""
         for cid, core in self._cores.items():
             if cid in other._cores:
@@ -390,7 +393,7 @@ class CoreSet:
                     return False
         return True
 
-    def get_first_cores(self, num_cores: int) -> 'CoreSet':
+    def get_first_cores(self, num_cores: int) -> "CoreSet":
         """Returns the first num_cores cores in this set.
 
         Args:
@@ -400,7 +403,7 @@ class CoreSet:
         cids = list(self._cores.keys())
         selected = cids[:num_cores]
         if len(selected) < num_cores:
-            raise RuntimeError('Tried to get more cores than available')
+            raise RuntimeError("Tried to get more cores than available")
 
         result._cores = {c.cid: c for c in result._cores.values() if c.cid in selected}
         return result
@@ -416,6 +419,7 @@ class OnNodeResources:
     make a copy using copy.copy() and modify that copy anywhere without changing the
     original.
     """
+
     def __init__(self, node_name: str, cpu_cores: CoreSet) -> None:
         """Create an OnNodeResources.
 
@@ -431,35 +435,36 @@ class OnNodeResources:
             return NotImplemented
 
         return (
-                isinstance(other, OnNodeResources) and
-                self.node_name == other.node_name and
-                self.cpu_cores == other.cpu_cores)
+            isinstance(other, OnNodeResources)
+            and self.node_name == other.node_name
+            and self.cpu_cores == other.cpu_cores
+        )
 
-    def __copy__(self) -> 'OnNodeResources':
+    def __copy__(self) -> "OnNodeResources":
         return OnNodeResources(self.node_name, copy(self.cpu_cores))
 
-    def __ior__(self, other: object) -> 'OnNodeResources':
+    def __ior__(self, other: object) -> "OnNodeResources":
         if not isinstance(other, OnNodeResources):
             return NotImplemented
 
         if self.node_name != other.node_name:
-            raise ValueError('Cannot merge resources on different nodes')
+            raise ValueError("Cannot merge resources on different nodes")
 
         self.cpu_cores |= other.cpu_cores
         return self
 
-    def __isub__(self, other: object) -> 'OnNodeResources':
+    def __isub__(self, other: object) -> "OnNodeResources":
         if not isinstance(other, OnNodeResources):
             return NotImplemented
 
         if self.node_name != other.node_name:
-            raise ValueError('Cannot remove resources on different nodes')
+            raise ValueError("Cannot remove resources on different nodes")
 
         self.cpu_cores -= other.cpu_cores
         return self
 
     def __str__(self) -> str:
-        return f'OnNodeResources({self.node_name}, c: {str(self.cpu_cores)})'
+        return f"OnNodeResources({self.node_name}, c: {str(self.cpu_cores)})"
 
     def __repr__(self) -> str:
         return f'OnNodeResources("{self.node_name}", {repr(self.cpu_cores)})'
@@ -472,11 +477,11 @@ class OnNodeResources:
         """Return the number of CPU cores in this node."""
         return len(self.cpu_cores)
 
-    def isdisjoint(self, other: 'OnNodeResources') -> bool:
+    def isdisjoint(self, other: "OnNodeResources") -> bool:
         """Returns whether we share resources with other."""
-        return (
-                self.node_name != other.node_name or
-                self.cpu_cores.isdisjoint(other.cpu_cores))
+        return self.node_name != other.node_name or self.cpu_cores.isdisjoint(
+            other.cpu_cores
+        )
 
 
 class Resources:
@@ -492,6 +497,7 @@ class Resources:
     Attributes:
         nodes: A collection of nodes to include in this resource set
     """
+
     def __init__(self, nodes: Optional[Iterable[OnNodeResources]] = None) -> None:
         """Create a Resources object with the given nodes.
 
@@ -528,11 +534,11 @@ class Resources:
 
         return True
 
-    def __copy__(self) -> 'Resources':
+    def __copy__(self) -> "Resources":
         """Copy the object."""
         return Resources(copy(n) for n in self._nodes.values())
 
-    def __ior__(self, other: object) -> 'Resources':
+    def __ior__(self, other: object) -> "Resources":
         """Add the resources in the argument to this object."""
         if not isinstance(other, Resources):
             return NotImplemented
@@ -545,7 +551,7 @@ class Resources:
 
         return self
 
-    def __isub__(self, other: object) -> 'Resources':
+    def __isub__(self, other: object) -> "Resources":
         """Remove the resources in the argument from this object."""
         if not isinstance(other, Resources):
             return NotImplemented
@@ -560,14 +566,15 @@ class Resources:
 
     def __str__(self) -> str:
         """Return a human-readable string representation."""
-        nodes = ','.join(
-                map(str, sorted(self._nodes.values(), key=lambda n: n.node_name)))
-        return f'Resources({nodes})'
+        nodes = ",".join(
+            map(str, sorted(self._nodes.values(), key=lambda n: n.node_name))
+        )
+        return f"Resources({nodes})"
 
     def __repr__(self) -> str:
         """Return a string representation."""
         nodes = sorted(self._nodes.values(), key=lambda n: n.node_name)
-        return f'Resources({nodes})'
+        return f"Resources({nodes})"
 
     def nodes(self) -> Iterable[str]:
         """Return the names of the nodes on which we designate resources."""
@@ -580,16 +587,20 @@ class Resources:
     def cores(self) -> Iterable[tuple[str, int]]:
         """Return this resources as a list of node, core."""
         return (
-                (node.node_name, core.cid)
-                for node in self._nodes.values() for core in node.cpu_cores)
+            (node.node_name, core.cid)
+            for node in self._nodes.values()
+            for core in node.cpu_cores
+        )
 
     def hwthreads(self) -> Iterable[tuple[str, int]]:
         """Return this resources as a list of node, hwthread."""
         return (
-                (node.node_name, hwthread)
-                for node in self._nodes.values() for hwthread in node.hwthreads())
+            (node.node_name, hwthread)
+            for node in self._nodes.values()
+            for hwthread in node.hwthreads()
+        )
 
-    def isdisjoint(self, other: 'Resources') -> bool:
+    def isdisjoint(self, other: "Resources") -> bool:
         """Return whether we share resources with other."""
         for node_name, node in self._nodes.items():
             if node_name in other._nodes:
@@ -611,9 +622,10 @@ class Resources:
         """
         if node_res.node_name in self._nodes:
             raise RuntimeError(
-                    'Tried to add a OnNodeResources to a Resources for a node that is'
-                    ' already present. This is a bug in MUSCLE3, please report it on'
-                    ' GitHub.')
+                "Tried to add a OnNodeResources to a Resources for a node that is"
+                " already present. This is a bug in MUSCLE3, please report it on"
+                " GitHub."
+            )
 
         self._nodes[node_res.node_name] = node_res
 
@@ -632,7 +644,7 @@ class Resources:
             self._nodes[node_res.node_name] = copy(node_res)
 
     @staticmethod
-    def union(resources: Iterable['Resources']) -> 'Resources':
+    def union(resources: Iterable["Resources"]) -> "Resources":
         """Combines the resources into one.
 
         Args:

--- a/libmuscle/python/libmuscle/planner/test/test_planner.py
+++ b/libmuscle/python/libmuscle/planner/test/test_planner.py
@@ -27,74 +27,89 @@ Ref = Reference
 
 @pytest.fixture
 def all_resources() -> Resources:
-    return resources({
-        'node001': [c(1), c(2), c(3), c(4)],
-        'node002': [c(1), c(2), c(3), c(4)],
-        'node003': [c(1), c(2), c(3), c(4)]})
+    return resources(
+        {
+            "node001": [c(1), c(2), c(3), c(4)],
+            "node002": [c(1), c(2), c(3), c(4)],
+            "node003": [c(1), c(2), c(3), c(4)],
+        }
+    )
 
 
 @pytest.fixture
 def init() -> Component:
-    return Component('init', Ports(o_f=['state_out']), '', 'init')
+    return Component("init", Ports(o_f=["state_out"]), "", "init")
 
 
 @pytest.fixture
 def macro() -> Component:
     return Component(
-            'macro', Ports(f_init=['initial_state_in'], o_i=['bc_out'], s=['bc_in']),
-            '', 'macro')
+        "macro",
+        Ports(f_init=["initial_state_in"], o_i=["bc_out"], s=["bc_in"]),
+        "",
+        "macro",
+    )
 
 
 @pytest.fixture
 def micro() -> Component:
     return Component(
-            'micro', Ports(f_init=['initial_bc_in'], o_f=['final_bc_out']), '', 'micro')
+        "micro", Ports(f_init=["initial_bc_in"], o_f=["final_bc_out"]), "", "micro"
+    )
 
 
 @pytest.fixture
 def model(init: Component, macro: Component, micro: Component) -> Model:
     return Model(
-            'test_model', None, '', None, [init, macro, micro],
-            [
-                Conduit('init.state_out', 'macro.initial_state_in'),
-                Conduit('macro.bc_out', 'micro.initial_bc_in'),
-                Conduit('micro.final_bc_out', 'macro.bc_in')])
+        "test_model",
+        None,
+        "",
+        None,
+        [init, macro, micro],
+        [
+            Conduit("init.state_out", "macro.initial_state_in"),
+            Conduit("macro.bc_out", "micro.initial_bc_in"),
+            Conduit("micro.final_bc_out", "macro.bc_in"),
+        ],
+    )
 
 
 @pytest.fixture
 def programs() -> list[Program]:
     return [
-            Program(Ref('init'), script='init'),
-            Program(Ref('macro'), script='macro'),
-            Program(Ref('micro'), script='micro')]
+        Program(Ref("init"), script="init"),
+        Program(Ref("macro"), script="macro"),
+        Program(Ref("micro"), script="micro"),
+    ]
 
 
 @pytest.fixture
 def requirements() -> dict[Reference, ResourceRequirements]:
     res_list = [
-            ThreadedResReq(Ref('test_model.init'), 4),
-            ThreadedResReq(Ref('test_model.macro'), 4),
-            ThreadedResReq(Ref('test_model.micro'), 4)]
+        ThreadedResReq(Ref("test_model.init"), 4),
+        ThreadedResReq(Ref("test_model.macro"), 4),
+        ThreadedResReq(Ref("test_model.micro"), 4),
+    ]
     return {r.name: r for r in res_list}
 
 
 @pytest.fixture
 def configuration(
-        model: Model, programs: list[Program],
-        requirements: dict[Reference, ResourceRequirements]) -> Configuration:
-    return Configuration('config', [], [model], None, None, programs, requirements)
+    model: Model,
+    programs: list[Program],
+    requirements: dict[Reference, ResourceRequirements],
+) -> Configuration:
+    return Configuration("config", [], [model], None, None, programs, requirements)
 
 
 @pytest.fixture
 def assignment() -> ResourceAssignment:
-    return ResourceAssignment([
-        onr('node001', {0, 1}),
-        onr('node002', {2, 3})])
+    return ResourceAssignment([onr("node001", {0, 1}), onr("node002", {2, 3})])
 
 
 def test_model_graph(
-        init: Component, macro: Component, micro: Component, model: Model
-        ) -> None:
+    init: Component, macro: Component, micro: Component, model: Model
+) -> None:
     graph = ModelGraph(model)
 
     assert set(graph.components()) == set(model.components.values())
@@ -121,148 +136,160 @@ def test_resource_assignment_eq() -> None:
 
     assert asm1 == asm2
 
-    asm1.by_rank.append(onr('node001', {0, 1}))
+    asm1.by_rank.append(onr("node001", {0, 1}))
     assert asm1 != asm2
 
-    asm2.by_rank.append(onr('node001', {0, 2}))
+    asm2.by_rank.append(onr("node001", {0, 2}))
     assert asm1 != asm2
 
-    asm2.by_rank[0] = onr('node001', {0, 1})
+    asm2.by_rank[0] = onr("node001", {0, 1})
     assert asm1 == asm2
 
 
 def test_resource_assignment_str(assignment: ResourceAssignment) -> None:
     assert str(assignment) == (
-            '[OnNodeResources(node001, c: 0-1(0-1)),'
-            ' OnNodeResources(node002, c: 2-3(2-3))]')
+        "[OnNodeResources(node001, c: 0-1(0-1)), OnNodeResources(node002, c: 2-3(2-3))]"
+    )
 
 
 def test_resource_assignment_repr(assignment: ResourceAssignment) -> None:
     assert repr(assignment) == (
-            'ResourceAssignment(['
-            'OnNodeResources("node001", CoreSet({Core(0, {0}), Core(1, {1})})),'
-            ' OnNodeResources("node002", CoreSet({Core(2, {2}), Core(3, {3})}))])')
+        "ResourceAssignment(["
+        'OnNodeResources("node001", CoreSet({Core(0, {0}), Core(1, {1})})),'
+        ' OnNodeResources("node002", CoreSet({Core(2, {2}), Core(3, {3})}))])'
+    )
 
 
 def test_resource_assignment_as_resources(assignment) -> None:
     res = assignment.as_resources()
 
     assert res._nodes == {
-            'node001': onr('node001', {0, 1}),
-            'node002': onr('node002', {2, 3})}
+        "node001": onr("node001", {0, 1}),
+        "node002": onr("node002", {2, 3}),
+    }
 
-    asm2 = ResourceAssignment([
-        onr('node001', {0, 1}), onr('node001', {2, 3}), onr('node001', {2, 3}),
-        onr('node003', {4, 5})])
+    asm2 = ResourceAssignment(
+        [
+            onr("node001", {0, 1}),
+            onr("node001", {2, 3}),
+            onr("node001", {2, 3}),
+            onr("node003", {4, 5}),
+        ]
+    )
 
     res = asm2.as_resources()
 
     assert res._nodes == {
-            'node001': onr('node001', {0, 1, 2, 3}),
-            'node003': onr('node003', {4, 5})}
+        "node001": onr("node001", {0, 1, 2, 3}),
+        "node003": onr("node003", {4, 5}),
+    }
 
 
-def test_planner(
-        all_resources: Resources, configuration: Configuration) -> None:
+def test_planner(all_resources: Resources, configuration: Configuration) -> None:
     planner = Planner(all_resources)
     allocations = planner.allocate_all(configuration)
 
-    assert allocations[Ref('init')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('macro')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('micro')].by_rank == [onr('node001', {1, 2, 3, 4})]
+    assert allocations[Ref("init")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("macro")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("micro")].by_rank == [onr("node001", {1, 2, 3, 4})]
 
 
 def test_planner_exclusive_macro(
-        all_resources: Resources, configuration: Configuration) -> None:
+    all_resources: Resources, configuration: Configuration
+) -> None:
     planner = Planner(all_resources)
-    configuration.programs[Ref('macro')].can_share_resources = False
+    configuration.programs[Ref("macro")].can_share_resources = False
     allocations = planner.allocate_all(configuration)
 
-    assert allocations[Ref('init')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('macro')].by_rank == [onr('node002', {1, 2, 3, 4})]
-    assert allocations[Ref('micro')].by_rank == [onr('node001', {1, 2, 3, 4})]
+    assert allocations[Ref("init")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("macro")].by_rank == [onr("node002", {1, 2, 3, 4})]
+    assert allocations[Ref("micro")].by_rank == [onr("node001", {1, 2, 3, 4})]
 
 
 def test_planner_exclusive_predecessor(
-        all_resources: Resources, configuration: Configuration) -> None:
+    all_resources: Resources, configuration: Configuration
+) -> None:
     planner = Planner(all_resources)
-    configuration.programs[Ref('init')].can_share_resources = False
+    configuration.programs[Ref("init")].can_share_resources = False
     allocations = planner.allocate_all(configuration)
 
-    assert allocations[Ref('init')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('macro')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('micro')].by_rank == [onr('node001', {1, 2, 3, 4})]
+    assert allocations[Ref("init")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("macro")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("micro")].by_rank == [onr("node001", {1, 2, 3, 4})]
 
 
-def test_oversubscribe(
-        all_resources: Resources, configuration: Configuration) -> None:
+def test_oversubscribe(all_resources: Resources, configuration: Configuration) -> None:
 
-    for component in configuration.models['test_model'].components.values():
+    for component in configuration.models["test_model"].components.values():
         component.multiplicity = [5]
 
     planner = Planner(all_resources)
     allocations = planner.allocate_all(configuration)
 
-    assert allocations[Ref('init[0]')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('init[1]')].by_rank == [onr('node002', {1, 2, 3, 4})]
-    assert allocations[Ref('init[2]')].by_rank == [onr('node003', {1, 2, 3, 4})]
-    assert allocations[Ref('init[3]')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('init[4]')].by_rank == [onr('node002', {1, 2, 3, 4})]
+    assert allocations[Ref("init[0]")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("init[1]")].by_rank == [onr("node002", {1, 2, 3, 4})]
+    assert allocations[Ref("init[2]")].by_rank == [onr("node003", {1, 2, 3, 4})]
+    assert allocations[Ref("init[3]")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("init[4]")].by_rank == [onr("node002", {1, 2, 3, 4})]
 
-    assert allocations[Ref('macro[0]')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('macro[1]')].by_rank == [onr('node002', {1, 2, 3, 4})]
-    assert allocations[Ref('macro[2]')].by_rank == [onr('node003', {1, 2, 3, 4})]
-    assert allocations[Ref('macro[3]')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('macro[4]')].by_rank == [onr('node002', {1, 2, 3, 4})]
+    assert allocations[Ref("macro[0]")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("macro[1]")].by_rank == [onr("node002", {1, 2, 3, 4})]
+    assert allocations[Ref("macro[2]")].by_rank == [onr("node003", {1, 2, 3, 4})]
+    assert allocations[Ref("macro[3]")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("macro[4]")].by_rank == [onr("node002", {1, 2, 3, 4})]
 
-    assert allocations[Ref('micro[0]')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('micro[1]')].by_rank == [onr('node002', {1, 2, 3, 4})]
-    assert allocations[Ref('micro[2]')].by_rank == [onr('node003', {1, 2, 3, 4})]
-    assert allocations[Ref('micro[3]')].by_rank == [onr('node001', {1, 2, 3, 4})]
-    assert allocations[Ref('micro[4]')].by_rank == [onr('node002', {1, 2, 3, 4})]
+    assert allocations[Ref("micro[0]")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("micro[1]")].by_rank == [onr("node002", {1, 2, 3, 4})]
+    assert allocations[Ref("micro[2]")].by_rank == [onr("node003", {1, 2, 3, 4})]
+    assert allocations[Ref("micro[3]")].by_rank == [onr("node001", {1, 2, 3, 4})]
+    assert allocations[Ref("micro[4]")].by_rank == [onr("node002", {1, 2, 3, 4})]
 
 
 def test_oversubscribe_single_instance_threaded() -> None:
-    model = Model('single_instance', None, '', None, [Component('x', Ports(), '', 'x')])
-    programs = [Program(Ref('x'), script='x')]
+    model = Model("single_instance", None, "", None, [Component("x", Ports(), "", "x")])
+    programs = [Program(Ref("x"), script="x")]
     reqs: dict[Reference, ResourceRequirements] = {
-            Ref('single_instance.x'): ThreadedResReq(Ref('single_instance.x'), 24)}
-    config = Configuration('config', [], [model], None, None, programs, reqs)
+        Ref("single_instance.x"): ThreadedResReq(Ref("single_instance.x"), 24)
+    }
+    config = Configuration("config", [], [model], None, None, programs, reqs)
 
-    res = resources({'node001': [c(1), c(2), c(3), c(4)]})
+    res = resources({"node001": [c(1), c(2), c(3), c(4)]})
 
     planner = Planner(res)
     allocations = planner.allocate_all(config)
 
-    assert allocations[Ref('x')].by_rank == [onr('node001', {1, 2, 3, 4})]
+    assert allocations[Ref("x")].by_rank == [onr("node001", {1, 2, 3, 4})]
 
 
 def test_oversubscribe_single_instance_mpi() -> None:
-    model = Model('single_instance', None, '', None, [Component('x', Ports(), '', 'x')])
-    programs = [Program(Ref('x'), script='x')]
+    model = Model("single_instance", None, "", None, [Component("x", Ports(), "", "x")])
+    programs = [Program(Ref("x"), script="x")]
     reqs: dict[Reference, ResourceRequirements] = {
-            Ref('single_instance.x'): MPICoresResReq(Ref('single_instance.x'), 24)}
-    config = Configuration('config', [], [model], None, None, programs, reqs)
+        Ref("single_instance.x"): MPICoresResReq(Ref("single_instance.x"), 24)
+    }
+    config = Configuration("config", [], [model], None, None, programs, reqs)
 
-    res = resources({'node001': [c(1), c(2), c(3), c(4)]})
+    res = resources({"node001": [c(1), c(2), c(3), c(4)]})
 
     planner = Planner(res)
     allocations = planner.allocate_all(config)
 
-    assert len(allocations[Ref('x')].by_rank) == 24
+    assert len(allocations[Ref("x")].by_rank) == 24
     for r in range(24):
-        assert allocations[Ref('x')].by_rank[r] == onr('node001', {r % 4 + 1})
+        assert allocations[Ref("x")].by_rank[r] == onr("node001", {r % 4 + 1})
 
 
 def test_virtual_allocation() -> None:
     model = Model(
-            'ensemble', None, '', None, [Component('x', Ports(), '', 'x', False, 9)])
-    programs = [Program(Ref('x'), script='x')]
+        "ensemble", None, "", None, [Component("x", Ports(), "", "x", False, 9)]
+    )
+    programs = [Program(Ref("x"), script="x")]
     reqs: dict[Ref, ResourceRequirements] = {
-            Ref('ensemble.x'): MPICoresResReq(Ref('ensemble.x'), 13)}
-    config = Configuration('config', [], [model], None, None, programs, reqs)
+        Ref("ensemble.x"): MPICoresResReq(Ref("ensemble.x"), 13)
+    }
+    config = Configuration("config", [], [model], None, None, programs, reqs)
 
-    res = resources({'node000001': [c(1), c(2), c(3), c(4)]})
+    res = resources({"node000001": [c(1), c(2), c(3), c(4)]})
 
     planner = Planner(res)
     allocations = planner.allocate_all(config, virtual=True)
@@ -270,19 +297,21 @@ def test_virtual_allocation() -> None:
     assert res.total_cores() == 120
     for i in range(9):
         for r in range(13):
-            assert len(allocations[Ref(f'x[{i}]')].by_rank) == 13
-            assert allocations[Ref(f'x[{i}]')].by_rank[r].total_cores() == 1
+            assert len(allocations[Ref(f"x[{i}]")].by_rank) == 13
+            assert allocations[Ref(f"x[{i}]")].by_rank[r].total_cores() == 1
 
 
 def test_impossible_virtual_allocation() -> None:
     model = Model(
-            'ensemble', None, '', None, [Component('x', Ports(), '', 'x', False, 9)])
-    program = [Program(Ref('x'), script='x')]
+        "ensemble", None, "", None, [Component("x", Ports(), "", "x", False, 9)]
+    )
+    program = [Program(Ref("x"), script="x")]
     reqs: dict[Ref, ResourceRequirements] = {
-            Ref('ensemble.x'): ThreadedResReq(Ref('ensemble.x'), 13)}
-    config = Configuration('config', [], [model], None, None, program, reqs)
+        Ref("ensemble.x"): ThreadedResReq(Ref("ensemble.x"), 13)
+    }
+    config = Configuration("config", [], [model], None, None, program, reqs)
 
-    res = resources({'node000001': [c(1), c(2), c(3), c(4)]})
+    res = resources({"node000001": [c(1), c(2), c(3), c(4)]})
 
     planner = Planner(res)
     with pytest.raises(InsufficientResourcesAvailable):

--- a/libmuscle/python/libmuscle/planner/test/test_planner_scenarios.py
+++ b/libmuscle/python/libmuscle/planner/test/test_planner_scenarios.py
@@ -26,823 +26,1032 @@ _Scenario = tuple[Configuration, Resources]
 
 
 s0_model = Model(
-        'semidetached_macro_micro', None, '', None,
-        [
-            Component('macro', Ports(o_i=['out']), '', 'macro'),
-            Component('micro', Ports(f_init=['in']), '', 'micro')],
-        [
-            Conduit('macro.out', 'micro.in')])
+    "semidetached_macro_micro",
+    None,
+    "",
+    None,
+    [
+        Component("macro", Ports(o_i=["out"]), "", "macro"),
+        Component("micro", Ports(f_init=["in"]), "", "micro"),
+    ],
+    [Conduit("macro.out", "micro.in")],
+)
 
 
 s0_programs = [
-        Program(Reference('macro'), script='macro'),
-        Program(Reference('micro'), script='micro')]
+    Program(Reference("macro"), script="macro"),
+    Program(Reference("micro"), script="micro"),
+]
 
 
 s0_requirements = [
-        ThreadedResReq(Reference('semidetached_macro_micro.macro'), 2),
-        ThreadedResReq(Reference('semidetached_macro_micro.micro'), 2)]
+    ThreadedResReq(Reference("semidetached_macro_micro.macro"), 2),
+    ThreadedResReq(Reference("semidetached_macro_micro.micro"), 2),
+]
 
 
 s0_config = Configuration(
-        's0', [], [s0_model], None, None, s0_programs, s0_requirements)
+    "s0", [], [s0_model], None, None, s0_programs, s0_requirements
+)
 
 
-s0_resources = resources({'node001': [c(0), c(1), c(2), c(3)]})
+s0_resources = resources({"node001": [c(0), c(1), c(2), c(3)]})
 
 
 s0_solution = {
-        Reference('macro'): ResourceAssignment([onr('node001', {0, 1})]),
-        Reference('micro'): ResourceAssignment([onr('node001', {2, 3})])}
+    Reference("macro"): ResourceAssignment([onr("node001", {0, 1})]),
+    Reference("micro"): ResourceAssignment([onr("node001", {2, 3})]),
+}
 
 
 s1_model = Model(
-        'serial_micros', None, '', None,
-        [
-            Component(
-                'macro', Ports(o_i=['bc_out'], s=['bc_in']), '', 'macro'),
-            Component(
-                'micro1', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro1'),
-            Component(
-                'micro2', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro2'),
-            Component(
-                'micro3', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro3')],
-        [
-            Conduit('macro.bc_out', 'micro1.bc_in'),
-            Conduit('micro1.bc_out', 'micro2.bc_in'),
-            Conduit('micro2.bc_out', 'micro3.bc_in'),
-            Conduit('micro3.bc_out', 'macro.bc_in')])
+    "serial_micros",
+    None,
+    "",
+    None,
+    [
+        Component("macro", Ports(o_i=["bc_out"], s=["bc_in"]), "", "macro"),
+        Component("micro1", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro1"),
+        Component("micro2", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro2"),
+        Component("micro3", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro3"),
+    ],
+    [
+        Conduit("macro.bc_out", "micro1.bc_in"),
+        Conduit("micro1.bc_out", "micro2.bc_in"),
+        Conduit("micro2.bc_out", "micro3.bc_in"),
+        Conduit("micro3.bc_out", "macro.bc_in"),
+    ],
+)
 
 
 s1_programs = [
-        Program(Reference('macro'), script='macro'),
-        Program(Reference('micro1'), script='micro1'),
-        Program(Reference('micro2'), script='micro2'),
-        Program(Reference('micro3'), script='micro3'),
-        ]
+    Program(Reference("macro"), script="macro"),
+    Program(Reference("micro1"), script="micro1"),
+    Program(Reference("micro2"), script="micro2"),
+    Program(Reference("micro3"), script="micro3"),
+]
 
 
 s1_requirements = [
-        ThreadedResReq(Reference('serial_micros.macro'), 4),
-        ThreadedResReq(Reference('serial_micros.micro1'), 2),
-        ThreadedResReq(Reference('serial_micros.micro2'), 2),
-        ThreadedResReq(Reference('serial_micros.micro3'), 1)]
+    ThreadedResReq(Reference("serial_micros.macro"), 4),
+    ThreadedResReq(Reference("serial_micros.micro1"), 2),
+    ThreadedResReq(Reference("serial_micros.micro2"), 2),
+    ThreadedResReq(Reference("serial_micros.micro3"), 1),
+]
 
 
 s1_config = Configuration(
-        's1', [], [s1_model], None, None, s1_programs, s1_requirements)
+    "s1", [], [s1_model], None, None, s1_programs, s1_requirements
+)
 
 
-s1_resources = resources({'node001': [c(0), c(1), c(2), c(3)]})
+s1_resources = resources({"node001": [c(0), c(1), c(2), c(3)]})
 
 
 s1_solution = {
-        Reference('macro'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro1'): ResourceAssignment([onr('node001', {0, 1})]),
-        Reference('micro2'): ResourceAssignment([onr('node001', {0, 1})]),
-        Reference('micro3'): ResourceAssignment([onr('node001', 0)])}
+    Reference("macro"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro1"): ResourceAssignment([onr("node001", {0, 1})]),
+    Reference("micro2"): ResourceAssignment([onr("node001", {0, 1})]),
+    Reference("micro3"): ResourceAssignment([onr("node001", 0)]),
+}
 
 
 s2_model = Model(
-        'parallel_micros', None, '', None,
-        [
-            Component('macro', Ports(o_i=['bc_out'], s=['bc_in']), '', 'macro'),
-            Component('micro1', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro1'),
-            Component('micro2', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro2')],
-        [
-            Conduit('macro.bc_out', 'micro1.bc_in'),
-            Conduit('macro.bc_out', 'micro2.bc_in'),
-            Conduit('micro1.bc_out', 'macro.bc_in'),
-            Conduit('micro2.bc_out', 'macro.bc_in')])
+    "parallel_micros",
+    None,
+    "",
+    None,
+    [
+        Component("macro", Ports(o_i=["bc_out"], s=["bc_in"]), "", "macro"),
+        Component("micro1", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro1"),
+        Component("micro2", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro2"),
+    ],
+    [
+        Conduit("macro.bc_out", "micro1.bc_in"),
+        Conduit("macro.bc_out", "micro2.bc_in"),
+        Conduit("micro1.bc_out", "macro.bc_in"),
+        Conduit("micro2.bc_out", "macro.bc_in"),
+    ],
+)
 
 
 s2_programs = [
-        Program(Reference('macro'), script='macro'),
-        Program(Reference('micro1'), script='micro1'),
-        Program(Reference('micro2'), script='micro2'),
-        ]
+    Program(Reference("macro"), script="macro"),
+    Program(Reference("micro1"), script="micro1"),
+    Program(Reference("micro2"), script="micro2"),
+]
 
 
 s2_requirements = [
-        ThreadedResReq(Reference('parallel_micros.macro'), 1),
-        ThreadedResReq(Reference('parallel_micros.micro1'), 3),
-        ThreadedResReq(Reference('parallel_micros.micro2'), 2)]
+    ThreadedResReq(Reference("parallel_micros.macro"), 1),
+    ThreadedResReq(Reference("parallel_micros.micro1"), 3),
+    ThreadedResReq(Reference("parallel_micros.micro2"), 2),
+]
 
 
 s2_config = Configuration(
-        's2', [], [s2_model], None, None, s2_programs, s2_requirements)
+    "s2", [], [s2_model], None, None, s2_programs, s2_requirements
+)
 
 
 s2_resources = resources(
-        {'node001': [c(0), c(1), c(2), c(3)], 'node002': [c(0), c(1), c(2), c(3)]})
+    {"node001": [c(0), c(1), c(2), c(3)], "node002": [c(0), c(1), c(2), c(3)]}
+)
 
 
 s2_solution = {
-        Reference('macro'): ResourceAssignment([onr('node001', 0)]),
-        Reference('micro1'): ResourceAssignment([onr('node001', {0, 1, 2})]),
-        Reference('micro2'): ResourceAssignment([onr('node002', {0, 1})])}
+    Reference("macro"): ResourceAssignment([onr("node001", 0)]),
+    Reference("micro1"): ResourceAssignment([onr("node001", {0, 1, 2})]),
+    Reference("micro2"): ResourceAssignment([onr("node002", {0, 1})]),
+}
 
 
 s3_model = Model(
-        'diamond', None, '', None,
-        [
-            Component('a', Ports(o_f=['out']), '', 'a'),
-            Component('b1', Ports(f_init=['in'], o_f=['out']), '', 'b1'),
-            Component('b2', Ports(f_init=['in'], o_f=['out']), '', 'b2'),
-            Component('c', Ports(f_init=['in'], o_f=['bc_out']), '', 'c')
-            ],
-        [
-            Conduit('a.out', 'b1.in'),
-            Conduit('a.out', 'b2.in'),
-            Conduit('b1.out', 'c.in'),
-            Conduit('b2.out', 'c.in')])
+    "diamond",
+    None,
+    "",
+    None,
+    [
+        Component("a", Ports(o_f=["out"]), "", "a"),
+        Component("b1", Ports(f_init=["in"], o_f=["out"]), "", "b1"),
+        Component("b2", Ports(f_init=["in"], o_f=["out"]), "", "b2"),
+        Component("c", Ports(f_init=["in"], o_f=["bc_out"]), "", "c"),
+    ],
+    [
+        Conduit("a.out", "b1.in"),
+        Conduit("a.out", "b2.in"),
+        Conduit("b1.out", "c.in"),
+        Conduit("b2.out", "c.in"),
+    ],
+)
 
 
 s3_programs = [
-        Program(Reference('a'), script='a'),
-        Program(Reference('b1'), script='b'),
-        Program(Reference('b2'), script='b'),
-        Program(Reference('c'), script='c'),
-        ]
+    Program(Reference("a"), script="a"),
+    Program(Reference("b1"), script="b"),
+    Program(Reference("b2"), script="b"),
+    Program(Reference("c"), script="c"),
+]
 
 
 s3_requirements = [
-        ThreadedResReq(Reference('diamond.a'), 1),
-        MPICoresResReq(Reference('diamond.b1'), 6),
-        ThreadedResReq(Reference('diamond.b2'), 2),
-        ThreadedResReq(Reference('diamond.c'), 4)]
+    ThreadedResReq(Reference("diamond.a"), 1),
+    MPICoresResReq(Reference("diamond.b1"), 6),
+    ThreadedResReq(Reference("diamond.b2"), 2),
+    ThreadedResReq(Reference("diamond.c"), 4),
+]
 
 
 s3_config = Configuration(
-        's3', [], [s3_model], None, None, s3_programs, s3_requirements)
+    "s3", [], [s3_model], None, None, s3_programs, s3_requirements
+)
 
 
 s3_resources = resources(
-        {'node001': [c(0), c(1), c(2), c(3)], 'node002': [c(0), c(1), c(2), c(3)]})
+    {"node001": [c(0), c(1), c(2), c(3)], "node002": [c(0), c(1), c(2), c(3)]}
+)
 
 
 s3_solution = {
-        Reference('a'): ResourceAssignment([onr('node001', 0)]),
-        Reference('b1'): ResourceAssignment([
-            onr('node001', 2), onr('node001', 3), onr('node002', 0), onr('node002', 1),
-            onr('node002', 2), onr('node002', 3)]),
-        Reference('b2'): ResourceAssignment([onr('node001', {0, 1})]),
-        Reference('c'): ResourceAssignment([onr('node001', {0, 1, 2, 3})])}
+    Reference("a"): ResourceAssignment([onr("node001", 0)]),
+    Reference("b1"): ResourceAssignment(
+        [
+            onr("node001", 2),
+            onr("node001", 3),
+            onr("node002", 0),
+            onr("node002", 1),
+            onr("node002", 2),
+            onr("node002", 3),
+        ]
+    ),
+    Reference("b2"): ResourceAssignment([onr("node001", {0, 1})]),
+    Reference("c"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+}
 
 
 s4_model = Model(
-        'lockstep_macros_micro', None, '', None,
-        [
-            Component(
-                'macro1', Ports(o_i=['bc_out'], s=['bc_in']), '', 'macro1'),
-            Component(
-                'macro2', Ports(o_i=['bc_out'], s=['bc_in']), '', 'macro2'),
-            Component(
-                'micro', Ports(f_init=['bc_in1', 'bc_in2'], o_f=['bc_out1', 'bc_out2']),
-                '', 'micro')],
-        [
-            Conduit('macro1.bc_out', 'micro.bc_in1'),
-            Conduit('macro2.bc_out', 'micro.bc_in2'),
-            Conduit('micro.bc_out1', 'macro1.bc_in'),
-            Conduit('micro.bc_out1', 'macro2.bc_in')])
+    "lockstep_macros_micro",
+    None,
+    "",
+    None,
+    [
+        Component("macro1", Ports(o_i=["bc_out"], s=["bc_in"]), "", "macro1"),
+        Component("macro2", Ports(o_i=["bc_out"], s=["bc_in"]), "", "macro2"),
+        Component(
+            "micro",
+            Ports(f_init=["bc_in1", "bc_in2"], o_f=["bc_out1", "bc_out2"]),
+            "",
+            "micro",
+        ),
+    ],
+    [
+        Conduit("macro1.bc_out", "micro.bc_in1"),
+        Conduit("macro2.bc_out", "micro.bc_in2"),
+        Conduit("micro.bc_out1", "macro1.bc_in"),
+        Conduit("micro.bc_out1", "macro2.bc_in"),
+    ],
+)
 
 
 s4_programs = [
-        Program(Reference('macro1'), script='macro1'),
-        Program(Reference('macro2'), script='macro2'),
-        Program(Reference('micro'), script='micro'),
-        ]
+    Program(Reference("macro1"), script="macro1"),
+    Program(Reference("macro2"), script="macro2"),
+    Program(Reference("micro"), script="micro"),
+]
 
 
 s4_requirements = [
-        ThreadedResReq(Reference('lockstep_macros_micro.macro1'), 2),
-        ThreadedResReq(Reference('lockstep_macros_micro.macro2'), 3),
-        ThreadedResReq(Reference('lockstep_macros_micro.micro'), 3)]
+    ThreadedResReq(Reference("lockstep_macros_micro.macro1"), 2),
+    ThreadedResReq(Reference("lockstep_macros_micro.macro2"), 3),
+    ThreadedResReq(Reference("lockstep_macros_micro.micro"), 3),
+]
 
 
 s4_config = Configuration(
-        's4', [], [s4_model], None, None, s4_programs, s4_requirements)
+    "s4", [], [s4_model], None, None, s4_programs, s4_requirements
+)
 
 
 s4_resources = resources(
-        {'node001': [c(0), c(1), c(2), c(3)], 'node002': [c(0), c(1), c(2), c(3)]})
+    {"node001": [c(0), c(1), c(2), c(3)], "node002": [c(0), c(1), c(2), c(3)]}
+)
 
 
 s4_solution = {
-        Reference('macro1'): ResourceAssignment([onr('node002', {0, 1})]),
-        Reference('macro2'): ResourceAssignment([onr('node001', {0, 1, 2})]),
-        Reference('micro'): ResourceAssignment([onr('node001', {0, 1, 2})])}
+    Reference("macro1"): ResourceAssignment([onr("node002", {0, 1})]),
+    Reference("macro2"): ResourceAssignment([onr("node001", {0, 1, 2})]),
+    Reference("micro"): ResourceAssignment([onr("node001", {0, 1, 2})]),
+}
 
 
 s5_model = Model(
-        'repeater_model', None, '', None,
-        [
-            Component('init', Ports(o_f=['out1', 'out2']), '', 'init'),
-            Component(
-                'macro', Ports(f_init=['in'], o_i=['bc_out'], s=['bc_in']), '', 'macro'
-                ),
-            Component('micro', Ports(f_init=['in', 'in2'], o_f=['out']), '', 'micro'),
-            Component(
-                'repeater', Ports(
-                    f_init=['data_in'], o_i=['data_out', 'trigger_out'],
-                    s=['trigger_in']),
-                '', 'repeater')],
-        [
-            Conduit('init.out1', 'macro.in'),
-            Conduit('init.out2', 'repeater.data_in'),
-            Conduit('macro.bc_out', 'repeater.trigger_in'),
-            Conduit('repeater.trigger_out', 'micro.in'),
-            Conduit('repeater.data_out', 'micro.in2'),
-            Conduit('micro.out', 'macro.bc_in')])
+    "repeater_model",
+    None,
+    "",
+    None,
+    [
+        Component("init", Ports(o_f=["out1", "out2"]), "", "init"),
+        Component(
+            "macro", Ports(f_init=["in"], o_i=["bc_out"], s=["bc_in"]), "", "macro"
+        ),
+        Component("micro", Ports(f_init=["in", "in2"], o_f=["out"]), "", "micro"),
+        Component(
+            "repeater",
+            Ports(
+                f_init=["data_in"], o_i=["data_out", "trigger_out"], s=["trigger_in"]
+            ),
+            "",
+            "repeater",
+        ),
+    ],
+    [
+        Conduit("init.out1", "macro.in"),
+        Conduit("init.out2", "repeater.data_in"),
+        Conduit("macro.bc_out", "repeater.trigger_in"),
+        Conduit("repeater.trigger_out", "micro.in"),
+        Conduit("repeater.data_out", "micro.in2"),
+        Conduit("micro.out", "macro.bc_in"),
+    ],
+)
 
 
 s5_programs = [
-        Program(Reference('init'), script='init'),
-        Program(Reference('macro'), script='macro'),
-        Program(Reference('micro'), script='micro'),
-        Program(Reference('repeater'), script='repeater'),
-        ]
+    Program(Reference("init"), script="init"),
+    Program(Reference("macro"), script="macro"),
+    Program(Reference("micro"), script="micro"),
+    Program(Reference("repeater"), script="repeater"),
+]
 
 
 s5_requirements = [
-        ThreadedResReq(Reference('repeater_model.init'), 4),
-        MPICoresResReq(Reference('repeater_model.repeater'), 1),
-        ThreadedResReq(Reference('repeater_model.macro'), 4),
-        ThreadedResReq(Reference('repeater_model.micro'), 4)]
+    ThreadedResReq(Reference("repeater_model.init"), 4),
+    MPICoresResReq(Reference("repeater_model.repeater"), 1),
+    ThreadedResReq(Reference("repeater_model.macro"), 4),
+    ThreadedResReq(Reference("repeater_model.micro"), 4),
+]
 
 
 s5_config = Configuration(
-        's5', [], [s5_model], None, None, s5_programs, s5_requirements)
+    "s5", [], [s5_model], None, None, s5_programs, s5_requirements
+)
 
 
-s5_resources = resources({
-    'node001': [c(0), c(1), c(2), c(3)], 'node002': [c(0), c(1), c(2), c(3)],
-    'node003': [c(0), c(1)]})
+s5_resources = resources(
+    {
+        "node001": [c(0), c(1), c(2), c(3)],
+        "node002": [c(0), c(1), c(2), c(3)],
+        "node003": [c(0), c(1)],
+    }
+)
 
 
 # This is inefficient, as the models can all share resources. But repeater
 # is funny, and the algorithm cannot deal with it yet. It does give a valid
 # result with no overlap, so we'll accept that for the time being.
 s5_solution = {
-        Reference('init'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('repeater'): ResourceAssignment([onr('node003', 0)])}
+    Reference("init"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("repeater"): ResourceAssignment([onr("node003", 0)]),
+}
 
 
 s6_model = Model(
-        'scale_overlap', None, '', None,
-        [
-            Component('a', Ports(o_i=['bc_out'], s=['bc_in']), '', 'a'),
-            Component(
-                'tcf', Ports(o_i=['a_out', 'b_out'], s=['a_in', 'b_in']), '', 'tcf'),
-            Component('b', Ports(o_i=['bc_out'], s=['bc_in']), '', 'b')],
-        [
-            Conduit('a.bc_out', 'tcf.a_in'),
-            Conduit('tcf.a_out', 'a.bc_in'),
-            Conduit('b.bc_out', 'tcf.b_in'),
-            Conduit('tcf.b_out', 'b.bc_in')])
+    "scale_overlap",
+    None,
+    "",
+    None,
+    [
+        Component("a", Ports(o_i=["bc_out"], s=["bc_in"]), "", "a"),
+        Component("tcf", Ports(o_i=["a_out", "b_out"], s=["a_in", "b_in"]), "", "tcf"),
+        Component("b", Ports(o_i=["bc_out"], s=["bc_in"]), "", "b"),
+    ],
+    [
+        Conduit("a.bc_out", "tcf.a_in"),
+        Conduit("tcf.a_out", "a.bc_in"),
+        Conduit("b.bc_out", "tcf.b_in"),
+        Conduit("tcf.b_out", "b.bc_in"),
+    ],
+)
 
 
 s6_programs = [
-        Program(Reference('a'), script='a'),
-        Program(Reference('tcf'), script='tcf'),
-        Program(Reference('b'), script='b'),
-        ]
+    Program(Reference("a"), script="a"),
+    Program(Reference("tcf"), script="tcf"),
+    Program(Reference("b"), script="b"),
+]
 
 
 s6_requirements = [
-        ThreadedResReq(Reference('scale_overlap.a'), 4),
-        MPICoresResReq(Reference('scale_overlap.b'), 16),
-        ThreadedResReq(Reference('scale_overlap.tcf'), 1)]
+    ThreadedResReq(Reference("scale_overlap.a"), 4),
+    MPICoresResReq(Reference("scale_overlap.b"), 16),
+    ThreadedResReq(Reference("scale_overlap.tcf"), 1),
+]
 
 
 s6_config = Configuration(
-        's6', [], [s6_model], None, None, s6_programs, s6_requirements)
+    "s6", [], [s6_model], None, None, s6_programs, s6_requirements
+)
 
 
-s6_resources = resources({
-        'node001': [c(0), c(1), c(2), c(3)], 'node002': [c(0), c(1), c(2), c(3)],
-        'node003': [c(0), c(1), c(2), c(3)], 'node004': [c(0), c(1), c(2), c(3)],
-        'node005': [c(0), c(1), c(2), c(3)], 'node006': [c(0), c(1), c(2), c(3)]
-        })
+s6_resources = resources(
+    {
+        "node001": [c(0), c(1), c(2), c(3)],
+        "node002": [c(0), c(1), c(2), c(3)],
+        "node003": [c(0), c(1), c(2), c(3)],
+        "node004": [c(0), c(1), c(2), c(3)],
+        "node005": [c(0), c(1), c(2), c(3)],
+        "node006": [c(0), c(1), c(2), c(3)],
+    }
+)
 
 
 s6_solution = {
-        Reference('a'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('tcf'): ResourceAssignment([onr('node002', 0)]),
-        Reference('b'): ResourceAssignment([
-            onr('node002', 1), onr('node002', 2), onr('node002', 3), onr('node003', 0),
-            onr('node003', 1), onr('node003', 2), onr('node003', 3), onr('node004', 0),
-            onr('node004', 1), onr('node004', 2), onr('node004', 3), onr('node005', 0),
-            onr('node005', 1), onr('node005', 2), onr('node005', 3), onr('node006', 0)])
-        }
+    Reference("a"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("tcf"): ResourceAssignment([onr("node002", 0)]),
+    Reference("b"): ResourceAssignment(
+        [
+            onr("node002", 1),
+            onr("node002", 2),
+            onr("node002", 3),
+            onr("node003", 0),
+            onr("node003", 1),
+            onr("node003", 2),
+            onr("node003", 3),
+            onr("node004", 0),
+            onr("node004", 1),
+            onr("node004", 2),
+            onr("node004", 3),
+            onr("node005", 0),
+            onr("node005", 1),
+            onr("node005", 2),
+            onr("node005", 3),
+            onr("node006", 0),
+        ]
+    ),
+}
 
 
 s7_model = Model(
-        'monte_carlo_init_macro_micro', None, '', None,
-        [
-            Component('mc', Ports(o_i=['pars_out'], s=['results_in']), '', 'mc'),
-            Component('init', Ports(o_f=['state_out']), '', 'init', False, 10),
-            Component(
-                'macro', Ports(
-                    f_init=['state_in'], o_i=['bc_out'], s=['bc_in'],
-                    o_f=['final_out']),
-                '', 'macro', False, 10),
-            Component(
-                'micro', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro', False,
-                10)],
-        [
-            Conduit('mc.pars_out', 'init.muscle_settings_in'),
-            Conduit('init.state_out', 'macro.state_in'),
-            Conduit('macro.bc_out', 'micro.bc_in'),
-            Conduit('micro.bc_out', 'macro.bc_in'),
-            Conduit('macro.final_out', 'mc.results_in')])
+    "monte_carlo_init_macro_micro",
+    None,
+    "",
+    None,
+    [
+        Component("mc", Ports(o_i=["pars_out"], s=["results_in"]), "", "mc"),
+        Component("init", Ports(o_f=["state_out"]), "", "init", False, 10),
+        Component(
+            "macro",
+            Ports(f_init=["state_in"], o_i=["bc_out"], s=["bc_in"], o_f=["final_out"]),
+            "",
+            "macro",
+            False,
+            10,
+        ),
+        Component(
+            "micro", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro", False, 10
+        ),
+    ],
+    [
+        Conduit("mc.pars_out", "init.muscle_settings_in"),
+        Conduit("init.state_out", "macro.state_in"),
+        Conduit("macro.bc_out", "micro.bc_in"),
+        Conduit("micro.bc_out", "macro.bc_in"),
+        Conduit("macro.final_out", "mc.results_in"),
+    ],
+)
 
 
 s7_programs = [
-        Program(Reference('mc'), script='mc'),
-        Program(Reference('init'), script='init'),
-        Program(Reference('macro'), script='macro'),
-        Program(Reference('micro'), script='micro'),
-        ]
+    Program(Reference("mc"), script="mc"),
+    Program(Reference("init"), script="init"),
+    Program(Reference("macro"), script="macro"),
+    Program(Reference("micro"), script="micro"),
+]
 
 
 s7_requirements = [
-        ThreadedResReq(Reference('monte_carlo_init_macro_micro.mc'), 1),
-        ThreadedResReq(Reference('monte_carlo_init_macro_micro.init'), 4),
-        ThreadedResReq(Reference('monte_carlo_init_macro_micro.macro'), 4),
-        MPICoresResReq(Reference('monte_carlo_init_macro_micro.micro'), 4)]
+    ThreadedResReq(Reference("monte_carlo_init_macro_micro.mc"), 1),
+    ThreadedResReq(Reference("monte_carlo_init_macro_micro.init"), 4),
+    ThreadedResReq(Reference("monte_carlo_init_macro_micro.macro"), 4),
+    MPICoresResReq(Reference("monte_carlo_init_macro_micro.micro"), 4),
+]
 
 
 s7_config = Configuration(
-        's7', [], [s7_model], None, None, s7_programs, s7_requirements)
+    "s7", [], [s7_model], None, None, s7_programs, s7_requirements
+)
 
 
-s7_resources = resources({
-        'node001': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node002': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node003': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node004': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node005': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        })
+s7_resources = resources(
+    {
+        "node001": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node002": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node003": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node004": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node005": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+    }
+)
 
 
 s7_solution = {
-        Reference('mc'): ResourceAssignment([onr('node001', 0)]),
-
-        Reference('init[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('init[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('init[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('init[3]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        Reference('init[4]'): ResourceAssignment([onr('node003', {0, 1, 2, 3})]),
-        Reference('init[5]'): ResourceAssignment([onr('node003', {4, 5, 6, 7})]),
-        Reference('init[6]'): ResourceAssignment([onr('node004', {0, 1, 2, 3})]),
-        Reference('init[7]'): ResourceAssignment([onr('node004', {4, 5, 6, 7})]),
-        Reference('init[8]'): ResourceAssignment([onr('node005', {0, 1, 2, 3})]),
-        Reference('init[9]'): ResourceAssignment([onr('node005', {4, 5, 6, 7})]),
-
-        Reference('macro[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('macro[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('macro[3]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        Reference('macro[4]'): ResourceAssignment([onr('node003', {0, 1, 2, 3})]),
-        Reference('macro[5]'): ResourceAssignment([onr('node003', {4, 5, 6, 7})]),
-        Reference('macro[6]'): ResourceAssignment([onr('node004', {0, 1, 2, 3})]),
-        Reference('macro[7]'): ResourceAssignment([onr('node004', {4, 5, 6, 7})]),
-        Reference('macro[8]'): ResourceAssignment([onr('node005', {0, 1, 2, 3})]),
-        Reference('macro[9]'): ResourceAssignment([onr('node005', {4, 5, 6, 7})]),
-
-        Reference('micro[0]'): ResourceAssignment([
-            onr('node001', 0), onr('node001', 1), onr('node001', 2),
-            onr('node001', 3)]),
-        Reference('micro[1]'): ResourceAssignment([
-            onr('node001', 4), onr('node001', 5), onr('node001', 6),
-            onr('node001', 7)]),
-        Reference('micro[2]'): ResourceAssignment([
-            onr('node002', 0), onr('node002', 1), onr('node002', 2),
-            onr('node002', 3)]),
-        Reference('micro[3]'): ResourceAssignment([
-            onr('node002', 4), onr('node002', 5), onr('node002', 6),
-            onr('node002', 7)]),
-        Reference('micro[4]'): ResourceAssignment([
-            onr('node003', 0), onr('node003', 1), onr('node003', 2),
-            onr('node003', 3)]),
-        Reference('micro[5]'): ResourceAssignment([
-            onr('node003', 4), onr('node003', 5), onr('node003', 6),
-            onr('node003', 7)]),
-        Reference('micro[6]'): ResourceAssignment([
-            onr('node004', 0), onr('node004', 1), onr('node004', 2),
-            onr('node004', 3)]),
-        Reference('micro[7]'): ResourceAssignment([
-            onr('node004', 4), onr('node004', 5), onr('node004', 6),
-            onr('node004', 7)]),
-        Reference('micro[8]'): ResourceAssignment([
-            onr('node005', 0), onr('node005', 1), onr('node005', 2),
-            onr('node005', 3)]),
-        Reference('micro[9]'): ResourceAssignment([
-            onr('node005', 4), onr('node005', 5), onr('node005', 6),
-            onr('node005', 7)])}
+    Reference("mc"): ResourceAssignment([onr("node001", 0)]),
+    Reference("init[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("init[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("init[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("init[3]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+    Reference("init[4]"): ResourceAssignment([onr("node003", {0, 1, 2, 3})]),
+    Reference("init[5]"): ResourceAssignment([onr("node003", {4, 5, 6, 7})]),
+    Reference("init[6]"): ResourceAssignment([onr("node004", {0, 1, 2, 3})]),
+    Reference("init[7]"): ResourceAssignment([onr("node004", {4, 5, 6, 7})]),
+    Reference("init[8]"): ResourceAssignment([onr("node005", {0, 1, 2, 3})]),
+    Reference("init[9]"): ResourceAssignment([onr("node005", {4, 5, 6, 7})]),
+    Reference("macro[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("macro[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("macro[3]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+    Reference("macro[4]"): ResourceAssignment([onr("node003", {0, 1, 2, 3})]),
+    Reference("macro[5]"): ResourceAssignment([onr("node003", {4, 5, 6, 7})]),
+    Reference("macro[6]"): ResourceAssignment([onr("node004", {0, 1, 2, 3})]),
+    Reference("macro[7]"): ResourceAssignment([onr("node004", {4, 5, 6, 7})]),
+    Reference("macro[8]"): ResourceAssignment([onr("node005", {0, 1, 2, 3})]),
+    Reference("macro[9]"): ResourceAssignment([onr("node005", {4, 5, 6, 7})]),
+    Reference("micro[0]"): ResourceAssignment(
+        [onr("node001", 0), onr("node001", 1), onr("node001", 2), onr("node001", 3)]
+    ),
+    Reference("micro[1]"): ResourceAssignment(
+        [onr("node001", 4), onr("node001", 5), onr("node001", 6), onr("node001", 7)]
+    ),
+    Reference("micro[2]"): ResourceAssignment(
+        [onr("node002", 0), onr("node002", 1), onr("node002", 2), onr("node002", 3)]
+    ),
+    Reference("micro[3]"): ResourceAssignment(
+        [onr("node002", 4), onr("node002", 5), onr("node002", 6), onr("node002", 7)]
+    ),
+    Reference("micro[4]"): ResourceAssignment(
+        [onr("node003", 0), onr("node003", 1), onr("node003", 2), onr("node003", 3)]
+    ),
+    Reference("micro[5]"): ResourceAssignment(
+        [onr("node003", 4), onr("node003", 5), onr("node003", 6), onr("node003", 7)]
+    ),
+    Reference("micro[6]"): ResourceAssignment(
+        [onr("node004", 0), onr("node004", 1), onr("node004", 2), onr("node004", 3)]
+    ),
+    Reference("micro[7]"): ResourceAssignment(
+        [onr("node004", 4), onr("node004", 5), onr("node004", 6), onr("node004", 7)]
+    ),
+    Reference("micro[8]"): ResourceAssignment(
+        [onr("node005", 0), onr("node005", 1), onr("node005", 2), onr("node005", 3)]
+    ),
+    Reference("micro[9]"): ResourceAssignment(
+        [onr("node005", 4), onr("node005", 5), onr("node005", 6), onr("node005", 7)]
+    ),
+}
 
 
 s8_model = Model(
-        'serial_micros_exclusive_macro', None, '', None,
-        [
-            Component('macro', Ports(o_i=['bc_out'], s=['bc_in']), '', 'macro'),
-            Component('micro1', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro1'),
-            Component('micro2', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro2')],
-        [
-            Conduit('macro.bc_out', 'micro1.bc_in'),
-            Conduit('micro1.bc_out', 'micro2.bc_in'),
-            Conduit('micro2.bc_out', 'macro.bc_in')])
+    "serial_micros_exclusive_macro",
+    None,
+    "",
+    None,
+    [
+        Component("macro", Ports(o_i=["bc_out"], s=["bc_in"]), "", "macro"),
+        Component("micro1", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro1"),
+        Component("micro2", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro2"),
+    ],
+    [
+        Conduit("macro.bc_out", "micro1.bc_in"),
+        Conduit("micro1.bc_out", "micro2.bc_in"),
+        Conduit("micro2.bc_out", "macro.bc_in"),
+    ],
+)
 
 
 s8_programs = [
-        Program(
-            Reference('macro'), script='macro',
-            can_share_resources=False),
-        Program(Reference('micro1'), script='micro1'),
-        Program(Reference('micro2'), script='micro2'),
-        ]
+    Program(Reference("macro"), script="macro", can_share_resources=False),
+    Program(Reference("micro1"), script="micro1"),
+    Program(Reference("micro2"), script="micro2"),
+]
 
 
 s8_requirements = [
-        ThreadedResReq(Reference('serial_micros_exclusive_macro.macro'), 1),
-        ThreadedResReq(Reference('serial_micros_exclusive_macro.micro1'), 3),
-        ThreadedResReq(Reference('serial_micros_exclusive_macro.micro2'), 2)]
+    ThreadedResReq(Reference("serial_micros_exclusive_macro.macro"), 1),
+    ThreadedResReq(Reference("serial_micros_exclusive_macro.micro1"), 3),
+    ThreadedResReq(Reference("serial_micros_exclusive_macro.micro2"), 2),
+]
 
 
 s8_config = Configuration(
-        's8', [], [s8_model], None, None, s8_programs, s8_requirements)
+    "s8", [], [s8_model], None, None, s8_programs, s8_requirements
+)
 
 
 s8_resources = resources(
-        {'node001': [c(0), c(1), c(2), c(3)], 'node002': [c(0), c(1), c(2), c(3)]})
+    {"node001": [c(0), c(1), c(2), c(3)], "node002": [c(0), c(1), c(2), c(3)]}
+)
 
 
 s8_solution = {
-        Reference('macro'): ResourceAssignment([onr('node001', 3)]),
-        Reference('micro1'): ResourceAssignment([onr('node001', {0, 1, 2})]),
-        Reference('micro2'): ResourceAssignment([onr('node001', {0, 1})])}
+    Reference("macro"): ResourceAssignment([onr("node001", 3)]),
+    Reference("micro1"): ResourceAssignment([onr("node001", {0, 1, 2})]),
+    Reference("micro2"): ResourceAssignment([onr("node001", {0, 1})]),
+}
 
 
 s9_model = Model(
-        'converging_graph', None, '', None,
-        [
-            Component('e', Ports(o_f=['out']), '', 'e'),
-            Component('b', Ports(f_init=['in1', 'in2'], o_f=['out']), '', 'b'),
-            Component('c', Ports(f_init=['in']), '', 'c'),
-            Component('a', Ports(o_f=['out']), '', 'a'),
-            Component('d', Ports(f_init=['in'], o_f=['out']), '', 'd'),
-            ],
-        [
-            Conduit('e.out', 'b.in1'),
-            Conduit('b.out', 'c.in'),
-            Conduit('a.out', 'd.in'),
-            Conduit('d.out', 'b.in2')])
+    "converging_graph",
+    None,
+    "",
+    None,
+    [
+        Component("e", Ports(o_f=["out"]), "", "e"),
+        Component("b", Ports(f_init=["in1", "in2"], o_f=["out"]), "", "b"),
+        Component("c", Ports(f_init=["in"]), "", "c"),
+        Component("a", Ports(o_f=["out"]), "", "a"),
+        Component("d", Ports(f_init=["in"], o_f=["out"]), "", "d"),
+    ],
+    [
+        Conduit("e.out", "b.in1"),
+        Conduit("b.out", "c.in"),
+        Conduit("a.out", "d.in"),
+        Conduit("d.out", "b.in2"),
+    ],
+)
 
 
 s9_programs = [
-        Program(Reference('a'), script='a'),
-        Program(Reference('b'), script='b'),
-        Program(Reference('c'), script='c'),
-        Program(Reference('d'), script='d'),
-        Program(Reference('e'), script='e'),
-        ]
+    Program(Reference("a"), script="a"),
+    Program(Reference("b"), script="b"),
+    Program(Reference("c"), script="c"),
+    Program(Reference("d"), script="d"),
+    Program(Reference("e"), script="e"),
+]
 
 
 s9_requirements = [
-        ThreadedResReq(Reference('converging_graph.a'), 1),
-        ThreadedResReq(Reference('converging_graph.b'), 1),
-        ThreadedResReq(Reference('converging_graph.c'), 1),
-        ThreadedResReq(Reference('converging_graph.d'), 1),
-        ThreadedResReq(Reference('converging_graph.e'), 1)]
+    ThreadedResReq(Reference("converging_graph.a"), 1),
+    ThreadedResReq(Reference("converging_graph.b"), 1),
+    ThreadedResReq(Reference("converging_graph.c"), 1),
+    ThreadedResReq(Reference("converging_graph.d"), 1),
+    ThreadedResReq(Reference("converging_graph.e"), 1),
+]
 
 
 s9_config = Configuration(
-        's9', [], [s9_model], None, None, s9_programs, s9_requirements)
+    "s9", [], [s9_model], None, None, s9_programs, s9_requirements
+)
 
 
-s9_resources = resources({'node001': [c(0), c(1), c(2), c(3)]})
+s9_resources = resources({"node001": [c(0), c(1), c(2), c(3)]})
 
 
 s9_solution = {
-        Reference('a'): ResourceAssignment([onr('node001', 1)]),
-        Reference('b'): ResourceAssignment([onr('node001', 0)]),
-        Reference('c'): ResourceAssignment([onr('node001', 0)]),
-        Reference('d'): ResourceAssignment([onr('node001', 1)]),
-        Reference('e'): ResourceAssignment([onr('node001', 0)])}
+    Reference("a"): ResourceAssignment([onr("node001", 1)]),
+    Reference("b"): ResourceAssignment([onr("node001", 0)]),
+    Reference("c"): ResourceAssignment([onr("node001", 0)]),
+    Reference("d"): ResourceAssignment([onr("node001", 1)]),
+    Reference("e"): ResourceAssignment([onr("node001", 0)]),
+}
 
 
 s10_model = Model(
-        'rdmc_mismatched_resources', None, '', None,
-        [
-            Component('mc', Ports(o_i=['pars_out'], s=['results_in']), '', 'mc'),
-            Component(
-                'rr', Ports(
-                    f_init=['front_in'], o_f=['front_out'],
-                    o_i=['back_out'], s=['back_in']),
-                '', 'rr'),
-            Component(
-                'macro', Ports(
-                    f_init=['state_in'], o_i=['bc_out'], s=['bc_in'],
-                    o_f=['final_out']),
-                '', 'macro', False, 8),
-            Component(
-                'micro', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro', False,
-                8)],
-        [
-            Conduit('mc.pars_out', 'rr.front_in'),
-            Conduit('rr.back_out', 'macro.muscle_settings_in'),
-            Conduit('macro.bc_out', 'micro.bc_in'),
-            Conduit('micro.bc_out', 'macro.bc_in'),
-            Conduit('macro.final_out', 'rr.back_in'),
-            Conduit('rr.front_out', 'mc.results_in')])
+    "rdmc_mismatched_resources",
+    None,
+    "",
+    None,
+    [
+        Component("mc", Ports(o_i=["pars_out"], s=["results_in"]), "", "mc"),
+        Component(
+            "rr",
+            Ports(
+                f_init=["front_in"], o_f=["front_out"], o_i=["back_out"], s=["back_in"]
+            ),
+            "",
+            "rr",
+        ),
+        Component(
+            "macro",
+            Ports(f_init=["state_in"], o_i=["bc_out"], s=["bc_in"], o_f=["final_out"]),
+            "",
+            "macro",
+            False,
+            8,
+        ),
+        Component(
+            "micro", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro", False, 8
+        ),
+    ],
+    [
+        Conduit("mc.pars_out", "rr.front_in"),
+        Conduit("rr.back_out", "macro.muscle_settings_in"),
+        Conduit("macro.bc_out", "micro.bc_in"),
+        Conduit("micro.bc_out", "macro.bc_in"),
+        Conduit("macro.final_out", "rr.back_in"),
+        Conduit("rr.front_out", "mc.results_in"),
+    ],
+)
 
 
 s10_programs = [
-        Program(Reference('mc'), script='mc'),
-        Program(Reference('rr'), script='rr'),
-        Program(Reference('macro'), script='macro'),
-        Program(Reference('micro'), script='micro'),
-        ]
+    Program(Reference("mc"), script="mc"),
+    Program(Reference("rr"), script="rr"),
+    Program(Reference("macro"), script="macro"),
+    Program(Reference("micro"), script="micro"),
+]
 
 
 s10_requirements = [
-        ThreadedResReq(Reference('rdmc_mismatched_resources.mc'), 1),
-        ThreadedResReq(Reference('rdmc_mismatched_resources.rr'), 1),
-        ThreadedResReq(Reference('rdmc_mismatched_resources.macro'), 4),
-        ThreadedResReq(Reference('rdmc_mismatched_resources.micro'), 2)]
+    ThreadedResReq(Reference("rdmc_mismatched_resources.mc"), 1),
+    ThreadedResReq(Reference("rdmc_mismatched_resources.rr"), 1),
+    ThreadedResReq(Reference("rdmc_mismatched_resources.macro"), 4),
+    ThreadedResReq(Reference("rdmc_mismatched_resources.micro"), 2),
+]
 
 
 s10_config = Configuration(
-        's10', [], [s10_model], None, None, s10_programs, s10_requirements)
+    "s10", [], [s10_model], None, None, s10_programs, s10_requirements
+)
 
 
-s10_resources = resources({
-        'node001': [
-            c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7),
-            c(8), c(9), c(10), c(11), c(12), c(13), c(14), c(15)],
-        'node002': [
-            c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7),
-            c(8), c(9), c(10), c(11), c(12), c(13), c(14), c(15)],
-        'node003': [
-            c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7),
-            c(8), c(9), c(10), c(11), c(12), c(13), c(14), c(15)],
-        })
+s10_resources = resources(
+    {
+        "node001": [
+            c(0),
+            c(1),
+            c(2),
+            c(3),
+            c(4),
+            c(5),
+            c(6),
+            c(7),
+            c(8),
+            c(9),
+            c(10),
+            c(11),
+            c(12),
+            c(13),
+            c(14),
+            c(15),
+        ],
+        "node002": [
+            c(0),
+            c(1),
+            c(2),
+            c(3),
+            c(4),
+            c(5),
+            c(6),
+            c(7),
+            c(8),
+            c(9),
+            c(10),
+            c(11),
+            c(12),
+            c(13),
+            c(14),
+            c(15),
+        ],
+        "node003": [
+            c(0),
+            c(1),
+            c(2),
+            c(3),
+            c(4),
+            c(5),
+            c(6),
+            c(7),
+            c(8),
+            c(9),
+            c(10),
+            c(11),
+            c(12),
+            c(13),
+            c(14),
+            c(15),
+        ],
+    }
+)
 
 
 s10_solution = {
-        Reference('mc'): ResourceAssignment([onr('node001', 0)]),
-        Reference('rr'): ResourceAssignment([onr('node001', 0)]),
-
-        Reference('macro[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('macro[2]'): ResourceAssignment([onr('node001', {8, 9, 10, 11})]),
-        Reference('macro[3]'): ResourceAssignment([onr('node001', {12, 13, 14, 15})]),
-        Reference('macro[4]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('macro[5]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        Reference('macro[6]'): ResourceAssignment([onr('node002', {8, 9, 10, 11})]),
-        Reference('macro[7]'): ResourceAssignment([onr('node002', {12, 13, 14, 15})]),
-
-        Reference('micro[0]'): ResourceAssignment([onr('node001', {0, 1})]),
-        Reference('micro[1]'): ResourceAssignment([onr('node001', {4, 5})]),
-        Reference('micro[2]'): ResourceAssignment([onr('node001', {8, 9})]),
-        Reference('micro[3]'): ResourceAssignment([onr('node001', {12, 13})]),
-        Reference('micro[4]'): ResourceAssignment([onr('node002', {0, 1})]),
-        Reference('micro[5]'): ResourceAssignment([onr('node002', {4, 5})]),
-        Reference('micro[6]'): ResourceAssignment([onr('node002', {8, 9})]),
-        Reference('micro[7]'): ResourceAssignment([onr('node002', {12, 13})])}
+    Reference("mc"): ResourceAssignment([onr("node001", 0)]),
+    Reference("rr"): ResourceAssignment([onr("node001", 0)]),
+    Reference("macro[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("macro[2]"): ResourceAssignment([onr("node001", {8, 9, 10, 11})]),
+    Reference("macro[3]"): ResourceAssignment([onr("node001", {12, 13, 14, 15})]),
+    Reference("macro[4]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("macro[5]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+    Reference("macro[6]"): ResourceAssignment([onr("node002", {8, 9, 10, 11})]),
+    Reference("macro[7]"): ResourceAssignment([onr("node002", {12, 13, 14, 15})]),
+    Reference("micro[0]"): ResourceAssignment([onr("node001", {0, 1})]),
+    Reference("micro[1]"): ResourceAssignment([onr("node001", {4, 5})]),
+    Reference("micro[2]"): ResourceAssignment([onr("node001", {8, 9})]),
+    Reference("micro[3]"): ResourceAssignment([onr("node001", {12, 13})]),
+    Reference("micro[4]"): ResourceAssignment([onr("node002", {0, 1})]),
+    Reference("micro[5]"): ResourceAssignment([onr("node002", {4, 5})]),
+    Reference("micro[6]"): ResourceAssignment([onr("node002", {8, 9})]),
+    Reference("micro[7]"): ResourceAssignment([onr("node002", {12, 13})]),
+}
 
 
 s11_model = Model(
-        'ensemble_of_dispatch_of_macro_micro', None, '', None,
-        [
-            Component(
-                'macro1', Ports(o_i=['bc_out'], s=['bc_in'], o_f=['state_out']), '',
-                'macro1', False, 3),
-            Component(
-                'micro1', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro1', False,
-                3),
-            Component(
-                'macro2', Ports(f_init=['state_in'], o_i=['bc_out'], s=['bc_in']), '',
-                'macro2', False, 3),
-            Component(
-                'micro2', Ports(f_init=['bc_in'], o_f=['bc_out']), '', 'micro2', False,
-                3)],
-        [
-            Conduit('macro1.bc_out', 'micro1.bc_in'),
-            Conduit('micro1.bc_out', 'macro1.bc_in'),
-            Conduit('macro1.state_out', 'macro2.state_in'),
-            Conduit('macro2.bc_out', 'micro2.bc_in'),
-            Conduit('micro2.bc_out', 'macro2.bc_in')])
+    "ensemble_of_dispatch_of_macro_micro",
+    None,
+    "",
+    None,
+    [
+        Component(
+            "macro1",
+            Ports(o_i=["bc_out"], s=["bc_in"], o_f=["state_out"]),
+            "",
+            "macro1",
+            False,
+            3,
+        ),
+        Component(
+            "micro1", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro1", False, 3
+        ),
+        Component(
+            "macro2",
+            Ports(f_init=["state_in"], o_i=["bc_out"], s=["bc_in"]),
+            "",
+            "macro2",
+            False,
+            3,
+        ),
+        Component(
+            "micro2", Ports(f_init=["bc_in"], o_f=["bc_out"]), "", "micro2", False, 3
+        ),
+    ],
+    [
+        Conduit("macro1.bc_out", "micro1.bc_in"),
+        Conduit("micro1.bc_out", "macro1.bc_in"),
+        Conduit("macro1.state_out", "macro2.state_in"),
+        Conduit("macro2.bc_out", "micro2.bc_in"),
+        Conduit("micro2.bc_out", "macro2.bc_in"),
+    ],
+)
 
 s11_programs = [
-        Program(Reference('macro1'), script='macro'),
-        Program(Reference('micro1'), script='micro'),
-        Program(Reference('macro2'), script='macro'),
-        Program(Reference('micro2'), script='micro')]
+    Program(Reference("macro1"), script="macro"),
+    Program(Reference("micro1"), script="micro"),
+    Program(Reference("macro2"), script="macro"),
+    Program(Reference("micro2"), script="micro"),
+]
 
 
 s11_requirements = [
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.macro1'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.micro1'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.macro2'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.micro2'), 4),
-        ]
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.macro1"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.micro1"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.macro2"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.micro2"), 4),
+]
 
 
 s11_config = Configuration(
-        's11', [], [s11_model], None, None, s11_programs, s11_requirements)
+    "s11", [], [s11_model], None, None, s11_programs, s11_requirements
+)
 
 
-s11_resources = resources({
-        'node001': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node002': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        })
+s11_resources = resources(
+    {
+        "node001": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node002": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+    }
+)
 
 
 s11_solution = {
-        Reference('macro1[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro1[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('macro1[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('micro1[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro1[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('micro1[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('macro2[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro2[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('macro2[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('micro2[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro2[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('micro2[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})])}
+    Reference("macro1[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro1[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("macro1[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("micro1[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro1[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("micro1[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("macro2[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro2[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("macro2[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("micro2[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro2[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("micro2[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+}
 
 
 s12_model = deepcopy(s11_model)
-s12_model.components[Reference('macro1')].multiplicity = []
-s12_model.components[Reference('micro1')].multiplicity = [2]
-s12_model.components[Reference('macro2')].multiplicity = []
-s12_model.components[Reference('micro2')].multiplicity = [4]
+s12_model.components[Reference("macro1")].multiplicity = []
+s12_model.components[Reference("micro1")].multiplicity = [2]
+s12_model.components[Reference("macro2")].multiplicity = []
+s12_model.components[Reference("micro2")].multiplicity = [4]
 
 
 s12_requirements = [
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.macro1'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.micro1'), 8),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.macro2'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.micro2'), 4),
-        ]
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.macro1"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.micro1"), 8),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.macro2"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.micro2"), 4),
+]
 
 
 s12_config = Configuration(
-        's12', [], [s12_model], None, None, s11_programs, s12_requirements)
+    "s12", [], [s12_model], None, None, s11_programs, s12_requirements
+)
 
 
 s12_solution = {
-        Reference('macro1'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro1[0]'): ResourceAssignment([
-            onr('node001', {0, 1, 2, 3, 4, 5, 6, 7})]),
-        Reference('micro1[1]'): ResourceAssignment([
-            onr('node002', {0, 1, 2, 3, 4, 5, 6, 7})]),
-        Reference('macro2'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro2[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro2[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('micro2[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('micro2[3]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        }
+    Reference("macro1"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro1[0]"): ResourceAssignment(
+        [onr("node001", {0, 1, 2, 3, 4, 5, 6, 7})]
+    ),
+    Reference("micro1[1]"): ResourceAssignment(
+        [onr("node002", {0, 1, 2, 3, 4, 5, 6, 7})]
+    ),
+    Reference("macro2"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro2[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro2[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("micro2[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("micro2[3]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+}
 
 
 s13_model = deepcopy(s11_model)
-s13_model.components[Reference('macro1')].multiplicity = [5]
-s13_model.components[Reference('micro1')].multiplicity = [5, 4]
-s13_model.components[Reference('macro2')].multiplicity = [5]
-s13_model.components[Reference('micro2')].multiplicity = [5, 2]
+s13_model.components[Reference("macro1")].multiplicity = [5]
+s13_model.components[Reference("micro1")].multiplicity = [5, 4]
+s13_model.components[Reference("macro2")].multiplicity = [5]
+s13_model.components[Reference("micro2")].multiplicity = [5, 2]
 
 
 s13_requirements = [
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.macro1'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.micro1'), 2),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.macro2'), 4),
-        ThreadedResReq(Reference('ensemble_of_dispatch_of_macro_micro.micro2'), 4),
-        ]
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.macro1"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.micro1"), 2),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.macro2"), 4),
+    ThreadedResReq(Reference("ensemble_of_dispatch_of_macro_micro.micro2"), 4),
+]
 
 
 s13_config = Configuration(
-        's13', [], [s13_model], None, None, s11_programs, s13_requirements)
+    "s13", [], [s13_model], None, None, s11_programs, s13_requirements
+)
 
 
-s13_resources = resources({
-        'node001': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node002': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node003': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node004': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        'node005': [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
-        })
+s13_resources = resources(
+    {
+        "node001": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node002": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node003": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node004": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+        "node005": [c(0), c(1), c(2), c(3), c(4), c(5), c(6), c(7)],
+    }
+)
 
 
 s13_solution = {
-        Reference('macro1[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro1[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('macro1[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('macro1[3]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        Reference('macro1[4]'): ResourceAssignment([onr('node003', {0, 1, 2, 3})]),
-
-        Reference('micro1[0][0]'): ResourceAssignment([onr('node001', {0, 1})]),
-        Reference('micro1[0][1]'): ResourceAssignment([onr('node001', {2, 3})]),
-        Reference('micro1[0][2]'): ResourceAssignment([onr('node003', {4, 5})]),
-        Reference('micro1[0][3]'): ResourceAssignment([onr('node003', {6, 7})]),
-        Reference('micro1[1][0]'): ResourceAssignment([onr('node001', {4, 5})]),
-        Reference('micro1[1][1]'): ResourceAssignment([onr('node001', {6, 7})]),
-        Reference('micro1[1][2]'): ResourceAssignment([onr('node004', {0, 1})]),
-        Reference('micro1[1][3]'): ResourceAssignment([onr('node004', {2, 3})]),
-        Reference('micro1[2][0]'): ResourceAssignment([onr('node002', {0, 1})]),
-        Reference('micro1[2][1]'): ResourceAssignment([onr('node002', {2, 3})]),
-        Reference('micro1[2][2]'): ResourceAssignment([onr('node004', {4, 5})]),
-        Reference('micro1[2][3]'): ResourceAssignment([onr('node004', {6, 7})]),
-        Reference('micro1[3][0]'): ResourceAssignment([onr('node002', {4, 5})]),
-        Reference('micro1[3][1]'): ResourceAssignment([onr('node002', {6, 7})]),
-        Reference('micro1[3][2]'): ResourceAssignment([onr('node005', {0, 1})]),
-        Reference('micro1[3][3]'): ResourceAssignment([onr('node005', {2, 3})]),
-        Reference('micro1[4][0]'): ResourceAssignment([onr('node003', {0, 1})]),
-        Reference('micro1[4][1]'): ResourceAssignment([onr('node003', {2, 3})]),
-        Reference('micro1[4][2]'): ResourceAssignment([onr('node005', {4, 5})]),
-        Reference('micro1[4][3]'): ResourceAssignment([onr('node005', {6, 7})]),
-
-        Reference('macro2[0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('macro2[1]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('macro2[2]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('macro2[3]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        Reference('macro2[4]'): ResourceAssignment([onr('node003', {0, 1, 2, 3})]),
-
-        Reference('micro2[0][0]'): ResourceAssignment([onr('node001', {0, 1, 2, 3})]),
-        Reference('micro2[0][1]'): ResourceAssignment([onr('node003', {4, 5, 6, 7})]),
-        Reference('micro2[1][0]'): ResourceAssignment([onr('node001', {4, 5, 6, 7})]),
-        Reference('micro2[1][1]'): ResourceAssignment([onr('node004', {0, 1, 2, 3})]),
-        Reference('micro2[2][0]'): ResourceAssignment([onr('node002', {0, 1, 2, 3})]),
-        Reference('micro2[2][1]'): ResourceAssignment([onr('node004', {4, 5, 6, 7})]),
-        Reference('micro2[3][0]'): ResourceAssignment([onr('node002', {4, 5, 6, 7})]),
-        Reference('micro2[3][1]'): ResourceAssignment([onr('node005', {0, 1, 2, 3})]),
-        Reference('micro2[4][0]'): ResourceAssignment([onr('node003', {0, 1, 2, 3})]),
-        Reference('micro2[4][1]'): ResourceAssignment([onr('node005', {4, 5, 6, 7})]),
-        }
+    Reference("macro1[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro1[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("macro1[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("macro1[3]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+    Reference("macro1[4]"): ResourceAssignment([onr("node003", {0, 1, 2, 3})]),
+    Reference("micro1[0][0]"): ResourceAssignment([onr("node001", {0, 1})]),
+    Reference("micro1[0][1]"): ResourceAssignment([onr("node001", {2, 3})]),
+    Reference("micro1[0][2]"): ResourceAssignment([onr("node003", {4, 5})]),
+    Reference("micro1[0][3]"): ResourceAssignment([onr("node003", {6, 7})]),
+    Reference("micro1[1][0]"): ResourceAssignment([onr("node001", {4, 5})]),
+    Reference("micro1[1][1]"): ResourceAssignment([onr("node001", {6, 7})]),
+    Reference("micro1[1][2]"): ResourceAssignment([onr("node004", {0, 1})]),
+    Reference("micro1[1][3]"): ResourceAssignment([onr("node004", {2, 3})]),
+    Reference("micro1[2][0]"): ResourceAssignment([onr("node002", {0, 1})]),
+    Reference("micro1[2][1]"): ResourceAssignment([onr("node002", {2, 3})]),
+    Reference("micro1[2][2]"): ResourceAssignment([onr("node004", {4, 5})]),
+    Reference("micro1[2][3]"): ResourceAssignment([onr("node004", {6, 7})]),
+    Reference("micro1[3][0]"): ResourceAssignment([onr("node002", {4, 5})]),
+    Reference("micro1[3][1]"): ResourceAssignment([onr("node002", {6, 7})]),
+    Reference("micro1[3][2]"): ResourceAssignment([onr("node005", {0, 1})]),
+    Reference("micro1[3][3]"): ResourceAssignment([onr("node005", {2, 3})]),
+    Reference("micro1[4][0]"): ResourceAssignment([onr("node003", {0, 1})]),
+    Reference("micro1[4][1]"): ResourceAssignment([onr("node003", {2, 3})]),
+    Reference("micro1[4][2]"): ResourceAssignment([onr("node005", {4, 5})]),
+    Reference("micro1[4][3]"): ResourceAssignment([onr("node005", {6, 7})]),
+    Reference("macro2[0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("macro2[1]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("macro2[2]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("macro2[3]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+    Reference("macro2[4]"): ResourceAssignment([onr("node003", {0, 1, 2, 3})]),
+    Reference("micro2[0][0]"): ResourceAssignment([onr("node001", {0, 1, 2, 3})]),
+    Reference("micro2[0][1]"): ResourceAssignment([onr("node003", {4, 5, 6, 7})]),
+    Reference("micro2[1][0]"): ResourceAssignment([onr("node001", {4, 5, 6, 7})]),
+    Reference("micro2[1][1]"): ResourceAssignment([onr("node004", {0, 1, 2, 3})]),
+    Reference("micro2[2][0]"): ResourceAssignment([onr("node002", {0, 1, 2, 3})]),
+    Reference("micro2[2][1]"): ResourceAssignment([onr("node004", {4, 5, 6, 7})]),
+    Reference("micro2[3][0]"): ResourceAssignment([onr("node002", {4, 5, 6, 7})]),
+    Reference("micro2[3][1]"): ResourceAssignment([onr("node005", {0, 1, 2, 3})]),
+    Reference("micro2[4][0]"): ResourceAssignment([onr("node003", {0, 1, 2, 3})]),
+    Reference("micro2[4][1]"): ResourceAssignment([onr("node005", {4, 5, 6, 7})]),
+}
 
 
 s14_model = Model(
-        'triangle', None, '', None,
-        [
-            Component('a', Ports(f_init=['in'], o_f=['out']), '', 'a'),
-            Component('b', Ports(f_init=['in'], o_f=['out']), '', 'b'),
-            Component('c', Ports(f_init=['in'], o_f=['out']), '', 'c'),
-            ],
-        [
-            Conduit('a.out', 'b.in'),
-            Conduit('b.out', 'c.in'),
-            Conduit('c.out', 'a.in'),
-            ])
+    "triangle",
+    None,
+    "",
+    None,
+    [
+        Component("a", Ports(f_init=["in"], o_f=["out"]), "", "a"),
+        Component("b", Ports(f_init=["in"], o_f=["out"]), "", "b"),
+        Component("c", Ports(f_init=["in"], o_f=["out"]), "", "c"),
+    ],
+    [
+        Conduit("a.out", "b.in"),
+        Conduit("b.out", "c.in"),
+        Conduit("c.out", "a.in"),
+    ],
+)
 
 
 s14_programs = [
-        Program(Reference('a'), script='a'),
-        Program(Reference('b'), script='b'),
-        Program(Reference('c'), script='c'),
-        ]
+    Program(Reference("a"), script="a"),
+    Program(Reference("b"), script="b"),
+    Program(Reference("c"), script="c"),
+]
 
 
 s14_requirements = [
-        ThreadedResReq(Reference('triangle.a'), 2),
-        ThreadedResReq(Reference('triangle.b'), 2),
-        ThreadedResReq(Reference('triangle.c'), 2),
-        ]
+    ThreadedResReq(Reference("triangle.a"), 2),
+    ThreadedResReq(Reference("triangle.b"), 2),
+    ThreadedResReq(Reference("triangle.c"), 2),
+]
 
 
 s14_config = Configuration(
-        's14', [], [s14_model], None, None, s14_programs, s14_requirements)
+    "s14", [], [s14_model], None, None, s14_programs, s14_requirements
+)
 
 
-s14_resources = resources({'node001': [c(0), c(1), c(2), c(3), c(4), c(5)]})
+s14_resources = resources({"node001": [c(0), c(1), c(2), c(3), c(4), c(5)]})
 
 
 s14_solution = RuntimeError
 
 
 scenarios = [
-        (s0_config, s0_resources, s0_solution),
-        (s1_config, s1_resources, s1_solution),
-        (s2_config, s2_resources, s2_solution),
-        (s3_config, s3_resources, s3_solution),
-        (s4_config, s4_resources, s4_solution),
-        (s5_config, s5_resources, s5_solution),
-        (s6_config, s6_resources, s6_solution),
-        (s7_config, s7_resources, s7_solution),
-        (s8_config, s8_resources, s8_solution),
-        (s9_config, s9_resources, s9_solution),
-        (s10_config, s10_resources, s10_solution),
-        (s11_config, s11_resources, s11_solution),
-        (s12_config, s11_resources, s12_solution),
-        (s13_config, s13_resources, s13_solution),
-        (s14_config, s14_resources, s14_solution),
-        ]
+    (s0_config, s0_resources, s0_solution),
+    (s1_config, s1_resources, s1_solution),
+    (s2_config, s2_resources, s2_solution),
+    (s3_config, s3_resources, s3_solution),
+    (s4_config, s4_resources, s4_solution),
+    (s5_config, s5_resources, s5_solution),
+    (s6_config, s6_resources, s6_solution),
+    (s7_config, s7_resources, s7_solution),
+    (s8_config, s8_resources, s8_solution),
+    (s9_config, s9_resources, s9_solution),
+    (s10_config, s10_resources, s10_solution),
+    (s11_config, s11_resources, s11_solution),
+    (s12_config, s11_resources, s12_solution),
+    (s13_config, s13_resources, s13_solution),
+    (s14_config, s14_resources, s14_solution),
+]
 
 
-@pytest.mark.parametrize('scenario', scenarios)
+@pytest.mark.parametrize("scenario", scenarios)
 def test_scenarios(scenario: _Scenario) -> None:
     config, res, solution = scenario
     planner = Planner(res)
@@ -858,9 +1067,7 @@ def test_scenarios(scenario: _Scenario) -> None:
     model_graph = ModelGraph(config.root_model())
     for cname, req in config.resources.items():
         # check that we have enough cores
-        component = [
-            c for c in model_graph.components()
-            if c.name == cname[1:]][0]
+        component = [c for c in model_graph.components() if c.name == cname[1:]][0]
 
         if isinstance(req, ThreadedResReq):
             for instance in component.instances():
@@ -882,25 +1089,24 @@ def test_scenarios(scenario: _Scenario) -> None:
             cname2 = instance2.without_trailing_ints()
             if cname1 != cname2:
                 if not res1.isdisjoint(res2):
-                    comp1 = [
-                        c for c in model_graph.components()
-                        if c.name == cname1][0]
+                    comp1 = [c for c in model_graph.components() if c.name == cname1][0]
                     program1 = config.programs[comp1.name]
-                    comp2 = [
-                        c for c in model_graph.components()
-                        if c.name == cname2][0]
+                    comp2 = [c for c in model_graph.components() if c.name == cname2][0]
                     program2 = config.programs[comp2.name]
                     assert (
-                            comp2 in {c for c, _ in model_graph.successors(comp1)} or
-                            comp2 in {c for c, _ in model_graph.predecessors(comp1)} or
-                            (
-                                comp2 in {c for c, _ in model_graph.macros(comp1)} and
-                                program2.can_share_resources and
-                                program1.can_share_resources) or
-                            (
-                                comp2 in {c for c, _ in model_graph.micros(comp1)} and
-                                program2.can_share_resources and
-                                program1.can_share_resources))
+                        comp2 in {c for c, _ in model_graph.successors(comp1)}
+                        or comp2 in {c for c, _ in model_graph.predecessors(comp1)}
+                        or (
+                            comp2 in {c for c, _ in model_graph.macros(comp1)}
+                            and program2.can_share_resources
+                            and program1.can_share_resources
+                        )
+                        or (
+                            comp2 in {c for c, _ in model_graph.micros(comp1)}
+                            and program2.can_share_resources
+                            and program1.can_share_resources
+                        )
+                    )
 
             elif instance1 != instance2:
                 assert res1.isdisjoint(res2)

--- a/libmuscle/python/libmuscle/planner/test/test_resources.py
+++ b/libmuscle/python/libmuscle/planner/test/test_resources.py
@@ -93,11 +93,11 @@ def test_core_isdisjoint(c1):
 
 
 def test_core_str(c1):
-    assert str(c1) == '0(0,1)'
+    assert str(c1) == "0(0,1)"
 
 
 def test_core_repr(c1):
-    assert repr(c1) == 'Core(0, {0,1})'
+    assert repr(c1) == "Core(0, {0,1})"
 
 
 @pytest.fixture
@@ -209,32 +209,30 @@ def test_core_set_subtract_threads(cs1):
 
 
 def test_core_set_str(cs1):
-    assert str(cs1) == '0-1(0-3)'
+    assert str(cs1) == "0-1(0-3)"
 
 
 def test_core_set_repr(cs1):
-    assert repr(cs1) == 'CoreSet({Core(0, {0,1}), Core(1, {2,3})})'
+    assert repr(cs1) == "CoreSet({Core(0, {0,1}), Core(1, {2,3})})"
 
 
 def test_core_set_get_first_cores(cs1):
     assert cs1.get_first_cores(0)._cores == {}
     assert cs1.get_first_cores(1)._cores == {0: Core(0, {0, 1})}
-    assert cs1.get_first_cores(2)._cores == {
-            0: Core(0, {0, 1}),
-            1: Core(1, {2, 3})}
+    assert cs1.get_first_cores(2)._cores == {0: Core(0, {0, 1}), 1: Core(1, {2, 3})}
     with pytest.raises(RuntimeError):
         cs1.get_first_cores(3)
 
 
 @pytest.fixture
 def n1(cs1):
-    return OnNodeResources('node001', cs1)
+    return OnNodeResources("node001", cs1)
 
 
 def test_node_resources_equals(n1):
-    n2 = OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))
-    n3 = OnNodeResources('node002', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))
-    n4 = OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(1, {4, 3})]))
+    n2 = OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))
+    n3 = OnNodeResources("node002", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))
+    n4 = OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(1, {4, 3})]))
 
     assert n1 == n2
     assert n1 != n3
@@ -251,9 +249,9 @@ def test_node_resources_copy(n1):
 
 
 def test_node_resources_union_onto(n1):
-    n2 = OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(4, {8, 9, 10, 11})]))
-    n3 = OnNodeResources('node001', CoreSet([Core(0, {3})]))
-    n4 = OnNodeResources('node002', CoreSet([Core(3, {3})]))
+    n2 = OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(4, {8, 9, 10, 11})]))
+    n3 = OnNodeResources("node001", CoreSet([Core(0, {3})]))
+    n4 = OnNodeResources("node002", CoreSet([Core(3, {3})]))
 
     n1 |= n2
 
@@ -274,9 +272,9 @@ def test_node_resources_hwthreads(n1):
 
 
 def test_node_resources_subtract(n1):
-    n2 = OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(4, {8, 9, 10, 11})]))
-    n3 = OnNodeResources('node001', CoreSet([Core(1, {3})]))
-    n4 = OnNodeResources('node002', CoreSet([Core(3, {3})]))
+    n2 = OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(4, {8, 9, 10, 11})]))
+    n3 = OnNodeResources("node001", CoreSet([Core(1, {3})]))
+    n4 = OnNodeResources("node002", CoreSet([Core(3, {3})]))
 
     n1 -= n2
 
@@ -298,15 +296,15 @@ def r1(n1):
 
 
 def test_resources_length(r1, n1):
-    r2 = Resources([n1, OnNodeResources('node002', CoreSet([Core(0, {0, 1})]))])
+    r2 = Resources([n1, OnNodeResources("node002", CoreSet([Core(0, {0, 1})]))])
 
     assert len(r1) == 1
     assert len(r2) == 2
 
 
 def test_resources_iter(cs1, n1):
-    n2 = OnNodeResources('node004', cs1)
-    n3 = OnNodeResources('node002', CoreSet([Core(3, {3})]))
+    n2 = OnNodeResources("node004", cs1)
+    n3 = OnNodeResources("node002", CoreSet([Core(3, {3})]))
     nodes = [n1, n2, n3]
     res = Resources(nodes)
 
@@ -316,31 +314,35 @@ def test_resources_iter(cs1, n1):
 
 def test_resources_equals(r1):
     assert r1 == Resources(
-            [OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))])
+        [OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))]
+    )
 
     r2 = Resources(
-            [OnNodeResources('node002', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))])
+        [OnNodeResources("node002", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))]
+    )
     assert r1 != r2
 
     r3 = Resources(
-            [OnNodeResources(
-                'node001', CoreSet([Core(0, {0, 1}), Core(1, {1, 2, 3})]))])
+        [OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(1, {1, 2, 3})]))]
+    )
     assert r1 != r3
 
-    r4 = Resources([OnNodeResources('node001', CoreSet([Core(1, {1, 2})]))])
+    r4 = Resources([OnNodeResources("node001", CoreSet([Core(1, {1, 2})]))])
     assert r1 != r4
 
-    r5 = Resources([
-            OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})])),
-            OnNodeResources('node002', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})]))
-            ])
+    r5 = Resources(
+        [
+            OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})])),
+            OnNodeResources("node002", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})])),
+        ]
+    )
     assert r1 != r5
 
 
 def test_resources_copy(r1):
     r2 = copy(r1)
-    assert id(r2._nodes['node001']) != id(r1._nodes['node001'])
-    assert id(r2._nodes['node001'].cpu_cores) != id(r1._nodes['node001'].cpu_cores)
+    assert id(r2._nodes["node001"]) != id(r1._nodes["node001"])
+    assert id(r2._nodes["node001"].cpu_cores) != id(r1._nodes["node001"].cpu_cores)
 
 
 def test_resources_union_onto(r1):
@@ -348,11 +350,11 @@ def test_resources_union_onto(r1):
     r2 |= r1
     assert r2 == r1
 
-    r3 = Resources([OnNodeResources('node002', CoreSet([Core(0, {0})]))])
+    r3 = Resources([OnNodeResources("node002", CoreSet([Core(0, {0})]))])
     r3 |= r1
     assert len(r3._nodes) == 2
-    assert id(r3._nodes['node001']) != id(r1._nodes['node001'])
-    assert sorted(r3._nodes.keys()) == ['node001', 'node002']
+    assert id(r3._nodes["node001"]) != id(r1._nodes["node001"])
+    assert sorted(r3._nodes.keys()) == ["node001", "node002"]
 
 
 def test_resources_subtract(r1):
@@ -363,72 +365,90 @@ def test_resources_subtract(r1):
     r1 -= r2
     assert len(r1._nodes) == 1
 
-    r3 = Resources([OnNodeResources('node001', CoreSet([Core(0, {0})]))])
+    r3 = Resources([OnNodeResources("node001", CoreSet([Core(0, {0})]))])
     r1 -= r3
     assert len(r1._nodes) == 1
-    assert r1._nodes['node001'].cpu_cores._cores[0].hwthreads == {1}
+    assert r1._nodes["node001"].cpu_cores._cores[0].hwthreads == {1}
 
 
 def test_resources_nodes():
-    r1 = Resources([
-        OnNodeResources('node001', CoreSet([Core(0, {0})])),
-        OnNodeResources('node003', CoreSet([Core(1, {1})])),
-        OnNodeResources('node004', CoreSet([Core(2, {2})]))])
+    r1 = Resources(
+        [
+            OnNodeResources("node001", CoreSet([Core(0, {0})])),
+            OnNodeResources("node003", CoreSet([Core(1, {1})])),
+            OnNodeResources("node004", CoreSet([Core(2, {2})])),
+        ]
+    )
 
-    assert sorted(r1.nodes()) == ['node001', 'node003', 'node004']
+    assert sorted(r1.nodes()) == ["node001", "node003", "node004"]
 
 
 def test_resources_total_cores():
-    r1 = Resources([
-        OnNodeResources('node001', CoreSet([Core(0, {0, 1})])),
-        OnNodeResources('node003', CoreSet([Core(1, {1}), Core(5, {5})])),
-        OnNodeResources('node004', CoreSet([Core(2, {2})]))])
+    r1 = Resources(
+        [
+            OnNodeResources("node001", CoreSet([Core(0, {0, 1})])),
+            OnNodeResources("node003", CoreSet([Core(1, {1}), Core(5, {5})])),
+            OnNodeResources("node004", CoreSet([Core(2, {2})])),
+        ]
+    )
 
     assert r1.total_cores() == 4
 
 
 def test_resource_hwthreads(n1, r1):
     hwthreads = list(r1.hwthreads())
-    assert hwthreads == [('node001', 0), ('node001', 1), ('node001', 2), ('node001', 3)]
+    assert hwthreads == [("node001", 0), ("node001", 1), ("node001", 2), ("node001", 3)]
 
-    n2 = OnNodeResources('node007', CoreSet([Core(7, {7}), Core(3, {3})]))
+    n2 = OnNodeResources("node007", CoreSet([Core(7, {7}), Core(3, {3})]))
     res = Resources([n1, n2])
 
     hwthreads = list(res.hwthreads())
     assert hwthreads == [
-            ('node001', 0), ('node001', 1), ('node001', 2), ('node001', 3),
-            ('node007', 7), ('node007', 3)]
+        ("node001", 0),
+        ("node001", 1),
+        ("node001", 2),
+        ("node001", 3),
+        ("node007", 7),
+        ("node007", 3),
+    ]
 
 
 def test_resources_isdisjoint(r1):
     r2 = Resources([])
     assert r1.isdisjoint(r2)
 
-    r3 = Resources([OnNodeResources('node001', CoreSet([Core(0, {0})]))])
+    r3 = Resources([OnNodeResources("node001", CoreSet([Core(0, {0})]))])
     assert not r1.isdisjoint(r3)
 
-    r4 = Resources([OnNodeResources('node001', CoreSet([Core(0, {2})]))])
+    r4 = Resources([OnNodeResources("node001", CoreSet([Core(0, {2})]))])
     assert r1.isdisjoint(r4)
 
-    r5 = Resources([OnNodeResources('node002', CoreSet([Core(0, {0})]))])
+    r5 = Resources([OnNodeResources("node002", CoreSet([Core(0, {0})]))])
     assert r1.isdisjoint(r5)
 
 
 def test_resources_union(r1):
     r2 = Resources([])
-    r3 = Resources([OnNodeResources('node001', CoreSet([Core(0, {0})]))])
-    r4 = Resources([OnNodeResources('node001', CoreSet([Core(0, {2})]))])
-    r5 = Resources([OnNodeResources('node002', CoreSet([Core(0, {0})]))])
+    r3 = Resources([OnNodeResources("node001", CoreSet([Core(0, {0})]))])
+    r4 = Resources([OnNodeResources("node001", CoreSet([Core(0, {2})]))])
+    r5 = Resources([OnNodeResources("node002", CoreSet([Core(0, {0})]))])
 
     assert Resources.union([r1, r2]) == r1
     assert Resources.union([r1, r3]) == r1
-    assert Resources.union([r1, r4]) == Resources([
-        OnNodeResources('node001', CoreSet([Core(0, {0, 1, 2}), Core(1, {2, 3})]))])
+    assert Resources.union([r1, r4]) == Resources(
+        [OnNodeResources("node001", CoreSet([Core(0, {0, 1, 2}), Core(1, {2, 3})]))]
+    )
 
-    assert Resources.union([r1, r5]) == Resources([
-        OnNodeResources('node001', CoreSet([Core(0, {0, 1}), Core(1, {2, 3})])),
-        OnNodeResources('node002', CoreSet([Core(0, {0})]))])
+    assert Resources.union([r1, r5]) == Resources(
+        [
+            OnNodeResources("node001", CoreSet([Core(0, {0, 1}), Core(1, {2, 3})])),
+            OnNodeResources("node002", CoreSet([Core(0, {0})])),
+        ]
+    )
 
-    assert Resources.union([r1, r2, r3, r4, r5]) == Resources([
-        OnNodeResources('node001', CoreSet([Core(0, {0, 1, 2}), Core(1, {2, 3})])),
-        OnNodeResources('node002', CoreSet([Core(0, {0})]))])
+    assert Resources.union([r1, r2, r3, r4, r5]) == Resources(
+        [
+            OnNodeResources("node001", CoreSet([Core(0, {0, 1, 2}), Core(1, {2, 3})])),
+            OnNodeResources("node002", CoreSet([Core(0, {0})])),
+        ]
+    )

--- a/libmuscle/python/libmuscle/port.py
+++ b/libmuscle/python/libmuscle/port.py
@@ -7,8 +7,7 @@ _T = TypeVar("_T")
 
 
 def _extend_list_to_size(lst: list[_T], size: int, padding: _T) -> None:
-    """When lst is smaller than size, extend to size using padding as values
-    """
+    """When lst is smaller than size, extend to size using padding as values"""
     num_extend = size - len(lst)
     if num_extend > 0:
         lst += [padding] * num_extend
@@ -30,9 +29,15 @@ class Port(ymmsl.v0_2.Port):
         operator (Operator): Operator associated with this port.
     """
 
-    def __init__(self, name: str, operator: Operator, is_vector: bool,
-                 is_connected: bool, our_ndims: int, peer_dims: list[int]
-                 ) -> None:
+    def __init__(
+        self,
+        name: str,
+        operator: Operator,
+        is_vector: bool,
+        is_connected: bool,
+        our_ndims: int,
+        peer_dims: list[int],
+    ) -> None:
         """Create a Port.
 
         Args:
@@ -54,26 +59,30 @@ class Port(ymmsl.v0_2.Port):
                 self._length = peer_dims[-1]
             elif our_ndims > len(peer_dims):
                 raise RuntimeError(
-                        f'Vector port "{name}" is connected to an instance set with'
-                        ' fewer dimensions. It should be connected to a scalar port on'
-                        ' a set with one more dimension, or to a vector port on a set'
-                        ' with the same number of dimensions.')
+                    f'Vector port "{name}" is connected to an instance set with'
+                    " fewer dimensions. It should be connected to a scalar port on"
+                    " a set with one more dimension, or to a vector port on a set"
+                    " with the same number of dimensions."
+                )
             else:
                 raise RuntimeError(
-                        f'Port "{name}" is connected to an instance set with more than'
-                        ' one dimension more than its own, which is not possible.')
+                    f'Port "{name}" is connected to an instance set with more than'
+                    " one dimension more than its own, which is not possible."
+                )
             self._is_open = [True] * self._length
         else:
             if our_ndims < len(peer_dims):
                 raise RuntimeError(
-                        f'Scalar port "{name}" is connected to an instance set with'
-                        ' more dimensions. It should be connected to a scalar port on'
-                        ' an instance set with the same dimensions, or to a vector port'
-                        ' on an instance set with one less dimension.')
+                    f'Scalar port "{name}" is connected to an instance set with'
+                    " more dimensions. It should be connected to a scalar port on"
+                    " an instance set with the same dimensions, or to a vector port"
+                    " on an instance set with one less dimension."
+                )
             elif our_ndims > len(peer_dims) + 1:
                 raise RuntimeError(
-                        f'Scalar port "{name}" is connected to an instance set with at'
-                        ' least two fewer dimensions, which is not possible.')
+                    f'Scalar port "{name}" is connected to an instance set with at'
+                    " least two fewer dimensions, which is not possible."
+                )
             self._length = None
             self._is_open = [True]
 
@@ -94,8 +103,7 @@ class Port(ymmsl.v0_2.Port):
         return self._is_connected
 
     def is_open(self, slot: Optional[int] = None) -> bool:
-        """Returns whether this port is open.
-        """
+        """Returns whether this port is open."""
         if slot is not None:
             return self._is_open[slot]
         return self._is_open[0]
@@ -109,8 +117,7 @@ class Port(ymmsl.v0_2.Port):
         return self._length is not None
 
     def is_resizable(self) -> bool:
-        """Returns whether this port can be resized.
-        """
+        """Returns whether this port can be resized."""
         return self._is_resizable
 
     def get_length(self) -> int:
@@ -120,7 +127,7 @@ class Port(ymmsl.v0_2.Port):
             RuntimeError: If this port is a scalar port.
         """
         if self._length is None:
-            raise RuntimeError(f'Tried to get length of scalar port {self.name}')
+            raise RuntimeError(f"Tried to get length of scalar port {self.name}")
         return self._length
 
     def set_length(self, length: int) -> None:
@@ -136,7 +143,8 @@ class Port(ymmsl.v0_2.Port):
         """
         if not self._is_resizable:
             raise RuntimeError(
-                    f'Tried to resize port {self.name}, but it is not resizable.')
+                f"Tried to resize port {self.name}, but it is not resizable."
+            )
         if length != self._length:
             self._length = length
             self._is_open = [True] * self._length
@@ -147,24 +155,21 @@ class Port(ymmsl.v0_2.Port):
             _extend_list_to_size(self._is_resuming, self._length, False)
 
     def set_closed(self, slot: Optional[int] = None) -> None:
-        """Marks this port as closed.
-        """
+        """Marks this port as closed."""
         if slot is not None:
             self._is_open[slot] = False
         else:
             self._is_open = [False]
 
     def restore_message_counts(self, num_messages: list[int]) -> None:
-        """Restore message counts from a snapshot
-        """
+        """Restore message counts from a snapshot"""
         self._num_messages = num_messages
         self._is_resuming = [True] * len(self._num_messages)
         _extend_list_to_size(self._num_messages, self._length or 1, 0)
         _extend_list_to_size(self._is_resuming, self._length or 1, False)
 
     def get_message_counts(self) -> list[int]:
-        """Get a list of message counts for all slots in this port
-        """
+        """Get a list of message counts for all slots in this port"""
         return self._num_messages.copy()
 
     def increment_num_messages(self, slot: Optional[int] = None) -> None:

--- a/libmuscle/python/libmuscle/port_manager.py
+++ b/libmuscle/python/libmuscle/port_manager.py
@@ -8,9 +8,10 @@ from libmuscle.port import Port
 
 class PortManager:
     """Manages sending and receiving ports of the current instance."""
+
     def __init__(
-            self, index: list[int], declared_ports: Optional[dict[Operator, list[str]]]
-            ) -> None:
+        self, index: list[int], declared_ports: Optional[dict[Operator, list[str]]]
+    ) -> None:
         """Create a PortManager.
 
         Args:
@@ -90,8 +91,7 @@ class PortManager:
         """
         return self._ports[port_name]
 
-    def restore_message_counts(
-            self, port_message_counts: dict[str, list[int]]) -> None:
+    def restore_message_counts(self, port_message_counts: dict[str, list[int]]) -> None:
         """Restore message counts on all ports.
 
         Args:
@@ -104,9 +104,11 @@ class PortManager:
             elif port_name in self._ports:
                 self._ports[port_name].restore_message_counts(num_messages)
             else:
-                raise RuntimeError(f'Unknown port {port_name} in snapshot.'
-                                   ' Have your port definitions changed since'
-                                   ' the snapshot was taken?')
+                raise RuntimeError(
+                    f"Unknown port {port_name} in snapshot."
+                    " Have your port definitions changed since"
+                    " the snapshot was taken?"
+                )
 
     def get_message_counts(self) -> dict[str, list[int]]:
         """Get message counts for all ports on the communicator.
@@ -115,10 +117,13 @@ class PortManager:
             A dictionary indexed by port name containing a list of counts, one
             for each slot of the corresponding port.
         """
-        port_message_counts = {port_name: port.get_message_counts()
-                               for port_name, port in self._ports.items()}
-        port_message_counts["muscle_settings_in"] = \
+        port_message_counts = {
+            port_name: port.get_message_counts()
+            for port_name, port in self._ports.items()
+        }
+        port_message_counts["muscle_settings_in"] = (
             self._muscle_settings_in.get_message_counts()
+        )
         return port_message_counts
 
     def _settings_in_port(self, peer_info: PeerInfo) -> Port:
@@ -127,15 +132,19 @@ class PortManager:
         Args:
             peer_info: Information about our peers from the manager.
         """
-        msi = Identifier('muscle_settings_in')
+        msi = Identifier("muscle_settings_in")
         if peer_info.is_connected(msi):
             sender_component = peer_info.get_peer_ports(msi)[0][:-1]
             return Port(
-                    str(msi), Operator.F_INIT, False, True, len(self._index),
-                    peer_info.get_peer_dims(sender_component))
+                str(msi),
+                Operator.F_INIT,
+                False,
+                True,
+                len(self._index),
+                peer_info.get_peer_dims(sender_component),
+            )
 
-        return Port(
-                str(msi), Operator.F_INIT, False, False, len(self._index), [])
+        return Port(str(msi), Operator.F_INIT, False, False, len(self._index), [])
 
     def _ports_from_declared(self, peer_info: PeerInfo) -> dict[str, Port]:
         """Derives port definitions from supplied declaration.
@@ -153,16 +162,22 @@ class PortManager:
         for operator, port_list in self._declared_ports.items():
             for port_desc in port_list:
                 port_name, is_vector = self._split_port_desc(port_desc)
-                if port_name.startswith('muscle_'):
+                if port_name.startswith("muscle_"):
                     raise RuntimeError(
-                            'Port names starting with "muscle_" are reserved for'
-                            f' MUSCLE, please rename port "{port_name}"')
+                        'Port names starting with "muscle_" are reserved for'
+                        f' MUSCLE, please rename port "{port_name}"'
+                    )
                 port_id = Identifier(port_name)
                 is_connected = peer_info.is_connected(port_id)
                 peer_dims = peer_info.check_peer_dimensions(port_id)
                 ports[port_name] = Port(
-                        port_name, operator, is_vector, is_connected,
-                        len(self._index), peer_dims)
+                    port_name,
+                    operator,
+                    is_vector,
+                    is_connected,
+                    len(self._index),
+                    peer_dims,
+                )
         return ports
 
     def _ports_from_conduits(self, peer_info: PeerInfo) -> dict[str, Port]:
@@ -177,10 +192,15 @@ class PortManager:
             is_connected = peer_info.is_connected(port.name)
             peer_dims = peer_info.check_peer_dimensions(port.name)
             ndims = max(0, len(peer_dims) - len(self._index))
-            is_vector = (ndims == 1)
+            is_vector = ndims == 1
             ports[port_name] = Port(
-                port_name, port.operator, is_vector, is_connected,
-                len(self._index), peer_dims)
+                port_name,
+                port.operator,
+                is_vector,
+                is_connected,
+                len(self._index),
+                peer_dims,
+            )
         return ports
 
     def _split_port_desc(self, port_desc: str) -> tuple[str, bool]:
@@ -194,13 +214,14 @@ class PortManager:
             port_desc: A port description string, as above.
         """
         is_vector = False
-        if port_desc.endswith('[]'):
+        if port_desc.endswith("[]"):
             is_vector = True
             port_desc = port_desc[:-2]
 
-        if port_desc.endswith('[]'):
+        if port_desc.endswith("[]"):
             raise ValueError(
-                    f'Port description "{port_desc}" is invalid: ports can have at most'
-                    ' one dimension.')
+                f'Port description "{port_desc}" is invalid: ports can have at most'
+                " one dimension."
+            )
 
         return port_desc, is_vector

--- a/libmuscle/python/libmuscle/post_office.py
+++ b/libmuscle/python/libmuscle/post_office.py
@@ -13,9 +13,9 @@ class PostOffice:
     A PostOffice holds outboxes with messages for receivers. It also
     acts as a request handler for incoming requests for messages.
     """
+
     def __init__(self) -> None:
-        """Create a PostOffice.
-        """
+        """Create a PostOffice."""
         self._outboxes: dict[Reference, Outbox] = {}
 
         self._outbox_lock = Lock()
@@ -52,8 +52,7 @@ class PostOffice:
         self._outboxes[receiver].deposit(message)
 
     def wait_for_receivers(self) -> None:
-        """Waits until all outboxes are empty.
-        """
+        """Waits until all outboxes are empty."""
         for outbox in self._outboxes.values():
             while not outbox.is_empty():
                 time.sleep(0.1)

--- a/libmuscle/python/libmuscle/profiler.py
+++ b/libmuscle/python/libmuscle/profiler.py
@@ -9,8 +9,8 @@ _COMMUNICATION_INTERVAL = 10.0  # seconds
 
 
 class Profiler:
-    """Collects profiling events and sends them to the manager.
-    """
+    """Collects profiling events and sends them to the manager."""
+
     def __init__(self, manager: MMPClient) -> None:
         """Create a Profiler.
 
@@ -51,7 +51,7 @@ class Profiler:
                     events to the manager.
         """
         with self._mutex:
-            self._enabled = level == 'all'
+            self._enabled = level == "all"
 
     def record_event(self, event: ProfileEvent) -> None:
         """Record a profiling event.

--- a/libmuscle/python/libmuscle/profiling.py
+++ b/libmuscle/python/libmuscle/profiling.py
@@ -7,6 +7,7 @@ from ymmsl.v0_2 import Port
 
 class ProfileEventType(Enum):
     """Profiling event types for MUSCLE3."""
+
     REGISTER = 0
     CONNECT = 4
     SEND = 2
@@ -29,6 +30,7 @@ class ProfileTimestamp:
     Attributes:
         nanoseconds: Nanoseconds since the UNIX epoch.
     """
+
     _time_ref = time_ns() - perf_counter_ns()
 
     def __init__(self, nanoseconds: Optional[int] = None) -> None:
@@ -78,18 +80,19 @@ class ProfileEvent:
         message_timestamp: Timestamp sent with the message, if
                 applicable.
     """
+
     def __init__(
-            self,
-            event_type: ProfileEventType,
-            start_time: Optional[ProfileTimestamp] = None,
-            stop_time: Optional[ProfileTimestamp] = None,
-            port: Optional[Port] = None,
-            port_length: Optional[int] = None,
-            slot: Optional[int] = None,
-            message_number: Optional[int] = None,
-            message_size: Optional[int] = None,
-            message_timestamp: Optional[float] = None
-            ) -> None:
+        self,
+        event_type: ProfileEventType,
+        start_time: Optional[ProfileTimestamp] = None,
+        stop_time: Optional[ProfileTimestamp] = None,
+        port: Optional[Port] = None,
+        port_length: Optional[int] = None,
+        slot: Optional[int] = None,
+        message_number: Optional[int] = None,
+        message_size: Optional[int] = None,
+        message_timestamp: Optional[float] = None,
+    ) -> None:
 
         self.event_type = event_type
         self.start_time = start_time
@@ -102,11 +105,9 @@ class ProfileEvent:
         self.message_timestamp = message_timestamp
 
     def start(self) -> None:
-        """Sets start_time to the current time.
-        """
+        """Sets start_time to the current time."""
         self.start_time = ProfileTimestamp()
 
     def stop(self) -> None:
-        """Sets stop_time to the current time.
-        """
+        """Sets stop_time to the current time."""
         self.stop_time = ProfileTimestamp()

--- a/libmuscle/python/libmuscle/pytest/__init__.py
+++ b/libmuscle/python/libmuscle/pytest/__init__.py
@@ -19,7 +19,8 @@ def _collect_log_report(run_dir: Path) -> str:
     log_file = run_dir / "muscle3_manager.log"
 
     error_lines = [
-        line for line in log_file.read_text().splitlines()
+        line
+        for line in log_file.read_text().splitlines()
         if " ERROR " in line or " CRITICAL " in line
     ]
     lines = [
@@ -34,8 +35,9 @@ def _collect_log_report(run_dir: Path) -> str:
 
 
 @pytest.fixture
-def muscle3_tester(request: pytest.FixtureRequest, tmp_path: Path
-                   ) -> Iterator[MuscleTester]:
+def muscle3_tester(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> Iterator[MuscleTester]:
     """Pytest fixture providing a MuscleTester instance."""
     run_dir = tmp_path / "run_dir"
 

--- a/libmuscle/python/libmuscle/pytest/implementation_tester.py
+++ b/libmuscle/python/libmuscle/pytest/implementation_tester.py
@@ -15,8 +15,12 @@ class ImplementationTester:
     "tester" component, which is connected to the implementation under test.
     """
 
-    def __init__(self, default_timeout: float, muscle_manager_address: str,
-                 test_ymmsl_config: Configuration) -> None:
+    def __init__(
+        self,
+        default_timeout: float,
+        muscle_manager_address: str,
+        test_ymmsl_config: Configuration,
+    ) -> None:
         """
         Initialize the implementation tester.
 
@@ -30,14 +34,14 @@ class ImplementationTester:
         os.environ["MUSCLE_INSTANCE"] = "muscle3_implementation_tester"
         test_model = test_ymmsl_config.programs[
             Reference("muscle3_implementation_tester")
-            ]
+        ]
         instance_ports = {
             Operator.O_I: [str(p) for p in test_model.ports.sending_port_names()],
-            Operator.S: [str(p) for p in test_model.ports.receiving_port_names()]
+            Operator.S: [str(p) for p in test_model.ports.receiving_port_names()],
         }
         self._instance = Instance(
-                ports=instance_ports,
-                flags=InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS)
+            ports=instance_ports, flags=InstanceFlags.SKIP_MMSF_SEQUENCE_CHECKS
+        )
         # Configure the deadlock-detection timeout to match the default receive
         # timeout: after `default_timeout` seconds of waiting the manager is
         # notified, and if a deadlock is detected the simulation is aborted.
@@ -88,7 +92,8 @@ class ImplementationTester:
             # it crashed)
             _logger.error(
                 "ImplementationTester: error while waiting for a message on"
-                " port '%s'. Shutting down.", port_name
+                " port '%s'. Shutting down.",
+                port_name,
             )
 
             self._is_shut_down = True

--- a/libmuscle/python/libmuscle/pytest/muscle_tester.py
+++ b/libmuscle/python/libmuscle/pytest/muscle_tester.py
@@ -61,8 +61,8 @@ class MuscleTester:
         self.cleanup()
 
     def _add_tester_component(
-            self, config: Configuration, implementation_name: str
-            ) -> Configuration:
+        self, config: Configuration, implementation_name: str
+    ) -> Configuration:
         """
         Add a 'muscle3_implementation_tester' as a tester component.
         - Finds the implementation (model or program) by name.
@@ -93,8 +93,7 @@ class MuscleTester:
             tester_o_i_ports.append(f"{port_name}")
             tester_model.conduits.append(
                 Conduit(
-                    f"{tester_name}.{port_name}",
-                    f"{implementation_name}.{port_name}"
+                    f"{tester_name}.{port_name}", f"{implementation_name}.{port_name}"
                 )
             )
 
@@ -103,8 +102,7 @@ class MuscleTester:
             tester_s_ports.append(f"{port_name}")
             tester_model.conduits.append(
                 Conduit(
-                    f"{implementation_name}.{port_name}",
-                    f"{tester_name}.{port_name}"
+                    f"{implementation_name}.{port_name}", f"{tester_name}.{port_name}"
                 )
             )
 
@@ -132,16 +130,18 @@ class MuscleTester:
         )
 
         config.resources[Reference(tester_name)] = ThreadedResReq(
-                name=Reference(tester_name),
-                threads=1
-            )
+            name=Reference(tester_name), threads=1
+        )
 
         config.models[Reference(test_model_name)] = tester_model
         return config
 
     def start_implementation(
-        self, ymmsl_source: Union[str, Path], implementation: str,
-        *, default_timeout: float = 60
+        self,
+        ymmsl_source: Union[str, Path],
+        implementation: str,
+        *,
+        default_timeout: float = 60,
     ) -> ImplementationTester:
         """Start a MUSCLE3 manager and return an ImplementationTester.
 
@@ -175,24 +175,27 @@ class MuscleTester:
         test_ymmsl_path = self.run_dir / "test_config.ymmsl"
         ymmsl.save(test_ymmsl_config, test_ymmsl_path)
 
-        server_ctx = make_server_process(
-            test_ymmsl_config, self.run_dir, True)
+        server_ctx = make_server_process(test_ymmsl_config, self.run_dir, True)
         muscle_manager_address = self._exitstack.enter_context(server_ctx)
 
         # patch ReceiveTimeoutHandler so we can (ab)use it for our timeouts:
-        self._exitstack.enter_context(patch.object(ReceiveTimeoutHandler, 'on_timeout',
-                                                    raise_error))
-        self._exitstack.enter_context(patch(
-            'libmuscle.mcp.tcp_transport_client.RECONNECT_TIMEOUT',
-            min(RECONNECT_TIMEOUT, default_timeout)
-            ))
-        self._exitstack.enter_context(patch(
-            'libmuscle.mmp_client.PEER_TIMEOUT',
-            min(PEER_TIMEOUT, default_timeout)
-            ))
-        self.implementation_tester = ImplementationTester(default_timeout, 
-                                                          muscle_manager_address,
-                                                          test_ymmsl_config)
+        self._exitstack.enter_context(
+            patch.object(ReceiveTimeoutHandler, "on_timeout", raise_error)
+        )
+        self._exitstack.enter_context(
+            patch(
+                "libmuscle.mcp.tcp_transport_client.RECONNECT_TIMEOUT",
+                min(RECONNECT_TIMEOUT, default_timeout),
+            )
+        )
+        self._exitstack.enter_context(
+            patch(
+                "libmuscle.mmp_client.PEER_TIMEOUT", min(PEER_TIMEOUT, default_timeout)
+            )
+        )
+        self.implementation_tester = ImplementationTester(
+            default_timeout, muscle_manager_address, test_ymmsl_config
+        )
         self._exitstack.callback(self.implementation_tester.cleanup)
         return self.implementation_tester
 
@@ -207,36 +210,40 @@ class MuscleTester:
         self.implementation_tester = None
 
 
-def start_mmp_server(control_pipe: tuple[Connection, Connection],
-                     ymmsl_config: Configuration, run_dir: RunDir,
-                     env: dict[str, str], start_instances: bool) -> None:
+def start_mmp_server(
+    control_pipe: tuple[Connection, Connection],
+    ymmsl_config: Configuration,
+    run_dir: RunDir,
+    env: dict[str, str],
+    start_instances: bool,
+) -> None:
     if start_instances:
         os.environ.clear()
         os.environ.update(env)
 
     control_pipe[0].close()
-    manager = Manager(ymmsl_config, run_dir, 'DEBUG')
+    manager = Manager(ymmsl_config, run_dir, "DEBUG")
     control_pipe[1].send(manager.get_server_location())
 
     if start_instances:
         manager.start_instances()
-    
+
     control_pipe[1].recv()
     control_pipe[1].close()
     manager.stop()
 
 
 @contextmanager
-def make_server_process(ymmsl_config: Configuration, run_dir: Path,
-                        start_instances: bool
-                        ) -> Generator[str, None, None]:
+def make_server_process(
+    ymmsl_config: Configuration, run_dir: Path, start_instances: bool
+) -> Generator[str, None, None]:
     run_dir_obj = RunDir(run_dir)
     env = os.environ.copy()
     control_pipe = mp.Pipe()
     process = mp.Process(
         target=start_mmp_server,
         args=(control_pipe, ymmsl_config, run_dir_obj, env, start_instances),
-        name='Manager'
+        name="Manager",
     )
     process.start()
     control_pipe[1].close()

--- a/libmuscle/python/libmuscle/pytest/test/test_muscle_tester.py
+++ b/libmuscle/python/libmuscle/pytest/test/test_muscle_tester.py
@@ -42,8 +42,9 @@ def model_config() -> Configuration:
     return Configuration(models=[sub_model])
 
 
-def test_add_tester_model_to_config(tmp_run_dir: Path, program_config: Configuration,
-                                    model_config: Configuration) -> None:
+def test_add_tester_model_to_config(
+    tmp_run_dir: Path, program_config: Configuration, model_config: Configuration
+) -> None:
     tester = MuscleTester(tmp_run_dir)
     result_program = tester._add_tester_component(program_config, "micro_model_program")
     result_model = tester._add_tester_component(model_config, "macro_model")
@@ -54,8 +55,9 @@ def test_add_tester_model_to_config(tmp_run_dir: Path, program_config: Configura
     assert Reference("muscle3_implementation_tester") in tester_model.components
 
 
-def test_add_tester_program_to_config(tmp_run_dir: Path, program_config: Configuration
-                                      ) -> None:
+def test_add_tester_program_to_config(
+    tmp_run_dir: Path, program_config: Configuration
+) -> None:
     tester = MuscleTester(tmp_run_dir)
     result = tester._add_tester_component(program_config, "micro_model_program")
     assert Reference("muscle3_implementation_tester") in result.programs
@@ -64,8 +66,9 @@ def test_add_tester_program_to_config(tmp_run_dir: Path, program_config: Configu
     assert tester_prog.execution_model == ExecutionModel.MANUAL
 
 
-def test_add_test_ports_to_config(tmp_run_dir: Path, program_config: Configuration
-                                  ) -> None:
+def test_add_test_ports_to_config(
+    tmp_run_dir: Path, program_config: Configuration
+) -> None:
     tester = MuscleTester(tmp_run_dir)
     result = tester._add_tester_component(program_config, "micro_model_program")
     tester_model = result.models[Reference("muscle3_test_model")]
@@ -77,26 +80,34 @@ def test_add_test_ports_to_config(tmp_run_dir: Path, program_config: Configurati
     assert Identifier("final_out") in tester_comp.ports.receiving_port_names()
 
 
-def test_add_test_conduits_to_config(tmp_run_dir: Path, program_config: Configuration
-                                     ) -> None:
+def test_add_test_conduits_to_config(
+    tmp_run_dir: Path, program_config: Configuration
+) -> None:
     tester = MuscleTester(tmp_run_dir)
     result = tester._add_tester_component(program_config, "micro_model_program")
     tester_model = result.models[Reference("muscle3_test_model")]
 
     # Tester sends init_in -> implementation receives init_in
-    assert Conduit(
-        "muscle3_implementation_tester.init_in",
-        "micro_model_program.init_in",
-    ) in tester_model.conduits
+    assert (
+        Conduit(
+            "muscle3_implementation_tester.init_in",
+            "micro_model_program.init_in",
+        )
+        in tester_model.conduits
+    )
     # Implementation sends final_out -> tester receives final_out
-    assert Conduit(
-        "micro_model_program.final_out",
-        "muscle3_implementation_tester.final_out",
-    ) in tester_model.conduits
+    assert (
+        Conduit(
+            "micro_model_program.final_out",
+            "muscle3_implementation_tester.final_out",
+        )
+        in tester_model.conduits
+    )
 
 
-def test_original_config_unchanged(tmp_run_dir: Path, program_config: Configuration
-                                   ) -> None:
+def test_original_config_unchanged(
+    tmp_run_dir: Path, program_config: Configuration
+) -> None:
     """add_tester_component should not remove the original model/program."""
     tester = MuscleTester(tmp_run_dir)
     result = tester._add_tester_component(program_config, "micro_model_program")

--- a/libmuscle/python/libmuscle/receive_timeout_handler.py
+++ b/libmuscle/python/libmuscle/receive_timeout_handler.py
@@ -24,10 +24,13 @@ class ReceiveTimeoutHandler(TimeoutHandler):
     """
 
     def __init__(
-            self, manager: MMPClient,
-            peer_instance: Reference, port_name: str, slot: Optional[int],
-            timeout: float
-            ) -> None:
+        self,
+        manager: MMPClient,
+        peer_instance: Reference,
+        port_name: str,
+        slot: Optional[int],
+        timeout: float,
+    ) -> None:
         """Initialize a new timeout handler.
 
         Args:
@@ -48,23 +51,26 @@ class ReceiveTimeoutHandler(TimeoutHandler):
     @property
     def timeout(self) -> float:
         # Increase timeout by a factor 1.5 with every timeout we hit:
-        factor = 1.5 ** self._num_timeouts
+        factor = 1.5**self._num_timeouts
         return self._timeout * factor
 
     def on_timeout(self) -> None:
         if self._num_timeouts == 0:
             # Notify the manager that we're waiting for a receive
             self._manager.waiting_for_receive(
-                    self._peer_instance, self._port_name, self._slot)
+                self._peer_instance, self._port_name, self._slot
+            )
         else:
             # Ask the manager if we're part of a detected deadlock
             if self._manager.is_deadlocked():
                 _logger.error(
-                        'Deadlock detected, shutting down! Please see the manager log'
-                        ' for a description of the problem.')
+                    "Deadlock detected, shutting down! Please see the manager log"
+                    " for a description of the problem."
+                )
                 raise Deadlock()
         self._num_timeouts += 1
 
     def on_receive(self) -> None:
         self._manager.waiting_for_receive_done(
-                self._peer_instance, self._port_name, self._slot)
+            self._peer_instance, self._port_name, self._slot
+        )

--- a/libmuscle/python/libmuscle/runner.py
+++ b/libmuscle/python/libmuscle/runner.py
@@ -4,6 +4,7 @@ Starting instances is out of scope for MUSCLE3, but is also very
 useful for testing and prototyping. So we have a little bit of
 support for it in this module.
 """
+
 import logging
 import multiprocessing as mp
 import multiprocessing.connection as mpc
@@ -23,7 +24,7 @@ from libmuscle.manager.logger import last_lines
 from libmuscle.manager.manager import Manager
 from libmuscle.util import generate_indices
 
-__all__ = ['run_simulation']
+__all__ = ["run_simulation"]
 
 
 _logger = logging.getLogger(__name__)
@@ -34,8 +35,8 @@ Pipe = tuple[mpc.Connection, mpc.Connection]
 
 class MMPServerController:
     def __init__(
-            self, process: mp.Process, control_pipe: Pipe,
-            manager_location: str) -> None:
+        self, process: mp.Process, control_pipe: Pipe, manager_location: str
+    ) -> None:
         """Create an MMPServerController.
 
         This class controls a manager running in a separate process.
@@ -87,9 +88,9 @@ def start_server_process(configuration: Configuration) -> MMPServerController:
         A controller through which the manager can be shut down.
     """
     control_pipe = mp.Pipe()
-    process = mp.Process(target=manager_process,
-                         args=(control_pipe, configuration),
-                         name='MuscleManager')
+    process = mp.Process(
+        target=manager_process, args=(control_pipe, configuration), name="MuscleManager"
+    )
     process.start()
     control_pipe[1].close()
     # wait for start
@@ -99,17 +100,17 @@ def start_server_process(configuration: Configuration) -> MMPServerController:
 
 
 def implementation_process(
-        instance_id: str, manager_location: str,
-        implementation: Callable) -> None:
-    prefix_tag = '--muscle-prefix='
-    name_prefix = ''
+    instance_id: str, manager_location: str, implementation: Callable
+) -> None:
+    prefix_tag = "--muscle-prefix="
+    name_prefix = ""
     index_prefix: list[int] = []
 
     instance = Reference(instance_id)
 
     for i, arg in enumerate(sys.argv):
         if arg.startswith(prefix_tag):
-            prefix_str = arg[len(prefix_tag):]
+            prefix_str = arg[len(prefix_tag) :]
             name_prefix, index_prefix = _parse_prefix(prefix_str)
 
             name, index = _split_reference(instance)
@@ -118,21 +119,24 @@ def implementation_process(
             index = index_prefix + index
 
             # replace it with the combined one
-            sys.argv[i] = f'--muscle-instance={name + index}'
+            sys.argv[i] = f"--muscle-instance={name + index}"
             break
     else:
-        sys.argv.append(f'--muscle-instance={instance_id}')
+        sys.argv.append(f"--muscle-instance={instance_id}")
 
     for arg in sys.argv:
-        if arg.startswith('--muscle-manager='):
+        if arg.startswith("--muscle-manager="):
             break
     else:
-        sys.argv.append(f'--muscle-manager={manager_location}')
+        sys.argv.append(f"--muscle-manager={manager_location}")
 
     root_logger = logging.getLogger()
-    handler = logging.FileHandler(f'muscle3.{instance}.log', 'w')
-    handler.setFormatter(logging.Formatter(
-        '%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s'))
+    handler = logging.FileHandler(f"muscle3.{instance}.log", "w")
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(message)s"
+        )
+    )
     root_logger.addHandler(handler)
 
     # chain call
@@ -141,8 +145,9 @@ def implementation_process(
     except Exception:
         traceback.print_exc()
         _logger.error(
-                f'Component {instance} crashed, please check the log file'
-                ' for error messages')
+            f"Component {instance} crashed, please check the log file"
+            " for error messages"
+        )
         exit(1)
 
 
@@ -162,21 +167,22 @@ def _parse_prefix(prefix: str) -> tuple[str, list[int]]:
     Returns:
         The identifier sequence and the list of ints.
     """
+
     def parse_identifier(prefix: str, i: int) -> tuple[str, int]:
-        name = ''
-        while i < len(prefix) and prefix[i] not in '[.':
+        name = ""
+        while i < len(prefix) and prefix[i] not in "[.":
             name += prefix[i]
             i += 1
         return name, i
 
     def parse_number(prefix: str, i: int) -> tuple[int, int]:
-        number = ''
-        while i < len(prefix) and prefix[i] in '0123456789':
+        number = ""
+        while i < len(prefix) and prefix[i] in "0123456789":
             number += prefix[i]
             i += 1
         return int(number), i
 
-    name = ''
+    name = ""
     index: list[int] = []
     i = 0
 
@@ -186,22 +192,22 @@ def _parse_prefix(prefix: str) -> tuple[str, list[int]]:
     idt, i = parse_identifier(prefix, i)
     name += idt
 
-    while i < len(prefix) and prefix[i] == '.':
-        name += '.'
+    while i < len(prefix) and prefix[i] == ".":
+        name += "."
         part, i = parse_identifier(prefix, i + 1)
         name += part
 
-    while i < len(prefix) and prefix[i] == '[':
+    while i < len(prefix) and prefix[i] == "[":
         nmb, i = parse_number(prefix, i + 1)
         index.append(nmb)
-        if prefix[i] != ']':
-            raise ValueError('Missing closing bracket in'
-                             ' --muscle-prefix.')
+        if prefix[i] != "]":
+            raise ValueError("Missing closing bracket in --muscle-prefix.")
         i += 1
 
     if i < len(prefix):
         raise ValueError(
-                f'Found invalid extra character {prefix[i]} in --muscle-prefix.')
+            f"Found invalid extra character {prefix[i]} in --muscle-prefix."
+        )
 
     return name, index
 
@@ -220,8 +226,7 @@ def _split_reference(ref: Reference) -> tuple[Reference, list[int]]:
     return name, index
 
 
-def run_instances(
-        instances: dict[str, Callable], manager_location: str) -> None:
+def run_instances(instances: dict[str, Callable], manager_location: str) -> None:
     """Runs the given instances and waits for them to finish.
 
     The instances are described in a dictionary with their instance
@@ -238,9 +243,10 @@ def run_instances(
     for instance_id_str, implementation in instances.items():
         instance_id = Reference(instance_id_str)
         process = mp.Process(
-                target=implementation_process,
-                args=(instance_id_str, manager_location, implementation),
-                name=str(instance_id))
+            target=implementation_process,
+            args=(instance_id_str, manager_location, implementation),
+            name=str(instance_id),
+        )
         process.start()
         instance_processes.append(process)
 
@@ -266,22 +272,23 @@ def run_instances(
                 process.kill()
 
         failed_names = [proc.name for proc in failed_processes]
-        log_files = [Path(f'muscle3.{name}.log') for name in failed_names]
+        log_files = [Path(f"muscle3.{name}.log") for name in failed_names]
         outputs = [last_lines(log_file, 20) for log_file in log_files]
         msg = (
-                f'Instance(s) {failed_names} failed to shut down cleanly. Here is the'
-                ' final bit of the output:')
+            f"Instance(s) {failed_names} failed to shut down cleanly. Here is the"
+            " final bit of the output:"
+        )
         for name, output in zip(failed_names, outputs):
-            msg += '\n ---------- ' + name + ' ----------\n'
-            msg += output + '\n'
-            msg += f'See muscle3.{name}.log for the complete output\n'
+            msg += "\n ---------- " + name + " ----------\n"
+            msg += output + "\n"
+            msg += f"See muscle3.{name}.log for the complete output\n"
 
         raise RuntimeError(msg)
 
 
 def run_simulation(
-        configuration: Document, implementations: dict[str, Callable]
-        ) -> None:
+    configuration: Document, implementations: dict[str, Callable]
+) -> None:
     """Runs a simulation with the given configuration and instances.
 
     The yMMSL document must contain a complete configuration.
@@ -296,16 +303,17 @@ def run_simulation(
     """
     if isinstance(configuration, v0_1.PartialConfiguration):
         with catch_warnings():
-            filterwarnings('ignore', 'In yMMSL v0.2.*')
-            filterwarnings('ignore', 'Comments can unfortunately.*')
+            filterwarnings("ignore", "In yMMSL v0.2.*")
+            filterwarnings("ignore", "Comments can unfortunately.*")
             configuration = convert_to(Configuration, configuration)
     elif not isinstance(configuration, Configuration):
-        raise RuntimeError('Invalid configuration type {type(configuration)}')
+        raise RuntimeError("Invalid configuration type {type(configuration)}")
 
     if configuration.imports:
         raise RuntimeError(
-                'Imports are not supported when running directly from Python. To run'
-                ' larger models, please use the command line.')
+            "Imports are not supported when running directly from Python. To run"
+            " larger models, please use the command line."
+        )
 
     configuration.check_consistent(False)
     configuration = flatten(configuration)
@@ -317,8 +325,9 @@ def run_simulation(
         impl_name = str(ce.implementation)
         if impl_name not in implementations:
             raise ValueError(
-                    f'The model specifies an implementation named "{impl_name}" but the'
-                    ' given set of implementations does not include it.')
+                f'The model specifies an implementation named "{impl_name}" but the'
+                " given set of implementations does not include it."
+            )
 
         impl_fn = implementations[impl_name]
         if not ce.multiplicity:

--- a/libmuscle/python/libmuscle/settings_manager.py
+++ b/libmuscle/python/libmuscle/settings_manager.py
@@ -17,41 +17,36 @@ def has_setting_type(value: SettingValue, typ: str) -> bool:
     Raises:
         ValueError: If the type specified is not valid.
     """
-    par_type_to_type = {
-            'str': str,
-            'int': int,
-            'float': float,
-            'bool': bool
-            }
+    par_type_to_type = {"str": str, "int": int, "float": float, "bool": bool}
 
     if typ in par_type_to_type:
         return isinstance(value, par_type_to_type[typ])
-    elif typ == '[int]':
+    elif typ == "[int]":
         if isinstance(value, list):
             if len(value) == 0 or isinstance(value[0], int):
                 # We don't check everything here, the yMMSL loader does
                 # a full type check, so we just need to discriminate.
                 return True
-    elif typ == '[float]':
+    elif typ == "[float]":
         if isinstance(value, list):
             if len(value) == 0 or isinstance(value[0], float):
                 # We don't check everything here, the yMMSL loader does
                 # a full type check, so we just need to discriminate.
                 return True
         return False
-    elif typ == '[[float]]':
+    elif typ == "[[float]]":
         if isinstance(value, list):
             if len(value) == 0 or isinstance(value[0], list):
                 # We don't check everything here, the yMMSL loader does
                 # a full type check, so we just need to discriminate.
                 return True
         return False
-    raise ValueError(f'Invalid setting type specified: {typ}')
+    raise ValueError(f"Invalid setting type specified: {typ}")
 
 
 class SettingsManager:
-    """Manages the current settings for a component instance.
-    """
+    """Manages the current settings for a component instance."""
+
     def __init__(self) -> None:
         """Create a SettingsManager.
 
@@ -95,6 +90,7 @@ class SettingsManager:
         Return:
             A list of setting names.
         """
+
         def extract_names(settings: Settings) -> set[str]:
             result: set[str] = set()
             for name in settings:
@@ -112,8 +108,8 @@ class SettingsManager:
         return sorted(names)
 
     def get_setting(
-            self, instance: Reference, setting_name: Reference,
-            typ: Optional[str] = None) -> SettingValue:
+        self, instance: Reference, setting_name: Reference, typ: Optional[str] = None
+    ) -> SettingValue:
         """Returns the value of a setting.
 
         Args:
@@ -148,6 +144,7 @@ class SettingsManager:
         if typ is not None:
             if not has_setting_type(value, typ):
                 raise TypeError(
-                        f'Value for setting "{name}" is of type {type(value)}, where'
-                        f' {typ} was expected.')
+                    f'Value for setting "{name}" is of type {type(value)}, where'
+                    f" {typ} was expected."
+                )
         return value

--- a/libmuscle/python/libmuscle/snapshot.py
+++ b/libmuscle/python/libmuscle/snapshot.py
@@ -15,15 +15,18 @@ class Snapshot(ABC):
 
     This is an abstract base class, implementations are provided by subclasses.
     """
-    SNAPSHOT_VERSION_BYTE = b'\0'
 
-    def __init__(self,
-                 triggers: list[str],
-                 wallclock_time: float,
-                 port_message_counts: dict[str, list[int]],
-                 is_final_snapshot: bool,
-                 message: Optional['communicator.Message'],
-                 settings_overlay: Settings) -> None:
+    SNAPSHOT_VERSION_BYTE = b"\0"
+
+    def __init__(
+        self,
+        triggers: list[str],
+        wallclock_time: float,
+        port_message_counts: dict[str, list[int]],
+        is_final_snapshot: bool,
+        message: Optional["communicator.Message"],
+        settings_overlay: Settings,
+    ) -> None:
         self.triggers = triggers
         self.wallclock_time = wallclock_time
         self.port_message_counts = port_message_counts
@@ -35,7 +38,7 @@ class Snapshot(ABC):
 
     @classmethod
     @abstractmethod
-    def from_bytes(cls, data: bytes) -> 'Snapshot':
+    def from_bytes(cls, data: bytes) -> "Snapshot":
         """Create a snapshot object from binary data.
 
         Args:
@@ -56,60 +59,75 @@ class Snapshot(ABC):
 
 
 class MsgPackSnapshot(Snapshot):
-    """Snapshot stored in messagepack format
-    """
-    SNAPSHOT_VERSION_BYTE = b'1'
+    """Snapshot stored in messagepack format"""
+
+    SNAPSHOT_VERSION_BYTE = b"1"
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> 'Snapshot':
+    def from_bytes(cls, data: bytes) -> "Snapshot":
         dct = msgpack.loads(data)
-        return cls(dct['triggers'],
-                   dct['wallclock_time'],
-                   dct['port_message_counts'],
-                   dct['is_final_snapshot'],
-                   cls.bytes_to_message(dct['message']),
-                   Settings(dct['settings_overlay']))
+        return cls(
+            dct["triggers"],
+            dct["wallclock_time"],
+            dct["port_message_counts"],
+            dct["is_final_snapshot"],
+            cls.bytes_to_message(dct["message"]),
+            Settings(dct["settings_overlay"]),
+        )
 
     def to_bytes(self) -> bytes:
-        return cast(bytes, msgpack.dumps({
-            'triggers': self.triggers,
-            'wallclock_time': self.wallclock_time,
-            'port_message_counts': self.port_message_counts,
-            'is_final_snapshot': self.is_final_snapshot,
-            'message': self.message_to_bytes(self.message),
-            'settings_overlay': self.settings_overlay.as_ordered_dict()
-        }))
+        return cast(
+            bytes,
+            msgpack.dumps(
+                {
+                    "triggers": self.triggers,
+                    "wallclock_time": self.wallclock_time,
+                    "port_message_counts": self.port_message_counts,
+                    "is_final_snapshot": self.is_final_snapshot,
+                    "message": self.message_to_bytes(self.message),
+                    "settings_overlay": self.settings_overlay.as_ordered_dict(),
+                }
+            ),
+        )
 
     @staticmethod
-    def message_to_bytes(message: Optional['communicator.Message']) -> Buffer:
-        """Use MPPMessage serializer for serializing the message object
-        """
+    def message_to_bytes(message: Optional["communicator.Message"]) -> Buffer:
+        """Use MPPMessage serializer for serializing the message object"""
         if message is None:
-            return b''
+            return b""
         settings = Settings()
         if message.settings is not None:
             settings = message.settings
-        return MPPMessage(Reference('_'), Reference('_'), None,
-                          message.timestamp, message.next_timestamp,
-                          settings, 0, -1.0, message.data).encoded()
+        return MPPMessage(
+            Reference("_"),
+            Reference("_"),
+            None,
+            message.timestamp,
+            message.next_timestamp,
+            settings,
+            0,
+            -1.0,
+            message.data,
+        ).encoded()
 
     @staticmethod
-    def bytes_to_message(data: Buffer) -> Optional['communicator.Message']:
-        """Use MPPMessage deserializer for serializing the message object
-        """
+    def bytes_to_message(data: Buffer) -> Optional["communicator.Message"]:
+        """Use MPPMessage deserializer for serializing the message object"""
         if not data:
             return None
         mpp_message = MPPMessage.from_bytes(data)
-        return communicator.Message(mpp_message.timestamp,
-                                    mpp_message.next_timestamp,
-                                    mpp_message.data,
-                                    mpp_message.settings_overlay)
+        return communicator.Message(
+            mpp_message.timestamp,
+            mpp_message.next_timestamp,
+            mpp_message.data,
+            mpp_message.settings_overlay,
+        )
 
 
 @dataclass
 class SnapshotMetadata:
-    """Metadata of a snapshot for sending to the muscle_manager.
-    """
+    """Metadata of a snapshot for sending to the muscle_manager."""
+
     triggers: list[str]
     wallclock_time: float
     timestamp: float
@@ -120,16 +138,14 @@ class SnapshotMetadata:
     snapshot_filename: str
 
     @staticmethod
-    def from_snapshot(snapshot: Snapshot, snapshot_filename: str
-                      ) -> 'SnapshotMetadata':
-        """Create snapshot metadata from the given snapshot and filename
-        """
+    def from_snapshot(snapshot: Snapshot, snapshot_filename: str) -> "SnapshotMetadata":
+        """Create snapshot metadata from the given snapshot and filename"""
         return SnapshotMetadata(
             snapshot.triggers,
             snapshot.wallclock_time,
-            snapshot.message.timestamp if snapshot.message else float('NaN'),
+            snapshot.message.timestamp if snapshot.message else float("NaN"),
             snapshot.message.next_timestamp if snapshot.message else None,
             snapshot.port_message_counts,
             snapshot.is_final_snapshot,
-            snapshot_filename
+            snapshot_filename,
         )

--- a/libmuscle/python/libmuscle/snapshot_manager.py
+++ b/libmuscle/python/libmuscle/snapshot_manager.py
@@ -15,8 +15,9 @@ _MAX_FILE_EXISTS_CHECK = 10000
 
 # error text for save_snapshot when msg = None
 _NO_MESSAGE_PROVIDED = (
-        'Invalid message provided to `{}`. Please create a Message object to'
-        ' store the state of the instance in a snapshot.')
+    "Invalid message provided to `{}`. Please create a Message object to"
+    " store the state of the instance in a snapshot."
+)
 
 
 class SnapshotManager:
@@ -26,8 +27,8 @@ class SnapshotManager:
     """
 
     def __init__(
-            self, instance_id: Reference, manager: MMPClient,
-            port_manager: PortManager) -> None:
+        self, instance_id: Reference, manager: MMPClient, port_manager: PortManager
+    ) -> None:
         """Create a new snapshot manager
 
         Args:
@@ -47,8 +48,8 @@ class SnapshotManager:
         self._next_snapshot_num = 1
 
     def prepare_resume(
-            self, resume_snapshot: Optional[Path],
-            snapshot_directory: Optional[Path]) -> Optional[float]:
+        self, resume_snapshot: Optional[Path], snapshot_directory: Optional[Path]
+    ) -> Optional[float]:
         """Apply checkpoint info received from the manager.
 
         If there is a snapshot to resume from, this loads it and does
@@ -90,8 +91,9 @@ class SnapshotManager:
         given an intermediate snapshot to resume from by the manager.
         """
         return (
-                self._resume_from_snapshot is not None and
-                not self._resume_from_snapshot.is_final_snapshot)
+            self._resume_from_snapshot is not None
+            and not self._resume_from_snapshot.is_final_snapshot
+        )
 
     def resuming_from_final(self) -> bool:
         """Check whether we have a final snapshot.
@@ -100,21 +102,24 @@ class SnapshotManager:
         given an intermediate snapshot to resume from by the manager.
         """
         return (
-                self._resume_from_snapshot is not None and
-                self._resume_from_snapshot.is_final_snapshot)
+            self._resume_from_snapshot is not None
+            and self._resume_from_snapshot.is_final_snapshot
+        )
 
     def load_snapshot(self) -> Message:
-        """Get the Message to resume from.
-        """
+        """Get the Message to resume from."""
         snapshot = cast(Snapshot, self._resume_from_snapshot)
         return cast(Message, snapshot.message)
 
     def save_snapshot(
-            self, msg: Optional[Message], final: bool,
-            triggers: list[str], wallclock_time: float,
-            f_init_max_timestamp: Optional[float],
-            settings_overlay: Settings
-            ) -> float:
+        self,
+        msg: Optional[Message],
+        final: bool,
+        triggers: list[str],
+        wallclock_time: float,
+        f_init_max_timestamp: Optional[float],
+        settings_overlay: Settings,
+    ) -> float:
         """Save a (final) snapshot.
 
         Args:
@@ -136,20 +141,20 @@ class SnapshotManager:
             all_ports = self._port_manager.list_ports()
             ports = all_ports.get(Operator.F_INIT, [])
             if self._port_manager.settings_in_connected():
-                ports.append('muscle_settings_in')
+                ports.append("muscle_settings_in")
             for port_name in ports:
                 new_counts = [i - 1 for i in port_message_counts[port_name]]
                 port_message_counts[port_name] = new_counts
 
         snapshot = MsgPackSnapshot(
-                triggers, wallclock_time, port_message_counts, final, msg,
-                settings_overlay)
+            triggers, wallclock_time, port_message_counts, final, msg, settings_overlay
+        )
 
         path = self.__store_snapshot(snapshot)
         metadata = SnapshotMetadata.from_snapshot(snapshot, str(path))
         self._manager.submit_snapshot_metadata(metadata)
 
-        timestamp = msg.timestamp if msg is not None else float('-inf')
+        timestamp = msg.timestamp if msg is not None else float("-inf")
         if final and f_init_max_timestamp is not None:
             # For final snapshots f_init_max_snapshot is the reference time (see
             # should_save_final_snapshot).
@@ -163,24 +168,28 @@ class SnapshotManager:
         Args:
             snapshot_location: path where the snapshot is stored.
         """
-        _logger.debug(f'Loading snapshot from {snapshot_location}')
+        _logger.debug(f"Loading snapshot from {snapshot_location}")
         if not snapshot_location.is_file():
-            raise RuntimeError(f'Unable to load snapshot: {snapshot_location}'
-                               ' is not a file. Please ensure this path exists'
-                               ' and can be read.')
+            raise RuntimeError(
+                f"Unable to load snapshot: {snapshot_location}"
+                " is not a file. Please ensure this path exists"
+                " and can be read."
+            )
 
         # TODO: encapsulate I/O errors?
-        with snapshot_location.open('rb') as snapshot_file:
+        with snapshot_location.open("rb") as snapshot_file:
             version = snapshot_file.read(1)
             data = snapshot_file.read()
 
             if version == MsgPackSnapshot.SNAPSHOT_VERSION_BYTE:
                 return MsgPackSnapshot.from_bytes(data)
-            raise RuntimeError('Unable to load snapshot from'
-                               f' {snapshot_location}: unknown version of'
-                               ' snapshot file. Was the file saved with a'
-                               ' different version of libmuscle or'
-                               ' edited?')
+            raise RuntimeError(
+                "Unable to load snapshot from"
+                f" {snapshot_location}: unknown version of"
+                " snapshot file. Was the file saved with a"
+                " different version of libmuscle or"
+                " edited?"
+            )
 
     def __store_snapshot(self, snapshot: Snapshot) -> Path:
         """Store a snapshot on the filesystem.
@@ -191,7 +200,7 @@ class SnapshotManager:
         Returns:
             Path where the snapshot is stored.
         """
-        _logger.debug(f'Saving snapshot to {self._snapshot_directory}')
+        _logger.debug(f"Saving snapshot to {self._snapshot_directory}")
         for _ in range(_MAX_FILE_EXISTS_CHECK):
             # Expectation is that muscle_snapshot_directory is empty initially
             # and we succeed in the first loop. Still wrapping in a for-loop
@@ -202,13 +211,15 @@ class SnapshotManager:
             if not fpath.exists():
                 break
         else:
-            raise RuntimeError('Could not find an available filename for'
-                               f' storing the next snapshot: {fpath} already'
-                               ' exists.')
+            raise RuntimeError(
+                "Could not find an available filename for"
+                f" storing the next snapshot: {fpath} already"
+                " exists."
+            )
         # Opening with mode 'x' since a file with the same name may be created
         # in the small window between checking above and opening here. It is
         # better to fail with an error than to overwrite an existing file.
-        with fpath.open('xb') as snapshot_file:
+        with fpath.open("xb") as snapshot_file:
             snapshot_file.write(snapshot.SNAPSHOT_VERSION_BYTE)
             snapshot_file.write(snapshot.to_bytes())
         return fpath

--- a/libmuscle/python/libmuscle/test/conftest.py
+++ b/libmuscle/python/libmuscle/test/conftest.py
@@ -17,18 +17,18 @@ from libmuscle.timestamp import Timestamp
 
 @pytest.fixture
 def mocked_mmp_client():
-    with patch('libmuscle.mmp_client.TcpTransportClient') as mock_ttc:
-        yield MMPClient(Reference('component[13]'), ''), mock_ttc.return_value
+    with patch("libmuscle.mmp_client.TcpTransportClient") as mock_ttc:
+        yield MMPClient(Reference("component[13]"), ""), mock_ttc.return_value
 
 
 @pytest.fixture
 def message() -> Message:
-    return Message(0.0, None, b'test', Settings())
+    return Message(0.0, None, b"test", Settings())
 
 
 @pytest.fixture
 def message2() -> Message:
-    return Message(0.0, None, {'test': 17}, Settings())
+    return Message(0.0, None, {"test": 17}, Settings())
 
 
 @pytest.fixture
@@ -58,34 +58,41 @@ def mocked_profiler():
 
 @pytest.fixture
 def profiler_comm_int_10ms():
-    with patch('libmuscle.profiler._COMMUNICATION_INTERVAL', 0.01):
+    with patch("libmuscle.profiler._COMMUNICATION_INTERVAL", 0.01):
         yield None
 
 
 @pytest.fixture
 def declared_ports():
     return {
-            Operator.F_INIT: ['in', 'not_connected'],
-            Operator.O_I: ['out_v', 'out_r'],
-            Operator.S: ['in_v', 'in_r', 'not_connected_v'],
-            Operator.O_F: ['out']}
+        Operator.F_INIT: ["in", "not_connected"],
+        Operator.O_I: ["out_v", "out_r"],
+        Operator.S: ["in_v", "in_r", "not_connected_v"],
+        Operator.O_F: ["out"],
+    }
 
 
 @pytest.fixture
 def mock_ports():
-    in_port = Port('in', Operator.F_INIT, False, True, 0, [])
-    nc_port = Port('not_connected', Operator.F_INIT, False, False, 0, [])
-    outv_port = Port('out_v', Operator.O_I, True, True, 0, [13])
-    outr_port = Port('out_r', Operator.O_I, True, True, 0, [])
-    inv_port = Port('in_v', Operator.S, True, True, 0, [13])
-    inr_port = Port('in_r', Operator.S, True, True, 0, [])
-    ncv_port = Port('not_connected_v', Operator.S, True, False, 0, [])
-    out_port = Port('out', Operator.O_F, False, True, 0, [])
+    in_port = Port("in", Operator.F_INIT, False, True, 0, [])
+    nc_port = Port("not_connected", Operator.F_INIT, False, False, 0, [])
+    outv_port = Port("out_v", Operator.O_I, True, True, 0, [13])
+    outr_port = Port("out_r", Operator.O_I, True, True, 0, [])
+    inv_port = Port("in_v", Operator.S, True, True, 0, [13])
+    inr_port = Port("in_r", Operator.S, True, True, 0, [])
+    ncv_port = Port("not_connected_v", Operator.S, True, False, 0, [])
+    out_port = Port("out", Operator.O_F, False, True, 0, [])
 
     return {
-            'in': in_port, 'not_connected': nc_port, 'out_v': outv_port,
-            'out_r': outr_port, 'in_v': inv_port, 'in_r': inr_port,
-            'not_connected_v': ncv_port, 'out': out_port}
+        "in": in_port,
+        "not_connected": nc_port,
+        "out_v": outv_port,
+        "out_r": outr_port,
+        "in_v": inv_port,
+        "in_r": inr_port,
+        "not_connected_v": ncv_port,
+        "out": out_port,
+    }
 
 
 @pytest.fixture
@@ -117,6 +124,9 @@ def on_node_resources(node_name: str, cores: Union[int, set[int]]) -> OnNodeReso
 
 def resources(node_resources: dict[str, list[Core]]) -> Resources:
     """Helper that defines a Resources from a dict."""
-    return Resources([
-        OnNodeResources(node_name, CoreSet(cores))
-        for node_name, cores in node_resources.items()])
+    return Resources(
+        [
+            OnNodeResources(node_name, CoreSet(cores))
+            for node_name, cores in node_resources.items()
+        ]
+    )

--- a/libmuscle/python/libmuscle/test/test_api_guard.py
+++ b/libmuscle/python/libmuscle/test/test_api_guard.py
@@ -100,7 +100,7 @@ _api_guard_funs = (
     (APIGuard.save_snapshot_done, ()),
     (APIGuard.verify_should_save_final_snapshot, ()),
     (APIGuard.should_save_final_snapshot_done, (True,)),
-    (APIGuard.verify_save_final_snapshot, ())
+    (APIGuard.verify_save_final_snapshot, ()),
 )
 
 
@@ -113,7 +113,7 @@ def run_until_before(guard: APIGuard, excluded: Callable) -> None:
 
 def check_all_raise_except(guard: APIGuard, excluded: set[Callable]) -> None:
     for fun, args in _api_guard_funs:
-        if fun.__name__.startswith('verify_'):
+        if fun.__name__.startswith("verify_"):
             if fun not in excluded:
                 with pytest.raises(RuntimeError):
                     fun(guard, *args)
@@ -121,10 +121,15 @@ def check_all_raise_except(guard: APIGuard, excluded: set[Callable]) -> None:
                 fun(guard, *args)
 
 
-@pytest.mark.parametrize('fun', [
+@pytest.mark.parametrize(
+    "fun",
+    [
         APIGuard.verify_load_snapshot,
-        APIGuard.verify_should_init, APIGuard.verify_save_snapshot,
-        APIGuard.verify_save_final_snapshot])
+        APIGuard.verify_should_init,
+        APIGuard.verify_save_snapshot,
+        APIGuard.verify_save_final_snapshot,
+    ],
+)
 def test_missing_step(guard, fun):
     run_until_before(guard, fun)
     check_all_raise_except(guard, {fun})
@@ -137,9 +142,13 @@ def test_missing_resuming(guard: APIGuard):
 
 def test_missing_should_save_final(guard: APIGuard):
     run_until_before(guard, APIGuard.verify_should_save_final_snapshot)
-    check_all_raise_except(guard, {
-        APIGuard.verify_should_save_snapshot,
-        APIGuard.verify_should_save_final_snapshot})
+    check_all_raise_except(
+        guard,
+        {
+            APIGuard.verify_should_save_snapshot,
+            APIGuard.verify_should_save_final_snapshot,
+        },
+    )
 
 
 def test_double_should_save(guard: APIGuard):

--- a/libmuscle/python/libmuscle/test/test_checkpoint_triggers.py
+++ b/libmuscle/python/libmuscle/test/test_checkpoint_triggers.py
@@ -64,14 +64,14 @@ def test_range_checkpoint_trigger_default_stop():
     range = CheckpointRangeRule(start=1.0, every=1.2)
     trigger = RangeCheckpointTrigger(range)
 
-    assert trigger.next_checkpoint(-1.) == 1
-    assert trigger.previous_checkpoint(-1.) is None
+    assert trigger.next_checkpoint(-1.0) == 1
+    assert trigger.previous_checkpoint(-1.0) is None
 
-    assert trigger.next_checkpoint(148148.) == pytest.approx(148148.2)
-    assert trigger.previous_checkpoint(148148.) == pytest.approx(148147)
+    assert trigger.next_checkpoint(148148.0) == pytest.approx(148148.2)
+    assert trigger.previous_checkpoint(148148.0) == pytest.approx(148147)
 
-    assert trigger.next_checkpoint(148148148.) == pytest.approx(148148149)
-    assert trigger.previous_checkpoint(148148148.) == pytest.approx(148148147.8)
+    assert trigger.next_checkpoint(148148148.0) == pytest.approx(148148149)
+    assert trigger.previous_checkpoint(148148148.0) == pytest.approx(148148147.8)
 
 
 def test_range_checkpoint_trigger_default_start():
@@ -84,19 +84,19 @@ def test_range_checkpoint_trigger_default_start():
     assert trigger.next_checkpoint(0.0) == pytest.approx(1.2)
     assert trigger.previous_checkpoint(0.0) == pytest.approx(0.0)
 
-    assert trigger.next_checkpoint(-148148.) == pytest.approx(-148147.2)
-    assert trigger.previous_checkpoint(-148148.) == pytest.approx(-148148.4)
+    assert trigger.next_checkpoint(-148148.0) == pytest.approx(-148147.2)
+    assert trigger.previous_checkpoint(-148148.0) == pytest.approx(-148148.4)
 
 
 def test_combined_checkpoint_trigger_every_at():
     rules = [CheckpointRangeRule(every=10.0), CheckpointAtRule([3.0, 7.0, 13.0, 17.0])]
     trigger = CombinedCheckpointTriggers(rules)
 
-    assert trigger.next_checkpoint(-11.) == pytest.approx(-10)
+    assert trigger.next_checkpoint(-11.0) == pytest.approx(-10)
     assert trigger.previous_checkpoint(-11) == pytest.approx(-20)
 
-    assert trigger.next_checkpoint(0.) == pytest.approx(3)
-    assert trigger.previous_checkpoint(0.) == pytest.approx(0)
+    assert trigger.next_checkpoint(0.0) == pytest.approx(3)
+    assert trigger.previous_checkpoint(0.0) == pytest.approx(0)
 
     assert trigger.next_checkpoint(8.3) == pytest.approx(10)
     assert trigger.previous_checkpoint(8.3) == pytest.approx(7)
@@ -109,16 +109,18 @@ def test_combined_checkpoint_trigger_every_at():
 
 
 def test_combined_checkpoint_trigger_at_ranges():
-    rules = [CheckpointAtRule([3.0, 7.0, 13.0, 17.0]),
-             CheckpointRangeRule(start=0.0, every=5.0, stop=20.0),
-             CheckpointRangeRule(start=20.0, every=20.0, stop=100.0)]
+    rules = [
+        CheckpointAtRule([3.0, 7.0, 13.0, 17.0]),
+        CheckpointRangeRule(start=0.0, every=5.0, stop=20.0),
+        CheckpointRangeRule(start=20.0, every=20.0, stop=100.0),
+    ]
     trigger = CombinedCheckpointTriggers(rules)
 
-    assert trigger.next_checkpoint(-11.) == pytest.approx(0)
+    assert trigger.next_checkpoint(-11.0) == pytest.approx(0)
     assert trigger.previous_checkpoint(-11) is None
 
-    assert trigger.next_checkpoint(0.) == pytest.approx(3)
-    assert trigger.previous_checkpoint(0.) == pytest.approx(0)
+    assert trigger.next_checkpoint(0.0) == pytest.approx(3)
+    assert trigger.previous_checkpoint(0.0) == pytest.approx(0)
 
     assert trigger.next_checkpoint(8.3) == pytest.approx(10)
     assert trigger.previous_checkpoint(8.3) == pytest.approx(7)
@@ -152,10 +154,14 @@ def test_trigger_manager_reference_time():
 def test_trigger_manager():
     ref_elapsed = 0.0
     trigger_manager = TriggerManager()
-    trigger_manager.set_checkpoint_info(ref_elapsed, Checkpoints(
+    trigger_manager.set_checkpoint_info(
+        ref_elapsed,
+        Checkpoints(
             at_end=True,
             wallclock_time=[CheckpointAtRule([1e-12])],
-            simulation_time=[CheckpointAtRule([1.0, 3.0, 5.0])]))
+            simulation_time=[CheckpointAtRule([1.0, 3.0, 5.0])],
+        ),
+    )
 
     assert trigger_manager.should_save_snapshot(0.1)
     triggers = trigger_manager.get_triggers()

--- a/libmuscle/python/libmuscle/test/test_communicator.py
+++ b/libmuscle/python/libmuscle/test/test_communicator.py
@@ -17,7 +17,7 @@ def profiler():
 
 @pytest.fixture(autouse=True)
 def MPPServer():
-    with patch('libmuscle.communicator.MPPServer') as MPPServer:
+    with patch("libmuscle.communicator.MPPServer") as MPPServer:
         yield MPPServer
 
 
@@ -28,7 +28,7 @@ def mpp_server(MPPServer):
 
 @pytest.fixture
 def port_manager():
-    with patch('libmuscle.communicator.PortManager') as PortManager:
+    with patch("libmuscle.communicator.PortManager") as PortManager:
         port_manager = PortManager.return_value
         port_manager.settings_in_connected.return_value = False
         yield port_manager
@@ -36,7 +36,7 @@ def port_manager():
 
 @pytest.fixture(autouse=True)
 def MPPClient():
-    with patch('libmuscle.communicator.MPPClient') as MPPClient:
+    with patch("libmuscle.communicator.MPPClient") as MPPClient:
         yield MPPClient
 
 
@@ -47,28 +47,27 @@ def mpp_client(MPPClient):
 
 @pytest.fixture
 def communicator(connected_port_manager, profiler):
-    return Communicator(Ref('component'), [], connected_port_manager, profiler, Mock())
+    return Communicator(Ref("component"), [], connected_port_manager, profiler, Mock())
 
 
 @pytest.fixture
 def connected_communicator(communicator):
     # These work with declared_ports and connected_port_manager in conftest.py
     conduits = [
-            Conduit('peer.out', 'component.in'),
-            Conduit('peer2.out_v', 'component.in_v'),
-            Conduit('peer3.out_r', 'component.in_r'),
-            Conduit('component.out_v', 'peer2.in'),
-            Conduit('component.out_r', 'peer3.in_r'),
-            Conduit('component.out', 'peer.in')]
+        Conduit("peer.out", "component.in"),
+        Conduit("peer2.out_v", "component.in_v"),
+        Conduit("peer3.out_r", "component.in_r"),
+        Conduit("component.out_v", "peer2.in"),
+        Conduit("component.out_r", "peer3.in_r"),
+        Conduit("component.out", "peer.in"),
+    ]
 
-    peer_dims = {Ref('peer'): [], Ref('peer2'): [13], Ref('peer3'): []}
+    peer_dims = {Ref("peer"): [], Ref("peer2"): [13], Ref("peer3"): []}
 
-    peer_locations = {
-            Ref('peer'): ['tcp:peer:9001'], Ref('peer3'): ['tcp:peer3:9001']}
-    peer_locations.update({
-        Ref(f'peer2[{s}]'): ['tcp:peer2:9001'] for s in range(13)})
+    peer_locations = {Ref("peer"): ["tcp:peer:9001"], Ref("peer3"): ["tcp:peer3:9001"]}
+    peer_locations.update({Ref(f"peer2[{s}]"): ["tcp:peer2:9001"] for s in range(13)})
 
-    peer_info = PeerInfo(Ref('component'), [], conduits, peer_dims, peer_locations, [])
+    peer_info = PeerInfo(Ref("component"), [], conduits, peer_dims, peer_locations, [])
     communicator.set_peer_info(peer_info)
     return communicator
 
@@ -79,201 +78,278 @@ def test_create_communicator(communicator, mpp_server):
 
 
 def test_send_message(connected_communicator, mpp_server):
-    msg = Message(0.0, 1.0, 'Testing', Settings({'s0': 0, 's1': '1'}))
+    msg = Message(0.0, 1.0, "Testing", Settings({"s0": 0, "s1": "1"}))
 
-    connected_communicator.send_message('out_v', msg, 7, -1.0)
+    connected_communicator.send_message("out_v", msg, 7, -1.0)
 
     mpp_server.deposit.assert_called_once()
     args = mpp_server.deposit.call_args[0]
-    assert args[0] == Ref('peer2[7].in')
+    assert args[0] == Ref("peer2[7].in")
 
     encoded_msg = MPPMessage.from_bytes(args[1])
-    assert encoded_msg.sender == Ref('component.out_v[7]')
-    assert encoded_msg.receiver == Ref('peer2[7].in')
+    assert encoded_msg.sender == Ref("component.out_v[7]")
+    assert encoded_msg.receiver == Ref("peer2[7].in")
     assert encoded_msg.port_length is None
     assert encoded_msg.timestamp == 0.0
     assert encoded_msg.next_timestamp == 1.0
     assert len(encoded_msg.settings_overlay) == 2
-    assert encoded_msg.settings_overlay['s0'] == 0
-    assert encoded_msg.settings_overlay['s1'] == '1'
+    assert encoded_msg.settings_overlay["s0"] == 0
+    assert encoded_msg.settings_overlay["s1"] == "1"
     assert encoded_msg.message_number == 0
     assert encoded_msg.saved_until == -1.0
-    assert encoded_msg.data == 'Testing'
+    assert encoded_msg.data == "Testing"
 
 
 def test_send_message_disconnected(connected_communicator, mpp_server):
     msg = MagicMock()
 
-    connected_communicator.send_message('not_connected', msg)
+    connected_communicator.send_message("not_connected", msg)
 
     mpp_server.deposit.assert_not_called()
 
 
 def test_receive_message(connected_communicator, mpp_client):
     msg = MPPMessage(
-            Ref('peer.out'), Ref('component.in'), None, 2.0, 3.0,
-            Settings({'s0': '0', 's1': True}), 0, 1.0, 'Testing')
+        Ref("peer.out"),
+        Ref("component.in"),
+        None,
+        2.0,
+        3.0,
+        Settings({"s0": "0", "s1": True}),
+        0,
+        1.0,
+        "Testing",
+    )
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
     connected_communicator.set_receive_timeout(-1)
-    recv_msg, saved_until = connected_communicator.receive_message('in')
+    recv_msg, saved_until = connected_communicator.receive_message("in")
 
-    mpp_client.receive.assert_called_with(Ref('component.in'), None)
+    mpp_client.receive.assert_called_with(Ref("component.in"), None)
 
     assert recv_msg.timestamp == 2.0
     assert recv_msg.next_timestamp == 3.0
-    assert recv_msg.data == 'Testing'
+    assert recv_msg.data == "Testing"
     assert len(recv_msg.settings) == 2
-    assert recv_msg.settings['s0'] == '0'
-    assert recv_msg.settings['s1'] is True
+    assert recv_msg.settings["s0"] == "0"
+    assert recv_msg.settings["s1"] is True
     assert saved_until == 1.0
 
 
 def test_receive_message_vector(connected_communicator, mpp_client):
     msg = MPPMessage(
-            Ref('peer2.out_v'), Ref('component.in_v'), 5, 4.0, 6.0,
-            Settings({'s0': [0.0], 's1': 1.0}), 0, 3.5, 'Testing2')
+        Ref("peer2.out_v"),
+        Ref("component.in_v"),
+        5,
+        4.0,
+        6.0,
+        Settings({"s0": [0.0], "s1": 1.0}),
+        0,
+        3.5,
+        "Testing2",
+    )
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
     connected_communicator.set_receive_timeout(-1)
-    recv_msg, saved_until = connected_communicator.receive_message('in_v', 5)
+    recv_msg, saved_until = connected_communicator.receive_message("in_v", 5)
 
-    mpp_client.receive.assert_called_with(Ref('component.in_v[5]'), None)
+    mpp_client.receive.assert_called_with(Ref("component.in_v[5]"), None)
 
     assert recv_msg.timestamp == 4.0
     assert recv_msg.next_timestamp == 6.0
-    assert recv_msg.data == 'Testing2'
+    assert recv_msg.data == "Testing2"
     assert len(recv_msg.settings) == 2
-    assert recv_msg.settings['s0'] == [0.0]
-    assert recv_msg.settings['s1'] == 1.0
+    assert recv_msg.settings["s0"] == [0.0]
+    assert recv_msg.settings["s1"] == 1.0
     assert saved_until == 3.5
 
 
 def test_receive_close_port(connected_communicator, mpp_client, port_manager):
     msg = MPPMessage(
-            Ref('peer.out'), Ref('component.in'), None, float('inf'), None,
-            Settings(), 0, 0.1, ClosePort())
+        Ref("peer.out"),
+        Ref("component.in"),
+        None,
+        float("inf"),
+        None,
+        Settings(),
+        0,
+        0.1,
+        ClosePort(),
+    )
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
-    recv_msg, saved_until = connected_communicator.receive_message('in')
+    recv_msg, saved_until = connected_communicator.receive_message("in")
 
-    assert port_manager.get_port('in').is_open() is False
+    assert port_manager.get_port("in").is_open() is False
 
 
 def test_receive_close_port_vector(connected_communicator, mpp_client, port_manager):
     msg = MPPMessage(
-            Ref('peer2.out_v'), Ref('component.in_v'), 5, float('inf'), None,
-            Settings(), 0, 3.5, ClosePort())
+        Ref("peer2.out_v"),
+        Ref("component.in_v"),
+        5,
+        float("inf"),
+        None,
+        Settings(),
+        0,
+        3.5,
+        ClosePort(),
+    )
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
-    recv_msg, saved_until = connected_communicator.receive_message('in_v', 5)
+    recv_msg, saved_until = connected_communicator.receive_message("in_v", 5)
 
-    assert port_manager.get_port('in_v').is_open(5) is False
+    assert port_manager.get_port("in_v").is_open(5) is False
 
 
 def test_port_count_validation(
-        connected_communicator, mpp_client, connected_port_manager):
+    connected_communicator, mpp_client, connected_port_manager
+):
 
     msg = MPPMessage(
-            Ref('peer.out'), Ref('component.in'),
-            None, 0.0, None, Settings({'test1': 12}), 0, 7.6,
-            b'test')
+        Ref("peer.out"),
+        Ref("component.in"),
+        None,
+        0.0,
+        None,
+        Settings({"test1": 12}),
+        0,
+        7.6,
+        b"test",
+    )
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
-    connected_communicator.receive_message('in')
-    assert connected_port_manager.get_port('in').get_message_counts() == [1]
+    connected_communicator.receive_message("in")
+    assert connected_port_manager.get_port("in").get_message_counts() == [1]
 
     with pytest.raises(RuntimeError):
         # the message received has message_number = 0 again
-        connected_communicator.receive_message('in')
+        connected_communicator.receive_message("in")
 
 
 def test_port_discard_error_on_resume(
-        caplog, connected_communicator, mpp_client, connected_port_manager):
+    caplog, connected_communicator, mpp_client, connected_port_manager
+):
 
     msg = MPPMessage(
-            Ref('other.out[13]'), Ref('kernel[13].in'),
-            None, 0.0, None, Settings({'test1': 12}), 1, 2.3,
-            b'test')
+        Ref("other.out[13]"),
+        Ref("kernel[13].in"),
+        None,
+        0.0,
+        None,
+        Settings({"test1": 12}),
+        1,
+        2.3,
+        b"test",
+    )
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
-    connected_port_manager.get_port('out').restore_message_counts([0])
-    connected_port_manager.get_port('in').restore_message_counts([2])
+    connected_port_manager.get_port("out").restore_message_counts([0])
+    connected_port_manager.get_port("in").restore_message_counts([2])
 
-    for port in ('out', 'in'):
+    for port in ("out", "in"):
         assert connected_port_manager.get_port(port)._is_resuming == [True]
         assert connected_port_manager.get_port(port).is_resuming(None)
 
     # In the next block, the first message with message_number=1 is discarded.
     # The RuntimeError is raised when 'receiving' the second message with
     # message_number=1
-    with caplog.at_level(logging.DEBUG, 'libmuscle.communicator'):
+    with caplog.at_level(logging.DEBUG, "libmuscle.communicator"):
         with pytest.raises(RuntimeError):
-            connected_communicator.receive_message('in')
+            connected_communicator.receive_message("in")
 
-        assert any([
-            'Discarding received message' in rec.message
-            for rec in caplog.records])
+        assert any(
+            ["Discarding received message" in rec.message for rec in caplog.records]
+        )
 
 
 def test_port_discard_success_on_resume(
-        caplog, connected_communicator, mpp_client, connected_port_manager):
+    caplog, connected_communicator, mpp_client, connected_port_manager
+):
 
-    side_effect = [(MPPMessage(
-            Ref('other.out[13]'), Ref('kernel[13].in'),
-            None, 0.0, None, Settings({'test1': 12}), message_number, 1.0,
-            {'this is message': message_number}).encoded(), MagicMock())
-            for message_number in [1, 2]]
+    side_effect = [
+        (
+            MPPMessage(
+                Ref("other.out[13]"),
+                Ref("kernel[13].in"),
+                None,
+                0.0,
+                None,
+                Settings({"test1": 12}),
+                message_number,
+                1.0,
+                {"this is message": message_number},
+            ).encoded(),
+            MagicMock(),
+        )
+        for message_number in [1, 2]
+    ]
 
     mpp_client.receive.side_effect = side_effect
 
-    connected_port_manager.get_port('out').restore_message_counts([0])
-    connected_port_manager.get_port('in').restore_message_counts([2])
+    connected_port_manager.get_port("out").restore_message_counts([0])
+    connected_port_manager.get_port("in").restore_message_counts([2])
 
-    for port in ('out', 'in'):
+    for port in ("out", "in"):
         assert connected_port_manager.get_port(port)._is_resuming == [True]
         assert connected_port_manager.get_port(port).is_resuming(None)
 
-    with caplog.at_level(logging.DEBUG, 'libmuscle.communicator'):
-        msg, _ = connected_communicator.receive_message('in')
-        assert any([
-            'Discarding received message' in rec.message
-            for rec in caplog.records])
+    with caplog.at_level(logging.DEBUG, "libmuscle.communicator"):
+        msg, _ = connected_communicator.receive_message("in")
+        assert any(
+            ["Discarding received message" in rec.message for rec in caplog.records]
+        )
 
     # message_number=1 should have been discarded:
-    assert msg.data == {'this is message': 2}
-    assert connected_communicator._port_manager.get_port(
-            'in').get_message_counts() == [3]
+    assert msg.data == {"this is message": 2}
+    assert connected_communicator._port_manager.get_port("in").get_message_counts() == [
+        3
+    ]
 
 
 def test_shutdown(
-        connected_communicator, mpp_client, connected_port_manager, mpp_server):
+    connected_communicator, mpp_client, connected_port_manager, mpp_server
+):
 
     msg = MPPMessage(
-            Ref('peer.out'), Ref('component.in'), None, float('inf'), None,
-            Settings(), 0, 0.0, ClosePort())
+        Ref("peer.out"),
+        Ref("component.in"),
+        None,
+        float("inf"),
+        None,
+        Settings(),
+        0,
+        0.0,
+        ClosePort(),
+    )
 
-    messages = {Ref('component.in'): msg}
+    messages = {Ref("component.in"): msg}
 
-    port_sender = {
-            'in_v': 'peer2[x].out_v',
-            'in_r': 'peer3.out_r[x]'}
+    port_sender = {"in_v": "peer2[x].out_v", "in_r": "peer3.out_r[x]"}
 
     for port_name, snd in port_sender.items():
         port = connected_port_manager.get_port(port_name)
         for slot in range(port.get_length()):
-            sender = Ref(snd.replace('x', str(slot)))
-            receiver = Ref(f'component.{port_name}[{slot}]')
+            sender = Ref(snd.replace("x", str(slot)))
+            receiver = Ref(f"component.{port_name}[{slot}]")
 
             messages[receiver] = MPPMessage(
-                    sender, receiver, slot, float('inf'), None,
-                    Settings(), 0, 3.5, ClosePort())
+                sender,
+                receiver,
+                slot,
+                float("inf"),
+                None,
+                Settings(),
+                0,
+                3.5,
+                ClosePort(),
+            )
 
     def receive(receiver, timeout_handler):
         return messages[receiver].encoded(), MagicMock()
@@ -283,15 +359,16 @@ def test_shutdown(
     connected_communicator.shutdown()
 
     expected_receivers = (
-            {Ref('peer.in')} |
-            {
-                Ref(f'peer2[{slot}].in')
-                for slot in range(
-                    connected_port_manager.get_port('out_v').get_length())} |
-            {
-                Ref(f'peer3.in[{slot}]')
-                for slot in range(
-                    connected_port_manager.get_port('out_r').get_length())})
+        {Ref("peer.in")}
+        | {
+            Ref(f"peer2[{slot}].in")
+            for slot in range(connected_port_manager.get_port("out_v").get_length())
+        }
+        | {
+            Ref(f"peer3.in[{slot}]")
+            for slot in range(connected_port_manager.get_port("out_r").get_length())
+        }
+    )
 
     for call in mpp_server.deposit.call_args_list:
         assert call[0][0] in expected_receivers

--- a/libmuscle/python/libmuscle/test/test_grid.py
+++ b/libmuscle/python/libmuscle/test/test_grid.py
@@ -7,10 +7,10 @@ from libmuscle.grid import Grid
 def test_grid() -> None:
     a = np.array([[1, 2, 3], [4, 5, 6]])
     _ = Grid(a)
-    _ = Grid(a, ['x', 'y'])
+    _ = Grid(a, ["x", "y"])
 
     with pytest.raises(ValueError):
-        _ = Grid(a, ['x'])
+        _ = Grid(a, ["x"])
 
     with pytest.raises(ValueError):
-        _ = Grid(a, ['x', 'y', 'z'])
+        _ = Grid(a, ["x", "y", "z"])

--- a/libmuscle/python/libmuscle/test/test_instance.py
+++ b/libmuscle/python/libmuscle/test/test_instance.py
@@ -13,20 +13,24 @@ from libmuscle.peer_info import PeerInfo
 
 @pytest.fixture
 def logger():
-    with patch('libmuscle.instance._logger') as logger:
+    with patch("libmuscle.instance._logger") as logger:
         yield logger
 
 
 @pytest.fixture(autouse=True)
 def MMPClient():
-    with patch('libmuscle.instance.MMPClient') as MMPClient:
+    with patch("libmuscle.instance.MMPClient") as MMPClient:
         mmp_client = MMPClient.return_value
-        mmp_client.request_peers.return_value = PeerInfo(*[MagicMock()]*6)
+        mmp_client.request_peers.return_value = PeerInfo(*[MagicMock()] * 6)
 
         checkpoints = MagicMock()
         checkpoints.__bool__.return_value = False
         mmp_client.get_checkpoint_info.return_value = [
-                MagicMock(), checkpoints, MagicMock(), MagicMock()]
+            MagicMock(),
+            checkpoints,
+            MagicMock(),
+            MagicMock(),
+        ]
         yield MMPClient
 
 
@@ -37,19 +41,19 @@ def mmp_client(MMPClient):
 
 @pytest.fixture
 def api_guard():
-    with patch('libmuscle.instance.APIGuard') as APIGuard:
+    with patch("libmuscle.instance.APIGuard") as APIGuard:
         yield APIGuard.return_value
 
 
 @pytest.fixture
 def profiler():
-    with patch('libmuscle.instance.Profiler') as Profiler:
+    with patch("libmuscle.instance.Profiler") as Profiler:
         yield Profiler.return_value
 
 
 @pytest.fixture
 def port_manager():
-    with patch('libmuscle.instance.PortManager') as PortManager:
+    with patch("libmuscle.instance.PortManager") as PortManager:
         port_manager = PortManager.return_value
         port_manager.settings_in_connected.return_value = False
         yield port_manager
@@ -57,13 +61,13 @@ def port_manager():
 
 @pytest.fixture
 def communicator():
-    with patch('libmuscle.instance.Communicator') as Communicator:
+    with patch("libmuscle.instance.Communicator") as Communicator:
         yield Communicator.return_value
 
 
 @pytest.fixture
 def settings_manager():
-    with patch('libmuscle.instance.SettingsManager') as SettingsManager:
+    with patch("libmuscle.instance.SettingsManager") as SettingsManager:
         settings_manager = SettingsManager.return_value
         # Emulate no settings available
         settings_manager.get_setting.side_effect = KeyError()
@@ -72,7 +76,7 @@ def settings_manager():
 
 @pytest.fixture(autouse=True)
 def snapshot_manager():
-    with patch('libmuscle.instance.SnapshotManager') as SnapshotManager:
+    with patch("libmuscle.instance.SnapshotManager") as SnapshotManager:
         yield SnapshotManager.return_value
 
 
@@ -86,94 +90,125 @@ def no_resume_snapshot_manager(snapshot_manager):
 
 @pytest.fixture(autouse=True)
 def trigger_manager():
-    with patch('libmuscle.instance.TriggerManager') as TriggerManager:
+    with patch("libmuscle.instance.TriggerManager") as TriggerManager:
         yield TriggerManager.return_value
 
 
 @pytest.fixture
 def sys_argv():
-    with patch('libmuscle.instance.sys.argv', []) as sys_argv:
+    with patch("libmuscle.instance.sys.argv", []) as sys_argv:
         yield sys_argv
 
 
 @pytest.fixture
 def manager_location_argv(sys_argv):
-    sys_argv.extend(['--test', '--muscle-manager=tcp:localhost:9001', 'bla'])
+    sys_argv.extend(["--test", "--muscle-manager=tcp:localhost:9001", "bla"])
     yield None
 
 
 @pytest.fixture
 def instance_argv(sys_argv):
-    sys_argv.extend(['distraction', '--muscle-instance=component'])
+    sys_argv.extend(["distraction", "--muscle-instance=component"])
     yield None
 
 
 @pytest.fixture
 def os_environ():
-    with patch('libmuscle.instance.os.environ', {}) as os_environ:
+    with patch("libmuscle.instance.os.environ", {}) as os_environ:
         yield os_environ
 
 
 @pytest.fixture
 def manager_location_envvar(os_environ):
-    os_environ['MUSCLE_MANAGER'] = 'tcp:localhost:9002'
+    os_environ["MUSCLE_MANAGER"] = "tcp:localhost:9002"
     yield None
 
 
 @pytest.fixture
 def instance_envvar(os_environ):
-    os_environ['MUSCLE_INSTANCE'] = 'component[13]'
+    os_environ["MUSCLE_INSTANCE"] = "component[13]"
     yield None
 
 
 @pytest.fixture
 def instance(
-        logger, MMPClient, mmp_client, api_guard, profiler, connected_port_manager,
-        communicator, settings_manager, no_resume_snapshot_manager, trigger_manager,
-        manager_location_argv, instance_argv, declared_ports):
+    logger,
+    MMPClient,
+    mmp_client,
+    api_guard,
+    profiler,
+    connected_port_manager,
+    communicator,
+    settings_manager,
+    no_resume_snapshot_manager,
+    trigger_manager,
+    manager_location_argv,
+    instance_argv,
+    declared_ports,
+):
 
     return Instance(declared_ports)
 
 
 @pytest.fixture
 def instance_dont_apply_overlay(
-        logger, MMPClient, mmp_client, api_guard, profiler, connected_port_manager,
-        communicator, settings_manager, no_resume_snapshot_manager, trigger_manager,
-        manager_location_argv, instance_argv, declared_ports):
+    logger,
+    MMPClient,
+    mmp_client,
+    api_guard,
+    profiler,
+    connected_port_manager,
+    communicator,
+    settings_manager,
+    no_resume_snapshot_manager,
+    trigger_manager,
+    manager_location_argv,
+    instance_argv,
+    declared_ports,
+):
 
     return Instance(declared_ports, InstanceFlags.DONT_APPLY_OVERLAY)
 
 
 def test_create_instance_manager_location_default(
-        instance_argv, MMPClient, declared_ports):
+    instance_argv, MMPClient, declared_ports
+):
 
     instance = Instance(declared_ports)
     instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
-    MMPClient.assert_called_once_with(Ref('component'), 'tcp:localhost:9000')
+    MMPClient.assert_called_once_with(Ref("component"), "tcp:localhost:9000")
 
 
 def test_create_instance_manager_location_argv(
-        manager_location_argv, instance_argv, MMPClient, declared_ports):
+    manager_location_argv, instance_argv, MMPClient, declared_ports
+):
 
     instance = Instance(declared_ports)
     instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
-    MMPClient.assert_called_once_with(Ref('component'), 'tcp:localhost:9001')
+    MMPClient.assert_called_once_with(Ref("component"), "tcp:localhost:9001")
 
 
 def test_create_instance_manager_location_envvar(
-        manager_location_envvar, instance_envvar, MMPClient, declared_ports):
+    manager_location_envvar, instance_envvar, MMPClient, declared_ports
+):
 
     instance = Instance(declared_ports)
     instance.error_shutdown("")  # ensure all threads and resources are cleaned up
 
-    MMPClient.assert_called_once_with(Ref('component[13]'), 'tcp:localhost:9002')
+    MMPClient.assert_called_once_with(Ref("component[13]"), "tcp:localhost:9002")
 
 
 def test_create_instance_registration(
-        manager_location_argv, instance_argv, mmp_client, communicator, port_manager,
-        profiler, declared_ports):
+    manager_location_argv,
+    instance_argv,
+    mmp_client,
+    communicator,
+    port_manager,
+    profiler,
+    declared_ports,
+):
 
     instance = Instance(declared_ports)
     instance.error_shutdown("")  # ensure all threads and resources are cleaned up
@@ -183,26 +218,27 @@ def test_create_instance_registration(
     mmp_client.register_instance.assert_called_once()
     assert mmp_client.register_instance.call_args[0][0] == locations
     port_desc = mmp_client.register_instance.call_args[0][1]
-    assert port_desc[0].name == 'in'
+    assert port_desc[0].name == "in"
     assert port_desc[0].operator == Operator.F_INIT
-    assert port_desc[1].name == 'not_connected'
+    assert port_desc[1].name == "not_connected"
     assert port_desc[1].operator == Operator.F_INIT
-    assert port_desc[2].name == 'out_v'
+    assert port_desc[2].name == "out_v"
     assert port_desc[2].operator == Operator.O_I
-    assert port_desc[3].name == 'out_r'
+    assert port_desc[3].name == "out_r"
     assert port_desc[3].operator == Operator.O_I
-    assert port_desc[4].name == 'in_v'
+    assert port_desc[4].name == "in_v"
     assert port_desc[4].operator == Operator.S
-    assert port_desc[5].name == 'in_r'
+    assert port_desc[5].name == "in_r"
     assert port_desc[5].operator == Operator.S
-    assert port_desc[6].name == 'not_connected_v'
+    assert port_desc[6].name == "not_connected_v"
     assert port_desc[6].operator == Operator.S
-    assert port_desc[7].name == 'out'
+    assert port_desc[7].name == "out"
     assert port_desc[7].operator == Operator.O_F
 
 
 def test_create_instance_profiling(
-        manager_location_argv, instance_argv, profiler, declared_ports):
+    manager_location_argv, instance_argv, profiler, declared_ports
+):
 
     instance = Instance(declared_ports)
 
@@ -211,8 +247,14 @@ def test_create_instance_profiling(
 
 
 def test_create_instance_connecting(
-        manager_location_argv, instance_argv, mmp_client, port_manager, communicator,
-        settings_manager, declared_ports):
+    manager_location_argv,
+    instance_argv,
+    mmp_client,
+    port_manager,
+    communicator,
+    settings_manager,
+    declared_ports,
+):
     peer_info = MagicMock()
     mmp_client.request_peers.return_value = peer_info
 
@@ -228,28 +270,37 @@ def test_create_instance_connecting(
 
 
 def test_create_instance_set_up_checkpointing(
-        manager_location_argv, instance_argv, mmp_client, trigger_manager,
-        no_resume_snapshot_manager, settings_manager, declared_ports):
+    manager_location_argv,
+    instance_argv,
+    mmp_client,
+    trigger_manager,
+    no_resume_snapshot_manager,
+    settings_manager,
+    declared_ports,
+):
 
     instance = Instance(declared_ports)
 
     elapsed_time, checkpoints, resume_path, snapshot_path = (
-            mmp_client.get_checkpoint_info.return_value)
+        mmp_client.get_checkpoint_info.return_value
+    )
 
     trigger_manager.set_checkpoint_info.assert_called_with(elapsed_time, checkpoints)
     no_resume_snapshot_manager.prepare_resume.assert_called_with(
-            resume_path, snapshot_path)
+        resume_path, snapshot_path
+    )
     assert settings_manager.overlay != no_resume_snapshot_manager.resume_overlay
     instance.error_shutdown("Ensure all threads and resources are cleaned up")
 
 
 def test_create_instance_set_up_logging(
-        manager_location_argv, instance_argv, settings_manager, declared_ports):
+    manager_location_argv, instance_argv, settings_manager, declared_ports
+):
 
     def get_setting(instance, name, typ, default=None):
-        return {
-                'muscle_local_log_level': 'debug',
-                'muscle_remote_log_level': 'error'}[str(name)]
+        return {"muscle_local_log_level": "debug", "muscle_remote_log_level": "error"}[
+            str(name)
+        ]
 
     settings_manager.get_setting = get_setting
 
@@ -258,13 +309,12 @@ def test_create_instance_set_up_logging(
     libmuscle_logger = MagicMock()
     ymmsl_logger = MagicMock()
 
-    def get_logger(name=''):
-        return {
-                '': root_logger,
-                'libmuscle': libmuscle_logger,
-                'ymmsl': ymmsl_logger}[name]
+    def get_logger(name=""):
+        return {"": root_logger, "libmuscle": libmuscle_logger, "ymmsl": ymmsl_logger}[
+            name
+        ]
 
-    with patch('libmuscle.instance.logging.getLogger', get_logger):
+    with patch("libmuscle.instance.logging.getLogger", get_logger):
         instance = Instance(declared_ports)
 
         assert instance._mmp_handler.level == logging.ERROR
@@ -274,10 +324,9 @@ def test_create_instance_set_up_logging(
     instance.error_shutdown("Ensure all threads and resources are cleaned up")
 
 
-def test_shutdown_instance(
-        logger, instance, mmp_client, communicator, profiler):
+def test_shutdown_instance(logger, instance, mmp_client, communicator, profiler):
 
-    msg = 'Testing'
+    msg = "Testing"
     num_profile_events = len(profiler.record_event.mock_calls)
 
     instance.error_shutdown(msg)
@@ -294,31 +343,32 @@ def test_shutdown_instance(
 
 def test_list_settings(instance, settings_manager):
     instance.list_settings()
-    settings_manager.list_settings.assert_called_with(Ref('component'))
+    settings_manager.list_settings.assert_called_with(Ref("component"))
 
 
 def test_get_setting(instance, settings_manager):
     settings_manager.get_setting.side_effect = None  # don't raise KeyError
-    instance.get_setting('test', 'int')
+    instance.get_setting("test", "int")
     settings_manager.get_setting.assert_called_with(
-        Ref('component'), Ref('test'), 'int')
+        Ref("component"), Ref("test"), "int"
+    )
 
 
 def test_get_setting_with_default(instance, settings_manager):
     settings_manager.get_setting.side_effect = None  # don't raise KeyError
-    settings_manager.get_setting.return_value = 'default_value'
-    result = instance.get_setting('test', default='default_value')
-    settings_manager.get_setting.assert_called_with(
-        Ref('component'), Ref('test'), None)
-    assert result == 'default_value'
+    settings_manager.get_setting.return_value = "default_value"
+    result = instance.get_setting("test", default="default_value")
+    settings_manager.get_setting.assert_called_with(Ref("component"), Ref("test"), None)
+    assert result == "default_value"
 
 
 def test_get_setting_with_default_and_type(instance, settings_manager):
     settings_manager.get_setting.side_effect = None  # don't raise KeyError
     settings_manager.get_setting.return_value = 42
-    result = instance.get_setting('test', 'int', default=0)
+    result = instance.get_setting("test", "int", default=0)
     settings_manager.get_setting.assert_called_with(
-        Ref('component'), Ref('test'), 'int')
+        Ref("component"), Ref("test"), "int"
+    )
     assert result == 42
 
 
@@ -330,67 +380,68 @@ def test_list_ports(instance, port_manager):
 
 
 def test_is_connected(instance):
-    assert instance.is_connected('in') is True
-    assert instance.is_connected('not_connected') is False
-    assert instance.is_connected('out_v') is True
-    assert instance.is_connected('out_r') is True
-    assert instance.is_connected('in_v') is True
-    assert instance.is_connected('in_r') is True
-    assert instance.is_connected('not_connected_v') is False
-    assert instance.is_connected('out') is True
+    assert instance.is_connected("in") is True
+    assert instance.is_connected("not_connected") is False
+    assert instance.is_connected("out_v") is True
+    assert instance.is_connected("out_r") is True
+    assert instance.is_connected("in_v") is True
+    assert instance.is_connected("in_r") is True
+    assert instance.is_connected("not_connected_v") is False
+    assert instance.is_connected("out") is True
 
 
 def test_is_vector_port(instance):
-    assert instance.is_vector_port('in') is False
-    assert instance.is_vector_port('not_connected') is False
-    assert instance.is_vector_port('out_v') is True
-    assert instance.is_vector_port('out_r') is True
-    assert instance.is_vector_port('in_v') is True
-    assert instance.is_vector_port('in_r') is True
-    assert instance.is_vector_port('not_connected_v') is True
-    assert instance.is_vector_port('out') is False
+    assert instance.is_vector_port("in") is False
+    assert instance.is_vector_port("not_connected") is False
+    assert instance.is_vector_port("out_v") is True
+    assert instance.is_vector_port("out_r") is True
+    assert instance.is_vector_port("in_v") is True
+    assert instance.is_vector_port("in_r") is True
+    assert instance.is_vector_port("not_connected_v") is True
+    assert instance.is_vector_port("out") is False
 
 
 def test_is_resizable(instance):
-    for port in ('in', 'not_connected', 'out_v', 'in_v', 'out'):
+    for port in ("in", "not_connected", "out_v", "in_v", "out"):
         assert instance.is_resizable(port) is False
 
-    assert instance.is_resizable('out_r') is True
-    assert instance.is_resizable('in_r') is True
-    assert instance.is_resizable('not_connected_v') is True
+    assert instance.is_resizable("out_r") is True
+    assert instance.is_resizable("in_r") is True
+    assert instance.is_resizable("not_connected_v") is True
 
 
 def test_get_port_length(instance):
-    assert instance.get_port_length('out_v') == 13
-    assert instance.get_port_length('out_r') == 0
-    assert instance.get_port_length('in_v') == 13
-    assert instance.get_port_length('in_r') == 0
+    assert instance.get_port_length("out_v") == 13
+    assert instance.get_port_length("out_r") == 0
+    assert instance.get_port_length("in_v") == 13
+    assert instance.get_port_length("in_r") == 0
 
 
 def test_set_port_length(instance, port_manager):
-    instance.set_port_length('not_connected_v', 7)
-    assert port_manager.get_port('not_connected_v').get_length() == 7
+    instance.set_port_length("not_connected_v", 7)
+    assert port_manager.get_port("not_connected_v").get_length() == 7
 
 
 def test_reuse_set_overlay(
-        instance, port_manager, mock_ports, communicator, settings_manager):
+    instance, port_manager, mock_ports, communicator, settings_manager
+):
     port_manager.settings_in_connected.return_value = True
-    mock_ports['in']._is_connected = False
+    mock_ports["in"]._is_connected = False
 
     mock_msg = MagicMock()
-    mock_msg.data = Settings({'s1': 1, 's2': 2})
-    mock_msg.settings = Settings({'s0': 0})
+    mock_msg.data = Settings({"s1": 1, "s2": 2})
+    mock_msg.settings = Settings({"s0": 0})
     communicator.receive_message.return_value = mock_msg, 0.0
 
     instance.reuse_instance()
 
-    communicator.receive_message.assert_called_with('muscle_settings_in')
-    assert settings_manager.overlay['s0'] == 0
-    assert settings_manager.overlay['s1'] == 1
-    assert settings_manager.overlay['s2'] == 2
+    communicator.receive_message.assert_called_with("muscle_settings_in")
+    assert settings_manager.overlay["s0"] == 0
+    assert settings_manager.overlay["s1"] == 1
+    assert settings_manager.overlay["s2"] == 2
 
 
-@pytest.mark.parametrize('closed_port', ['muscle_settings_in', 'in'])
+@pytest.mark.parametrize("closed_port", ["muscle_settings_in", "in"])
 def test_reuse_closed_port(instance, port_manager, communicator, closed_port):
 
     def receive_message(port, slot=None, default=None):
@@ -408,7 +459,7 @@ def test_reuse_closed_port(instance, port_manager, communicator, closed_port):
 
 
 def test_reuse_f_init_vector_port(instance, port_manager, communicator):
-    port_manager.get_port('in')._length = 10
+    port_manager.get_port("in")._length = 10
 
     def receive_message(port, slot=None, default=None):
         mock_msg = MagicMock()
@@ -428,7 +479,7 @@ def test_reuse_no_f_init_ports(instance, connected_port_manager, communicator):
 
 
 def test_send_message(instance, settings_manager, communicator):
-    port = 'out_v'
+    port = "out_v"
     msg = MagicMock()
     msg.settings = None
     slot = 3
@@ -444,15 +495,15 @@ def test_send_message(instance, settings_manager, communicator):
 
 def test_send_on_invalid_port(instance):
     with pytest.raises(RuntimeError):
-        instance.send('does_not_exist', MagicMock())
+        instance.send("does_not_exist", MagicMock())
 
 
 def test_send_after_resize(instance, message):
     with pytest.raises(RuntimeError):
-        instance.send('out_r', message, 13)
+        instance.send("out_r", message, 13)
 
-    instance.set_port_length('out_r', 20)
-    instance.send('out_r', message, 13)
+    instance.set_port_length("out_r", 20)
+    instance.send("out_r", message, 13)
 
 
 def test_send_on_receiving_port(instance, message):
@@ -462,7 +513,7 @@ def test_send_on_receiving_port(instance, message):
 
 def test_receive_on_invalid_port(instance):
     with pytest.raises(RuntimeError):
-        instance.receive('does_not_exist')
+        instance.receive("does_not_exist")
 
 
 def test_receive_on_sending_port(instance):
@@ -477,7 +528,7 @@ def test_receive_f_init(instance, port_manager, communicator):
 
     instance.reuse_instance()
 
-    msg = instance.receive('in')
+    msg = instance.receive("in")
 
     assert msg == mock_msg
 
@@ -485,7 +536,7 @@ def test_receive_f_init(instance, port_manager, communicator):
 def test_receive_default_f_init(instance):
     default_msg = MagicMock()
 
-    msg = instance.receive('not_connected', default=default_msg)
+    msg = instance.receive("not_connected", default=default_msg)
 
     assert msg == default_msg
 
@@ -493,30 +544,31 @@ def test_receive_default_f_init(instance):
 def test_receive_default(instance):
     default_msg = MagicMock()
 
-    msg = instance.receive('not_connected_v', 42, default_msg)
+    msg = instance.receive("not_connected_v", 42, default_msg)
 
     assert msg == default_msg
 
 
 def test_receive_no_default(instance):
     with pytest.raises(RuntimeError):
-        instance.receive('not_connected')
+        instance.receive("not_connected")
 
     with pytest.raises(RuntimeError):
-        instance.receive('not_connected_v', 14)
+        instance.receive("not_connected_v", 14)
 
 
 def test_receive_inconsistent_settings(
-        instance, settings_manager, port_manager, communicator):
+    instance, settings_manager, port_manager, communicator
+):
 
     def receive_message(port, slot=None):
         mock_msg = MagicMock()
-        if port == 'muscle_settings_in':
-            mock_msg.data = Settings({'s1': 1})
+        if port == "muscle_settings_in":
+            mock_msg.data = Settings({"s1": 1})
             mock_msg.settings = Settings()
         else:
             mock_msg.data = None
-            mock_msg.settings = Settings({'s0': 0})
+            mock_msg.settings = Settings({"s0": 0})
         return mock_msg, 0.0
 
     communicator.receive_message.side_effect = receive_message
@@ -528,44 +580,49 @@ def test_receive_inconsistent_settings(
 
 
 def test_receive_with_settings(
-        instance_dont_apply_overlay, settings_manager, communicator):
+    instance_dont_apply_overlay, settings_manager, communicator
+):
 
     mock_msg = MagicMock()
-    mock_msg.settings = Settings({'s0': 0, 's1': 1})
+    mock_msg.settings = Settings({"s0": 0, "s1": 1})
     communicator.receive_message.return_value = mock_msg, 0.0
 
     instance_dont_apply_overlay.reuse_instance()
-    msg = instance_dont_apply_overlay.receive('in')
+    msg = instance_dont_apply_overlay.receive("in")
 
-    assert msg.settings['s0'] == 0
-    assert msg.settings['s1'] == 1
+    assert msg.settings["s0"] == 0
+    assert msg.settings["s1"] == 1
 
     assert len(settings_manager.overlay) == 0
 
 
 def test_receive_with_settings_default(
-        instance_dont_apply_overlay, settings_manager, port_manager, communicator):
+    instance_dont_apply_overlay, settings_manager, port_manager, communicator
+):
 
-    port_manager.get_port('in')._is_connected = False
+    port_manager.get_port("in")._is_connected = False
 
     instance_dont_apply_overlay.reuse_instance()
 
     default_msg = MagicMock()
     default_msg.settings = MagicMock()
-    msg = instance_dont_apply_overlay.receive('in', default=default_msg)
+    msg = instance_dont_apply_overlay.receive("in", default=default_msg)
 
     assert msg == default_msg
     assert msg.settings == default_msg.settings
     assert len(settings_manager.overlay) == 0
 
 
-@pytest.mark.parametrize('flags, expectation', [
+@pytest.mark.parametrize(
+    "flags, expectation",
+    [
         (InstanceFlags(0), pytest.raises(RuntimeError)),
         (InstanceFlags.USES_CHECKPOINT_API, does_not_raise()),
         (InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE, does_not_raise()),
-        (InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE, does_not_raise())])
-def test_checkpoint_support(
-        instance_argv, mmp_client, tmp_path, flags, expectation):
+        (InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE, does_not_raise()),
+    ],
+)
+def test_checkpoint_support(instance_argv, mmp_client, tmp_path, flags, expectation):
 
     checkpoint_info = (0.0, Checkpoints(at_end=True), None, tmp_path)
     mmp_client.get_checkpoint_info.return_value = checkpoint_info

--- a/libmuscle/python/libmuscle/test/test_mmp_client.py
+++ b/libmuscle/python/libmuscle/test/test_mmp_client.py
@@ -11,34 +11,31 @@ from libmuscle.mmp_client import MMPClient
 
 
 def test_init() -> None:
-    with patch('libmuscle.mmp_client.TcpTransportClient') as mock_ttc:
+    with patch("libmuscle.mmp_client.TcpTransportClient") as mock_ttc:
         stub = mock_ttc.return_value
-        client = MMPClient(Reference([]), '')
-        assert client._transport_client == stub     # type: ignore
+        client = MMPClient(Reference([]), "")
+        assert client._transport_client == stub  # type: ignore
 
 
 def test_connection_fail() -> None:
-    ttc = 'libmuscle.mcp.tcp_transport_client'
-    with patch(f'{ttc}._CONNECT_TIMEOUT', 0.1):
-        with patch(f'{ttc}.RECONNECT_TIMEOUT', 0.5):
+    ttc = "libmuscle.mcp.tcp_transport_client"
+    with patch(f"{ttc}._CONNECT_TIMEOUT", 0.1):
+        with patch(f"{ttc}.RECONNECT_TIMEOUT", 0.5):
             with pytest.raises(ConnectionError):
                 # Port 255 is reserved and privileged, so there's probably
                 # nothing there.
-                client = MMPClient(Reference([]), 'tcp:localhost:255')
+                client = MMPClient(Reference([]), "tcp:localhost:255")
                 client.get_settings()
 
 
 def test_submit_log_message(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
     result = [ResponseType.SUCCESS.value]
-    stub.call.return_value = (
-            msgpack.packb(result, use_bin_type=True), profile_data)
+    stub.call.return_value = (msgpack.packb(result, use_bin_type=True), profile_data)
 
     message = LogMessage(
-            'test_mmp_client',
-            Timestamp(1.0),
-            LogLevel.WARNING,
-            'Testing the MMPClient')
+        "test_mmp_client", Timestamp(1.0), LogLevel.WARNING, "Testing the MMPClient"
+    )
 
     client.submit_log_message(message)
     assert stub.call.called
@@ -47,87 +44,98 @@ def test_submit_log_message(mocked_mmp_client, profile_data) -> None:
     decoded_request = msgpack.unpackb(sent_request, raw=False)
 
     assert decoded_request == [
-            RequestType.SUBMIT_LOG_MESSAGE.value,
-            'test_mmp_client', 1.0, LogLevel.WARNING.value,
-            'Testing the MMPClient']
+        RequestType.SUBMIT_LOG_MESSAGE.value,
+        "test_mmp_client",
+        1.0,
+        LogLevel.WARNING.value,
+        "Testing the MMPClient",
+    ]
 
 
 def test_get_settings(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
     settings_msg = {
-            'test1': 'test',
-            'test2': 12,
-            'test3': 3.14,
-            'test4': True,
-            'test5': [1.2, 3.4],
-            'test6': [[1.2, 3.4], [5.6, 7.8]]}
+        "test1": "test",
+        "test2": 12,
+        "test3": 3.14,
+        "test4": True,
+        "test5": [1.2, 3.4],
+        "test6": [[1.2, 3.4], [5.6, 7.8]],
+    }
     transport_result = [ResponseType.SUCCESS.value, settings_msg]
     stub.call.return_value = (
-            msgpack.packb(transport_result, use_bin_type=True), profile_data)
+        msgpack.packb(transport_result, use_bin_type=True),
+        profile_data,
+    )
 
     settings = client.get_settings()
     assert len(settings) == 6
-    assert settings['test1'] == 'test'
-    assert settings['test2'] == 12
-    assert settings['test3'] == 3.14
-    assert settings['test4'] is True
-    assert settings['test5'] == [1.2, 3.4]
-    assert settings['test6'] == [[1.2, 3.4], [5.6, 7.8]]
+    assert settings["test1"] == "test"
+    assert settings["test2"] == 12
+    assert settings["test3"] == 3.14
+    assert settings["test4"] is True
+    assert settings["test5"] == [1.2, 3.4]
+    assert settings["test6"] == [[1.2, 3.4], [5.6, 7.8]]
 
 
 def test_register_instance(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
     result = [ResponseType.SUCCESS.value]
-    stub.call.return_value = (
-            msgpack.packb(result, use_bin_type=True), profile_data)
+    stub.call.return_value = (msgpack.packb(result, use_bin_type=True), profile_data)
 
     client.register_instance(
-            ['direct:test', 'tcp:test'],
-            [Port('out', Operator.O_I), Port('in', Operator.S)])
+        ["direct:test", "tcp:test"], [Port("out", Operator.O_I), Port("in", Operator.S)]
+    )
 
     assert stub.call.called
     sent_msg = msgpack.unpackb(stub.call.call_args[0][0], raw=False)
     assert sent_msg == [
-            RequestType.REGISTER_INSTANCE.value, 'component[13]',
-            ['direct:test', 'tcp:test'], [['out', 'O_I'], ['in', 'S']],
-            libmuscle.__version__]
+        RequestType.REGISTER_INSTANCE.value,
+        "component[13]",
+        ["direct:test", "tcp:test"],
+        [["out", "O_I"], ["in", "S"]],
+        libmuscle.__version__,
+    ]
 
 
 def test_request_peers(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
     result_msg = [
-            ResponseType.SUCCESS.value,
-            [['component.out', 'other.in']],
-            {'other': [20]},
-            {'other': ['direct:test', 'tcp:test']},
-            [["out", "O_F"]]]
+        ResponseType.SUCCESS.value,
+        [["component.out", "other.in"]],
+        {"other": [20]},
+        {"other": ["direct:test", "tcp:test"]},
+        [["out", "O_F"]],
+    ]
     stub.call.return_value = (
-            msgpack.packb(result_msg, use_bin_type=True), profile_data)
+        msgpack.packb(result_msg, use_bin_type=True),
+        profile_data,
+    )
 
     peer_info = client.request_peers()
 
     assert stub.call.called
     sent_msg = msgpack.unpackb(stub.call.call_args[0][0], raw=False)
     assert sent_msg[0] == RequestType.GET_PEERS.value
-    assert sent_msg[1] == 'component[13]'
+    assert sent_msg[1] == "component[13]"
 
     assert peer_info._kernel == Reference("component")
     assert peer_info._index == [13]
 
     assert len(peer_info._conduits) == 1
     assert isinstance(peer_info._conduits[0], Conduit)
-    assert peer_info._conduits[0].sender == 'component.out'
-    assert peer_info._conduits[0].receiver == 'other.in'
+    assert peer_info._conduits[0].sender == "component.out"
+    assert peer_info._conduits[0].receiver == "other.in"
 
     assert peer_info._incoming_ports == []
     assert peer_info._outgoing_ports == [Reference("component.out")]
     assert peer_info._peers == {"component.out": ["other.in"]}
 
     assert peer_info._peer_dims == {"other": [20]}
-    assert peer_info._peer_locations == {"other": ['direct:test', 'tcp:test']}
+    assert peer_info._peer_locations == {"other": ["direct:test", "tcp:test"]}
 
     assert len(peer_info._ymmsl_ports) == 1
     assert peer_info._ymmsl_ports[0].name == "out"
@@ -137,9 +145,11 @@ def test_request_peers(mocked_mmp_client, profile_data) -> None:
 def test_request_peers_error(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
-    result_msg = [ResponseType.ERROR.value, 'test_error_message']
+    result_msg = [ResponseType.ERROR.value, "test_error_message"]
     stub.call.return_value = (
-            msgpack.packb(result_msg, use_bin_type=True), profile_data)
+        msgpack.packb(result_msg, use_bin_type=True),
+        profile_data,
+    )
 
     with pytest.raises(RuntimeError):
         client.request_peers()
@@ -148,13 +158,17 @@ def test_request_peers_error(mocked_mmp_client, profile_data) -> None:
 def test_request_peers_timeout(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
-    result_msg = [ResponseType.PENDING.value, 'test_status_message']
+    result_msg = [ResponseType.PENDING.value, "test_status_message"]
     stub.call.return_value = (
-            msgpack.packb(result_msg, use_bin_type=True), profile_data)
+        msgpack.packb(result_msg, use_bin_type=True),
+        profile_data,
+    )
 
-    with patch('libmuscle.mmp_client.PEER_TIMEOUT', 1), \
-            patch('libmuscle.mmp_client.PEER_INTERVAL_MIN', 0.1), \
-            patch('libmuscle.mmp_client.PEER_INTERVAL_MAX', 1.0):
+    with (
+        patch("libmuscle.mmp_client.PEER_TIMEOUT", 1),
+        patch("libmuscle.mmp_client.PEER_INTERVAL_MIN", 0.1),
+        patch("libmuscle.mmp_client.PEER_INTERVAL_MAX", 1.0),
+    ):
         with pytest.raises(RuntimeError):
             client.request_peers()
 
@@ -163,26 +177,24 @@ def test_deregister_instance(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
     result = [ResponseType.SUCCESS.value]
-    stub.call.return_value = (
-            msgpack.packb(result, use_bin_type=True), profile_data)
+    stub.call.return_value = (msgpack.packb(result, use_bin_type=True), profile_data)
 
     client.deregister_instance()
 
     assert stub.call.called
     sent_msg = msgpack.unpackb(stub.call.call_args[0][0], raw=False)
-    assert sent_msg == [RequestType.DEREGISTER_INSTANCE.value, 'component[13]']
+    assert sent_msg == [RequestType.DEREGISTER_INSTANCE.value, "component[13]"]
 
 
 def test_deregister_instance_error(mocked_mmp_client, profile_data) -> None:
     client, stub = mocked_mmp_client
 
-    result = [ResponseType.ERROR.value, 'Instance component[13] unknown']
-    stub.call.return_value = (
-            msgpack.packb(result, use_bin_type=True), profile_data)
+    result = [ResponseType.ERROR.value, "Instance component[13] unknown"]
+    stub.call.return_value = (msgpack.packb(result, use_bin_type=True), profile_data)
 
     with pytest.raises(RuntimeError):
         client.deregister_instance()
 
     assert stub.call.called
     sent_msg = msgpack.unpackb(stub.call.call_args[0][0], raw=False)
-    assert sent_msg == [RequestType.DEREGISTER_INSTANCE.value, 'component[13]']
+    assert sent_msg == [RequestType.DEREGISTER_INSTANCE.value, "component[13]"]

--- a/libmuscle/python/libmuscle/test/test_mmsf_validator.py
+++ b/libmuscle/python/libmuscle/test/test_mmsf_validator.py
@@ -11,6 +11,7 @@ from libmuscle.port_manager import PortManager
 
 class Contains:
     """Helper class to simplify tests using caplog.record_tuples"""
+
     def __init__(self, value: Any) -> None:
         self.value = value
 
@@ -34,11 +35,15 @@ def mock_peer_info() -> Mock:
 
 @pytest.fixture
 def validator_simple(mock_peer_info) -> MMSFValidator:
-    port_manager = PortManager([], {
+    port_manager = PortManager(
+        [],
+        {
             Operator.F_INIT: ["f_i"],
             Operator.O_I: ["o_i"],
             Operator.S: ["s"],
-            Operator.O_F: ["o_f"]})
+            Operator.O_F: ["o_f"],
+        },
+    )
     port_manager.connect_ports(mock_peer_info)
     return MMSFValidator(port_manager)
 
@@ -62,7 +67,8 @@ def test_simple_skip_f_init(validator_simple, caplog):
     validator_simple.reuse_instance()
     validator_simple.check_send("o_i", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_i'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_i'"))
+    ]
 
 
 def test_simple_skip_o_i(validator_simple, caplog):
@@ -71,17 +77,20 @@ def test_simple_skip_o_i(validator_simple, caplog):
 
     validator_simple.check_receive("f_i", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))
+    ]
 
     caplog.clear()
     validator_simple.check_receive("s", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 's'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 's'"))
+    ]
 
     caplog.clear()
     validator_simple.reuse_instance()
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("reuse_instance()"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("reuse_instance()"))
+    ]
 
 
 def test_simple_skip_s(validator_simple, caplog):
@@ -91,12 +100,14 @@ def test_simple_skip_s(validator_simple, caplog):
 
     validator_simple.check_send("o_i", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_i'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_i'"))
+    ]
 
     caplog.clear()
     validator_simple.check_send("o_f", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_f'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_f'"))
+    ]
 
 
 def test_simple_skip_o_f(validator_simple, caplog):
@@ -107,7 +118,8 @@ def test_simple_skip_o_f(validator_simple, caplog):
 
     validator_simple.reuse_instance()
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("reuse_instance()"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("reuse_instance()"))
+    ]
 
 
 def test_simple_skip_reuse_instance(validator_simple, caplog):
@@ -117,7 +129,8 @@ def test_simple_skip_reuse_instance(validator_simple, caplog):
 
     validator_simple.check_receive("f_i", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))
+    ]
 
 
 def test_only_o_f(mock_peer_info, caplog):
@@ -131,7 +144,8 @@ def test_only_o_f(mock_peer_info, caplog):
 
     validator.check_send("o_f", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_f'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_f'"))
+    ]
 
 
 def test_only_f_i(mock_peer_info, caplog):
@@ -145,7 +159,8 @@ def test_only_f_i(mock_peer_info, caplog):
 
     validator.check_receive("f_i", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))
+    ]
 
 
 def test_micro(mock_peer_info, caplog):
@@ -162,17 +177,20 @@ def test_micro(mock_peer_info, caplog):
 
     validator.check_receive("f_i", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Receive on port 'f_i'"))
+    ]
 
     caplog.clear()
     validator.reuse_instance()
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("reuse_instance()"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("reuse_instance()"))
+    ]
 
 
 def test_not_all_ports_used(mock_peer_info, caplog):
-    port_manager = PortManager([], {
-            Operator.F_INIT: ["f_i1", "f_i2"], Operator.O_F: ["o_f"]})
+    port_manager = PortManager(
+        [], {Operator.F_INIT: ["f_i1", "f_i2"], Operator.O_F: ["o_f"]}
+    )
     port_manager.connect_ports(mock_peer_info)
     validator = MMSFValidator(port_manager)
 
@@ -181,4 +199,5 @@ def test_not_all_ports_used(mock_peer_info, caplog):
 
     validator.check_send("o_f", None)
     assert caplog.record_tuples == [
-        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_f'"))]
+        ("libmuscle.mmsf_validator", WARNING, Contains("Send on port 'o_f'"))
+    ]

--- a/libmuscle/python/libmuscle/test/test_mpp_message.py
+++ b/libmuscle/python/libmuscle/test/test_mpp_message.py
@@ -9,17 +9,25 @@ from libmuscle.mpp_message import MPPMessage
 
 
 def test_create() -> None:
-    sender = Reference('sender.port')
-    receiver = Reference('receiver.port')
+    sender = Reference("sender.port")
+    receiver = Reference("receiver.port")
     timestamp = 10.0
     next_timestamp = 11.0
-    settings_overlay = (6789).to_bytes(2, 'little', signed=True)
+    settings_overlay = (6789).to_bytes(2, "little", signed=True)
     message_number = 0
     saved_until = 1.6
-    data = (12345).to_bytes(2, 'little', signed=True)
+    data = (12345).to_bytes(2, "little", signed=True)
     msg = MPPMessage(
-            sender, receiver, None, timestamp, next_timestamp,
-            settings_overlay, message_number, saved_until, data)
+        sender,
+        receiver,
+        None,
+        timestamp,
+        next_timestamp,
+        settings_overlay,
+        message_number,
+        saved_until,
+        data,
+    )
     assert msg.sender == sender
     assert msg.receiver == receiver
     assert msg.port_length is None
@@ -32,66 +40,63 @@ def test_create() -> None:
 
 
 def test_grid_encode() -> None:
-    sender = Reference('sender.port')
-    receiver = Reference('receiver.port')
+    sender = Reference("sender.port")
+    receiver = Reference("receiver.port")
     timestamp = 10.0
     next_timestamp = 11.0
 
     array = np.array(
-            [[[1.0, 2.0, 3.0],
-              [4.0, 5.0, 6.0]],
-             [[7.0, 8.0, 9.0],
-              [10.0, 11.0, 12.0]]], np.float32)
+        [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]],
+        np.float32,
+    )
 
-    grid = Grid(array, ['x', 'y', 'z'])
+    grid = Grid(array, ["x", "y", "z"])
     msg = MPPMessage(
-            sender, receiver, None, timestamp, next_timestamp, Settings(),
-            0, 1.0, grid)
+        sender, receiver, None, timestamp, next_timestamp, Settings(), 0, 1.0, grid
+    )
 
     wire_data = msg.encoded()
     mcp_decoded = msgpack.unpackb(wire_data, raw=False)
-    grid_decoded = msgpack.unpackb(mcp_decoded['data'].data, raw=False)
+    grid_decoded = msgpack.unpackb(mcp_decoded["data"].data, raw=False)
 
-    assert grid_decoded['type'] == 'float32'
-    assert grid_decoded['shape'] == [2, 2, 3]
-    assert grid_decoded['order'] == 'la'
+    assert grid_decoded["type"] == "float32"
+    assert grid_decoded["shape"] == [2, 2, 3]
+    assert grid_decoded["order"] == "la"
     next_value = 1.0
-    for value in struct.iter_unpack('<f', grid_decoded['data']):
+    for value in struct.iter_unpack("<f", grid_decoded["data"]):
         assert value[0] == next_value
         next_value = next_value + 1.0
 
-    assert grid_decoded['indexes'] == ['x', 'y', 'z']
+    assert grid_decoded["indexes"] == ["x", "y", "z"]
 
 
 def test_grid_decode() -> None:
     settings_data = msgpack.packb({}, use_bin_type=True)
 
     grid_buf = bytes(
-            [1, 0, 0, 0,
-             2, 0, 0, 0,
-             3, 0, 0, 0,
-             0, 0, 4, 0,
-             0, 0, 5, 0,
-             0, 0, 6, 0])
+        [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0]
+    )
 
     grid_dict = {
-            'type': 'int32',
-            'shape': [2, 3],
-            'order': 'la',
-            'data': grid_buf,
-            'indexes': []}
+        "type": "int32",
+        "shape": [2, 3],
+        "order": "la",
+        "data": grid_buf,
+        "indexes": [],
+    }
     grid_data = msgpack.packb(grid_dict, use_bin_type=True)
 
     msg_dict = {
-            'sender': 'elem1.port1',
-            'receiver': 'elem2.port2',
-            'port_length': 0,
-            'timestamp': 0.0,
-            'next_timestamp': None,
-            'settings_overlay': msgpack.ExtType(1, settings_data),
-            'message_number': 0,
-            'saved_until': 9.9,
-            'data': msgpack.ExtType(2, grid_data)}
+        "sender": "elem1.port1",
+        "receiver": "elem2.port2",
+        "port_length": 0,
+        "timestamp": 0.0,
+        "next_timestamp": None,
+        "settings_overlay": msgpack.ExtType(1, settings_data),
+        "message_number": 0,
+        "saved_until": 9.9,
+        "data": msgpack.ExtType(2, grid_data),
+    }
 
     wire_data = msgpack.packb(msg_dict, use_bin_type=True)
 
@@ -106,9 +111,9 @@ def test_grid_decode() -> None:
     assert msg.data.array[1, 1] == 5 * 65536
     assert msg.data.indexes is None
 
-    grid_dict['order'] = 'fa'
+    grid_dict["order"] = "fa"
     grid_data = msgpack.packb(grid_dict, use_bin_type=True)
-    msg_dict['data'] = msgpack.ExtType(2, grid_data)
+    msg_dict["data"] = msgpack.ExtType(2, grid_data)
     wire_data = msgpack.packb(msg_dict, use_bin_type=True)
     msg = MPPMessage.from_bytes(wire_data)
 
@@ -123,31 +128,31 @@ def test_grid_decode() -> None:
 
 
 def test_grid_roundtrip() -> None:
-    sender = Reference('sender.port')
-    receiver = Reference('receiver.port')
+    sender = Reference("sender.port")
+    receiver = Reference("receiver.port")
     timestamp = 10.0
     next_timestamp = 11.0
 
-    for order in ('C', 'F'):
+    for order in ("C", "F"):
         array = np.array(
-                [[[1.0, 2.0, 3.0],
-                  [4.0, 5.0, 6.0]],
-                 [[7.0, 8.0, 9.0],
-                  [10.0, 11.0, 12.0]]], np.float64, order=order)
+            [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]],
+            np.float64,
+            order=order,
+        )
 
         assert array[0, 0, 0] == 1.0
 
-        grid = Grid(array, ['x', 'y', 'z'])
+        grid = Grid(array, ["x", "y", "z"])
         msg = MPPMessage(
-                sender, receiver, None, timestamp, next_timestamp, Settings(),
-                0, 1.0, grid)
+            sender, receiver, None, timestamp, next_timestamp, Settings(), 0, 1.0, grid
+        )
 
         wire_data = msg.encoded()
         msg_out = MPPMessage.from_bytes(wire_data)
 
         assert isinstance(msg_out.data, Grid)
         grid_out = msg_out.data
-        assert grid_out.indexes == ['x', 'y', 'z']
+        assert grid_out.indexes == ["x", "y", "z"]
         assert isinstance(grid_out.array, np.ndarray)
         assert grid_out.array.dtype == np.float64
         assert grid_out.array.shape == (2, 2, 3)
@@ -157,24 +162,32 @@ def test_grid_roundtrip() -> None:
 
 
 def test_non_contiguous_grid_roundtrip() -> None:
-    sender = Reference('sender.port')
-    receiver = Reference('receiver.port')
+    sender = Reference("sender.port")
+    receiver = Reference("receiver.port")
     timestamp = 10.0
     next_timestamp = 11.0
 
     array = np.array(
-            [[[1.0 + 0.125j, 2.0 + 0.25j, 3.0 + 0.375j],
-              [4.0 + 0.4375j, 5.0 + 0.5j, 6.0 + 0.625j]],
-             [[7.0 + 0.75j, 8.0 + 0.875j, 9.0 + 0.9375j],
-              [10.0 + 0.10j, 11.0 + 0.11j, 12.0 + 0.12j]]], np.complex64)
+        [
+            [
+                [1.0 + 0.125j, 2.0 + 0.25j, 3.0 + 0.375j],
+                [4.0 + 0.4375j, 5.0 + 0.5j, 6.0 + 0.625j],
+            ],
+            [
+                [7.0 + 0.75j, 8.0 + 0.875j, 9.0 + 0.9375j],
+                [10.0 + 0.10j, 11.0 + 0.11j, 12.0 + 0.12j],
+            ],
+        ],
+        np.complex64,
+    )
 
     assert array.real[0, 0, 0] == 1.0
     assert array.imag[0, 0, 0] == 0.125
 
-    grid = Grid(array.real, ['a', 'b', 'c'])
+    grid = Grid(array.real, ["a", "b", "c"])
     msg = MPPMessage(
-            sender, receiver, None, timestamp, next_timestamp, Settings(),
-            0, 7.7, grid)
+        sender, receiver, None, timestamp, next_timestamp, Settings(), 0, 7.7, grid
+    )
 
     wire_data = msg.encoded()
     msg_out = MPPMessage.from_bytes(wire_data)

--- a/libmuscle/python/libmuscle/test/test_mpp_server.py
+++ b/libmuscle/python/libmuscle/test/test_mpp_server.py
@@ -7,7 +7,7 @@ from libmuscle.mpp_server import MPPServer
 
 @pytest.fixture(autouse=True)
 def PostOffice():
-    with patch('libmuscle.mpp_server.PostOffice') as PostOffice:
+    with patch("libmuscle.mpp_server.PostOffice") as PostOffice:
         yield PostOffice
 
 
@@ -15,13 +15,13 @@ def PostOffice():
 def MockTransportServer():
     MockTransportServer = MagicMock()
     transport_server = MockTransportServer.return_value
-    transport_server.get_location.return_value = 'tcp:testing:9001'
+    transport_server.get_location.return_value = "tcp:testing:9001"
     return MockTransportServer
 
 
 @pytest.fixture(autouse=True)
 def transport_server_types(MockTransportServer):
-    with patch('libmuscle.mpp_server.transport_server_types', [MockTransportServer]):
+    with patch("libmuscle.mpp_server.transport_server_types", [MockTransportServer]):
         yield None
 
 

--- a/libmuscle/python/libmuscle/test/test_outbox.py
+++ b/libmuscle/python/libmuscle/test/test_outbox.py
@@ -16,11 +16,8 @@ def outbox():
 def message():
     Ref = Reference
     return MPPMessage(
-            Ref('sender.out'), Ref('receiver.in'),
-            None, 0.0, 1.0,
-            b'',
-            0, 1.0,
-            b'testing')
+        Ref("sender.out"), Ref("receiver.in"), None, 0.0, 1.0, b"", 0, 1.0, b"testing"
+    )
 
 
 def test_create_outbox():

--- a/libmuscle/python/libmuscle/test/test_peer_info.py
+++ b/libmuscle/python/libmuscle/test/test_peer_info.py
@@ -8,18 +8,14 @@ from libmuscle.peer_info import PeerInfo
 
 @pytest.fixture
 def peer_info() -> PeerInfo:
-    kernel = Ref('kernel')
+    kernel = Ref("kernel")
     index = [13]
 
-    conduits = [
-            Conduit('kernel.out', 'other.in'),
-            Conduit('other.out', 'kernel.in')]
+    conduits = [Conduit("kernel.out", "other.in"), Conduit("other.out", "kernel.in")]
 
-    peer_dims = {
-            Ref('other'): []}
+    peer_dims = {Ref("other"): []}
 
-    peer_locations = {
-            Ref('other'): ['tcp:other']}
+    peer_locations = {Ref("other"): ["tcp:other"]}
 
     ymmsl_ports = [Port(Id("out"), Operator.O_I), Port(Id("in"), Operator.S)]
 
@@ -28,18 +24,14 @@ def peer_info() -> PeerInfo:
 
 @pytest.fixture
 def peer_info2() -> PeerInfo:
-    kernel = Ref('other')
+    kernel = Ref("other")
     index = []
 
-    conduits = [
-            Conduit('kernel.out', 'other.in'),
-            Conduit('other.out', 'kernel.in')]
+    conduits = [Conduit("kernel.out", "other.in"), Conduit("other.out", "kernel.in")]
 
-    peer_dims = {
-            Ref('kernel'): [20]}
+    peer_dims = {Ref("kernel"): [20]}
 
-    peer_locations = {
-            Ref('kernel'): ['tcp:kernel']}
+    peer_locations = {Ref("kernel"): ["tcp:kernel"]}
 
     ymmsl_ports = [Port(Id("out"), Operator.O_F), Port(Id("in"), Operator.F_INIT)]
 
@@ -48,18 +40,14 @@ def peer_info2() -> PeerInfo:
 
 @pytest.fixture
 def peer_info3() -> PeerInfo:
-    kernel = Ref('kernel')
+    kernel = Ref("kernel")
     index = []
 
-    conduits = [
-            Conduit('kernel.out', 'other.in'),
-            Conduit('other.out', 'kernel.in')]
+    conduits = [Conduit("kernel.out", "other.in"), Conduit("other.out", "kernel.in")]
 
-    peer_dims = {
-            Ref('other'): []}
+    peer_dims = {Ref("other"): []}
 
-    peer_locations = {
-            Ref('other'): ['tcp:other']}
+    peer_locations = {Ref("other"): ["tcp:other"]}
 
     ymmsl_ports = [Port(Id("out"), Operator.O_I), Port(Id("in"), Operator.S)]
 
@@ -71,46 +59,47 @@ def test_create_peer_info(peer_info) -> None:
 
 
 def test_is_connected(peer_info) -> None:
-    assert peer_info.is_connected(Id('out'))
-    assert peer_info.is_connected(Id('in'))
-    assert not peer_info.is_connected(Id('not_connected'))
+    assert peer_info.is_connected(Id("out"))
+    assert peer_info.is_connected(Id("in"))
+    assert not peer_info.is_connected(Id("not_connected"))
 
 
 def test_get_peer_port(peer_info, peer_info2, peer_info3) -> None:
-    assert peer_info.get_peer_ports(Id('out')) == [Ref('other.in')]
-    assert peer_info.get_peer_ports(Id('in')) == [Ref('other.out')]
+    assert peer_info.get_peer_ports(Id("out")) == [Ref("other.in")]
+    assert peer_info.get_peer_ports(Id("in")) == [Ref("other.out")]
 
-    assert peer_info2.get_peer_ports(Id('out')) == [Ref('kernel.in')]
-    assert peer_info2.get_peer_ports(Id('in')) == [Ref('kernel.out')]
+    assert peer_info2.get_peer_ports(Id("out")) == [Ref("kernel.in")]
+    assert peer_info2.get_peer_ports(Id("in")) == [Ref("kernel.out")]
 
-    assert peer_info3.get_peer_ports(Id('out')) == [Ref('other.in')]
-    assert peer_info3.get_peer_ports(Id('in')) == [Ref('other.out')]
+    assert peer_info3.get_peer_ports(Id("out")) == [Ref("other.in")]
+    assert peer_info3.get_peer_ports(Id("in")) == [Ref("other.out")]
 
 
 def test_get_peer_dims(peer_info, peer_info2, peer_info3) -> None:
-    assert peer_info.get_peer_dims(Ref('other')) == []
-    assert peer_info2.get_peer_dims(Ref('kernel')) == [20]
-    assert peer_info3.get_peer_dims(Ref('other')) == []
+    assert peer_info.get_peer_dims(Ref("other")) == []
+    assert peer_info2.get_peer_dims(Ref("kernel")) == [20]
+    assert peer_info3.get_peer_dims(Ref("other")) == []
 
 
 def test_get_peer_locations(peer_info, peer_info2, peer_info3) -> None:
-    assert peer_info.get_peer_locations(Ref('other')) == ['tcp:other']
-    assert peer_info2.get_peer_locations(Ref('kernel')) == ['tcp:kernel']
-    assert peer_info3.get_peer_locations(Ref('other')) == ['tcp:other']
+    assert peer_info.get_peer_locations(Ref("other")) == ["tcp:other"]
+    assert peer_info2.get_peer_locations(Ref("kernel")) == ["tcp:kernel"]
+    assert peer_info3.get_peer_locations(Ref("other")) == ["tcp:other"]
 
 
 def test_get_peer_endpoint(peer_info, peer_info2, peer_info3) -> None:
-    assert str(peer_info.get_peer_endpoints(Id('out'), [])[0]) == 'other.in[13]'
-    assert str(peer_info.get_peer_endpoints(Id('in'), [])[0]) == 'other.out[13]'
+    assert str(peer_info.get_peer_endpoints(Id("out"), [])[0]) == "other.in[13]"
+    assert str(peer_info.get_peer_endpoints(Id("in"), [])[0]) == "other.out[13]"
 
-    assert str(peer_info2.get_peer_endpoints(Id('out'), [11])[0]) == 'kernel[11].in'
-    assert str(peer_info2.get_peer_endpoints(Id('in'), [11])[0]) == 'kernel[11].out'
+    assert str(peer_info2.get_peer_endpoints(Id("out"), [11])[0]) == "kernel[11].in"
+    assert str(peer_info2.get_peer_endpoints(Id("in"), [11])[0]) == "kernel[11].out"
 
-    assert str(peer_info3.get_peer_endpoints(Id('out'), [42])[0]) == 'other.in[42]'
-    assert str(peer_info3.get_peer_endpoints(Id('in'), [42])[0]) == 'other.out[42]'
+    assert str(peer_info3.get_peer_endpoints(Id("out"), [42])[0]) == "other.in[42]"
+    assert str(peer_info3.get_peer_endpoints(Id("in"), [42])[0]) == "other.out[42]"
 
 
 def test_get_ymmsl_ports(peer_info) -> None:
     assert peer_info.list_ymmsl_ports() == [
-        Port(Id("out"), Operator.O_I), Port(Id("in"), Operator.S)
+        Port(Id("out"), Operator.O_I),
+        Port(Id("in"), Operator.S),
     ]

--- a/libmuscle/python/libmuscle/test/test_port.py
+++ b/libmuscle/python/libmuscle/test/test_port.py
@@ -5,8 +5,8 @@ from libmuscle.port import Operator, Port
 
 
 def test_create_port():
-    port = Port('out', Operator.O_I, False, True, 0, [])
-    assert port.name == Identifier('out')
+    port = Port("out", Operator.O_I, False, True, 0, [])
+    assert port.name == Identifier("out")
     assert port.operator == Operator.O_I
     assert port._length is None
     assert port._is_resizable is False
@@ -15,20 +15,20 @@ def test_create_port():
 
 def test_create_invalid_port():
     with pytest.raises(RuntimeError):
-        Port('out', Operator.O_I, True, True, 1, [])
+        Port("out", Operator.O_I, True, True, 1, [])
 
     with pytest.raises(RuntimeError):
-        Port('out', Operator.O_F, True, True, 0, [10, 10])
+        Port("out", Operator.O_F, True, True, 0, [10, 10])
 
     with pytest.raises(RuntimeError):
-        Port('out', Operator.O_F, False, True, 1, [11, 12])
+        Port("out", Operator.O_F, False, True, 1, [11, 12])
 
     with pytest.raises(RuntimeError):
-        Port('out', Operator.O_I, False, True, 2, [])
+        Port("out", Operator.O_I, False, True, 2, [])
 
 
 def test_port_properties():
-    port = Port('out', Operator.O_F, False, False, 0, [])
+    port = Port("out", Operator.O_F, False, False, 0, [])
     assert port.is_vector() is False
     assert port.is_resizable() is False
     assert port.is_connected() is False
@@ -37,14 +37,14 @@ def test_port_properties():
     with pytest.raises(RuntimeError):
         port.set_length(3)
 
-    port = Port('out', Operator.O_F, True, True, 0, [10])
+    port = Port("out", Operator.O_F, True, True, 0, [10])
     assert port.is_vector() is True
     assert port.is_resizable() is False
     assert port.get_length() == 10
     with pytest.raises(RuntimeError):
         port.set_length(3)
 
-    port = Port('out', Operator.O_F, False, True, 1, [10])
+    port = Port("out", Operator.O_F, False, True, 1, [10])
     assert port.is_vector() is False
     assert port.is_resizable() is False
     with pytest.raises(RuntimeError):
@@ -52,14 +52,14 @@ def test_port_properties():
     with pytest.raises(RuntimeError):
         port.set_length(4)
 
-    port = Port('out', Operator.O_F, True, True, 1, [10, 20])
+    port = Port("out", Operator.O_F, True, True, 1, [10, 20])
     assert port.is_vector() is True
     assert port.is_resizable() is False
     assert port.get_length() == 20
     with pytest.raises(RuntimeError):
         port.set_length(5)
 
-    port = Port('out', Operator.O_F, False, True, 2, [12])
+    port = Port("out", Operator.O_F, False, True, 2, [12])
     assert port.is_vector() is False
     assert port.is_resizable() is False
     with pytest.raises(RuntimeError):
@@ -67,7 +67,7 @@ def test_port_properties():
     with pytest.raises(RuntimeError):
         port.set_length(9)
 
-    port = Port('out', Operator.O_F, True, True, 1, [13])
+    port = Port("out", Operator.O_F, True, True, 1, [13])
     assert port.is_vector() is True
     assert port.is_resizable() is True
     assert port.get_length() == 0

--- a/libmuscle/python/libmuscle/test/test_port_manager.py
+++ b/libmuscle/python/libmuscle/test/test_port_manager.py
@@ -14,9 +14,7 @@ def index() -> list[int]:
 
 @pytest.fixture
 def port_manager(index) -> PortManager:
-    declared_ports = {
-            Operator.O_I: ['out'],
-            Operator.S: ['in']}
+    declared_ports = {Operator.O_I: ["out"], Operator.S: ["in"]}
     return PortManager(index, declared_ports)
 
 
@@ -27,16 +25,16 @@ def index2() -> list[int]:
 
 @pytest.fixture
 def port_manager2(index2) -> PortManager:
-    declared_ports = {
-            Operator.F_INIT: ['in[]'],
-            Operator.O_F: ['out[]']}
+    declared_ports = {Operator.F_INIT: ["in[]"], Operator.O_F: ["out[]"]}
     port_manager = PortManager(index2, declared_ports)
 
-    component_id = Ref('other')
-    conduits = [Conduit('component.out', 'other.in'),
-                Conduit('other.out', 'component.in')]
-    peer_dims = {Ref('component'): [20]}
-    peer_locations = {Ref('component'): ['direct:test']}
+    component_id = Ref("other")
+    conduits = [
+        Conduit("component.out", "other.in"),
+        Conduit("other.out", "component.in"),
+    ]
+    peer_dims = {Ref("component"): [20]}
+    peer_locations = {Ref("component"): ["direct:test"]}
     peer_info = PeerInfo(component_id, index2, conduits, peer_dims, peer_locations, [])
 
     port_manager.connect_ports(peer_info)
@@ -44,81 +42,81 @@ def port_manager2(index2) -> PortManager:
 
 
 def test_connect_ports(index, port_manager) -> None:
-    component_id = Ref('component')
-    conduits = [Conduit('component.out', 'other.in'),
-                Conduit('other.settings_out', 'component.muscle_settings_in'),
-                Conduit('other.out', 'component.in')]
-    peer_dims = {Ref('other'): []}
-    peer_locations = {Ref('other'): ['direct:test']}
+    component_id = Ref("component")
+    conduits = [
+        Conduit("component.out", "other.in"),
+        Conduit("other.settings_out", "component.muscle_settings_in"),
+        Conduit("other.out", "component.in"),
+    ]
+    peer_dims = {Ref("other"): []}
+    peer_locations = {Ref("other"): ["direct:test"]}
     peer_info = PeerInfo(component_id, index, conduits, peer_dims, peer_locations, [])
 
     port_manager.connect_ports(peer_info)
 
     # check automatic ports
     assert port_manager.settings_in_connected()
-    assert port_manager._muscle_settings_in.name == Id('muscle_settings_in')
+    assert port_manager._muscle_settings_in.name == Id("muscle_settings_in")
     assert port_manager._muscle_settings_in.operator == Operator.F_INIT
     assert port_manager._muscle_settings_in._length is None
 
     # check declared ports
     ports = port_manager._ports
-    assert ports['in'].name == Id('in')
-    assert ports['in'].operator == Operator.S
-    assert ports['in']._length is None
+    assert ports["in"].name == Id("in")
+    assert ports["in"].operator == Operator.S
+    assert ports["in"]._length is None
 
-    assert ports['out'].name == Id('out')
-    assert ports['out'].operator == Operator.O_I
-    assert ports['out']._length is None
+    assert ports["out"].name == Id("out")
+    assert ports["out"].operator == Operator.O_I
+    assert ports["out"]._length is None
 
 
 def test_connect_vector_ports(index) -> None:
-    declared_ports = {
-            Operator.F_INIT: ['in[]'],
-            Operator.O_F: ['out1', 'out2[]']}
+    declared_ports = {Operator.F_INIT: ["in[]"], Operator.O_F: ["out1", "out2[]"]}
 
     port_manager = PortManager(index, declared_ports)
 
-    component_id = Ref('component')
-    conduits = [Conduit('other1.out', 'component.in'),
-                Conduit('component.out1', 'other.in'),
-                Conduit('component.out2', 'other3.in')]
-    peer_dims = {
-            Ref('other1'): [20, 7],
-            Ref('other'): [25],
-            Ref('other3'): [20]}
+    component_id = Ref("component")
+    conduits = [
+        Conduit("other1.out", "component.in"),
+        Conduit("component.out1", "other.in"),
+        Conduit("component.out2", "other3.in"),
+    ]
+    peer_dims = {Ref("other1"): [20, 7], Ref("other"): [25], Ref("other3"): [20]}
     peer_locations = {
-            Ref('other'): ['direct:test'],
-            Ref('other1'): ['direct:test1'],
-            Ref('other3'): ['direct:test3']}
+        Ref("other"): ["direct:test"],
+        Ref("other1"): ["direct:test1"],
+        Ref("other3"): ["direct:test3"],
+    }
     peer_info = PeerInfo(component_id, index, conduits, peer_dims, peer_locations, [])
 
     port_manager.connect_ports(peer_info)
 
     ports = port_manager._ports
-    assert ports['in'].name == Id('in')
-    assert ports['in'].operator == Operator.F_INIT
-    assert ports['in']._length == 7
-    assert ports['in']._is_resizable is False
+    assert ports["in"].name == Id("in")
+    assert ports["in"].operator == Operator.F_INIT
+    assert ports["in"]._length == 7
+    assert ports["in"]._is_resizable is False
 
-    assert ports['out1'].name == Id('out1')
-    assert ports['out1'].operator == Operator.O_F
-    assert ports['out1']._length is None
+    assert ports["out1"].name == Id("out1")
+    assert ports["out1"].operator == Operator.O_F
+    assert ports["out1"]._length is None
 
-    assert ports['out2'].name == Id('out2')
-    assert ports['out2'].operator == Operator.O_F
-    assert ports['out2']._length == 0
-    assert ports['out2']._is_resizable is True
+    assert ports["out2"].name == Id("out2")
+    assert ports["out2"].operator == Operator.O_F
+    assert ports["out2"]._length == 0
+    assert ports["out2"]._is_resizable is True
 
 
 def test_connect_multidimensional_ports() -> None:
     index = [13]
-    declared_ports = {Operator.F_INIT: ['in[][]']}
+    declared_ports = {Operator.F_INIT: ["in[][]"]}
     port_manager = PortManager(index, declared_ports)
 
-    component_id = Ref('component')
-    conduits = [Conduit('other.out', 'component.in')]
-    peer_dims = {Ref('other'): [20, 7, 30]}
-    peer_locations = {Ref('other'): ['direct:test']}
+    component_id = Ref("component")
+    conduits = [Conduit("other.out", "component.in")]
+    peer_dims = {Ref("other"): [20, 7, 30]}
+    peer_locations = {Ref("other"): ["direct:test"]}
     peer_info = PeerInfo(component_id, index, conduits, peer_dims, peer_locations, [])
 
     with pytest.raises(ValueError):
@@ -129,40 +127,42 @@ def test_connect_inferred_ports() -> None:
     index = [13]
     port_manager = PortManager(index, None)
 
-    component_id = Ref('component')
-    conduits = [Conduit('other1.out', 'component.in'),
-                Conduit('component.out1', 'other.in'),
-                Conduit('component.out3', 'other2.in')]
-    peer_dims = {
-            Ref('other1'): [20, 7],
-            Ref('other'): [25],
-            Ref('other2'): []}
+    component_id = Ref("component")
+    conduits = [
+        Conduit("other1.out", "component.in"),
+        Conduit("component.out1", "other.in"),
+        Conduit("component.out3", "other2.in"),
+    ]
+    peer_dims = {Ref("other1"): [20, 7], Ref("other"): [25], Ref("other2"): []}
     peer_locations = {
-            Ref('other'): ['direct:test'],
-            Ref('other1'): ['direct:test1'],
-            Ref('other2'): ['direct:test2']}
+        Ref("other"): ["direct:test"],
+        Ref("other1"): ["direct:test1"],
+        Ref("other2"): ["direct:test2"],
+    }
     ymmsl_ports = [
         Port(Id("in"), Operator.F_INIT),
         Port(Id("out1"), Operator.O_F),
-        Port(Id("out3"), Operator.O_F)]
+        Port(Id("out3"), Operator.O_F),
+    ]
     peer_info = PeerInfo(
-            component_id, index, conduits, peer_dims, peer_locations, ymmsl_ports)
+        component_id, index, conduits, peer_dims, peer_locations, ymmsl_ports
+    )
 
     port_manager.connect_ports(peer_info)
 
     ports = port_manager._ports
-    assert ports['in'].name == Id('in')
-    assert ports['in'].operator == Operator.F_INIT
-    assert ports['in']._length == 7
-    assert ports['in']._is_resizable is False
+    assert ports["in"].name == Id("in")
+    assert ports["in"].operator == Operator.F_INIT
+    assert ports["in"]._length == 7
+    assert ports["in"]._is_resizable is False
 
-    assert ports['out1'].name == Id('out1')
-    assert ports['out1'].operator == Operator.O_F
-    assert ports['out1']._length is None
+    assert ports["out1"].name == Id("out1")
+    assert ports["out1"].operator == Operator.O_F
+    assert ports["out1"]._length is None
 
-    assert ports['out3'].name == Id('out3')
-    assert ports['out3'].operator == Operator.O_F
-    assert ports['out3']._length is None
+    assert ports["out3"].name == Id("out3")
+    assert ports["out3"].operator == Operator.O_F
+    assert ports["out3"]._length is None
 
 
 def test_connect_inferred_ports_oi_s() -> None:
@@ -188,31 +188,31 @@ def test_connect_inferred_ports_oi_s() -> None:
 
 
 def test_port_message_counts(port_manager) -> None:
-    port_manager.connect_ports(PeerInfo('component', [], [], {}, {}, []))
+    port_manager.connect_ports(PeerInfo("component", [], [], {}, {}, []))
 
     msg_counts = port_manager.get_message_counts()
-    assert msg_counts == {'in': [0], 'out': [0], 'muscle_settings_in': [0]}
+    assert msg_counts == {"in": [0], "out": [0], "muscle_settings_in": [0]}
 
-    port_manager.get_port('in').increment_num_messages()
+    port_manager.get_port("in").increment_num_messages()
 
     msg_counts2 = port_manager.get_message_counts()
-    assert msg_counts2 == {'in': [1], 'out': [0], 'muscle_settings_in': [0]}
+    assert msg_counts2 == {"in": [1], "out": [0], "muscle_settings_in": [0]}
 
-    port_manager.get_port('out').increment_num_messages()
-    port_manager.get_port('out').increment_num_messages()
+    port_manager.get_port("out").increment_num_messages()
+    port_manager.get_port("out").increment_num_messages()
 
     msg_counts3 = port_manager.get_message_counts()
-    assert msg_counts3 == {'in': [1], 'out': [2], 'muscle_settings_in': [0]}
+    assert msg_counts3 == {"in": [1], "out": [2], "muscle_settings_in": [0]}
 
     port_manager._muscle_settings_in.increment_num_messages()
 
     msg_counts4 = port_manager.get_message_counts()
-    assert msg_counts4 == {'in': [1], 'out': [2], 'muscle_settings_in': [1]}
+    assert msg_counts4 == {"in": [1], "out": [2], "muscle_settings_in": [1]}
 
     port_manager.restore_message_counts(msg_counts)
 
     msg_counts5 = port_manager.get_message_counts()
-    assert msg_counts5 == {'in': [0], 'out': [0], 'muscle_settings_in': [0]}
+    assert msg_counts5 == {"in": [0], "out": [0], "muscle_settings_in": [0]}
 
     with pytest.raises(RuntimeError):
         port_manager.restore_message_counts({"x?invalid_port": 3})
@@ -220,24 +220,26 @@ def test_port_message_counts(port_manager) -> None:
 
 def test_vector_port_message_counts(port_manager2) -> None:
     msg_counts = port_manager2.get_message_counts()
-    assert msg_counts == {'out': [0] * 20,
-                          'in': [0] * 20,
-                          'muscle_settings_in': [0]}
+    assert msg_counts == {"out": [0] * 20, "in": [0] * 20, "muscle_settings_in": [0]}
 
-    port_manager2.get_port('out').increment_num_messages(13)
+    port_manager2.get_port("out").increment_num_messages(13)
 
     msg_counts = port_manager2.get_message_counts()
-    assert msg_counts == {'out': [0] * 13 + [1] + [0] * 6,
-                          'in': [0] * 20,
-                          'muscle_settings_in': [0]}
+    assert msg_counts == {
+        "out": [0] * 13 + [1] + [0] * 6,
+        "in": [0] * 20,
+        "muscle_settings_in": [0],
+    }
 
-    port_manager2.restore_message_counts({'out': list(range(20)),
-                                          'in': list(range(20)),
-                                          'muscle_settings_in': [4]})
+    port_manager2.restore_message_counts(
+        {"out": list(range(20)), "in": list(range(20)), "muscle_settings_in": [4]}
+    )
 
-    port_manager2.get_port('out').increment_num_messages(13)
+    port_manager2.get_port("out").increment_num_messages(13)
 
     msg_counts = port_manager2.get_message_counts()
-    assert msg_counts == {'out': list(range(13)) + [14] + list(range(14, 20)),
-                          'in': list(range(20)),
-                          'muscle_settings_in': [4]}
+    assert msg_counts == {
+        "out": list(range(13)) + [14] + list(range(14, 20)),
+        "in": list(range(20)),
+        "muscle_settings_in": [4],
+    }

--- a/libmuscle/python/libmuscle/test/test_profiler.py
+++ b/libmuscle/python/libmuscle/test/test_profiler.py
@@ -46,7 +46,7 @@ def test_send_to_manager(profiler_comm_int_10ms, mocked_profiler) -> None:
     assert mock_mmp_client.sent_events == [e2]
 
     mock_mmp_client.sent_events = None
-    profiler.set_level('none')
+    profiler.set_level("none")
     e3 = ProfileEvent(ProfileEventType.RECEIVE, ProfileTimestamp())
     profiler.record_event(e3)
 

--- a/libmuscle/python/libmuscle/test/test_settings_manager.py
+++ b/libmuscle/python/libmuscle/test/test_settings_manager.py
@@ -16,104 +16,111 @@ def test_create(settings_manager):
 
 def test_list_settings_globals(settings_manager):
     ref = Reference
-    settings_manager.base[ref('test1')] = 13
-    settings_manager.base[ref('test2')] = 14
-    assert settings_manager.list_settings(ref('macro')) == ['test1', 'test2']
+    settings_manager.base[ref("test1")] = 13
+    settings_manager.base[ref("test2")] = 14
+    assert settings_manager.list_settings(ref("macro")) == ["test1", "test2"]
 
 
 def test_list_settings_specifics(settings_manager):
     ref = Reference
-    settings_manager.base[ref('macro.test1')] = 'test1'
-    settings_manager.base[ref('micro.test2')] = 'test2'
-    assert settings_manager.list_settings(ref('macro')) == ['test1']
+    settings_manager.base[ref("macro.test1")] = "test1"
+    settings_manager.base[ref("micro.test2")] = "test2"
+    assert settings_manager.list_settings(ref("macro")) == ["test1"]
 
-    settings_manager.base[ref('micro.test1')] = 'test1'
-    assert settings_manager.list_settings(ref('macro')) == ['test1']
+    settings_manager.base[ref("micro.test1")] = "test1"
+    assert settings_manager.list_settings(ref("macro")) == ["test1"]
 
 
 def test_list_settings_override(settings_manager):
     ref = Reference
-    settings_manager.base[ref('test1')] = 'test1'
-    settings_manager.base[ref('macro.test1')] = 42
-    assert settings_manager.list_settings(ref('macro')) == ['test1']
+    settings_manager.base[ref("test1")] = "test1"
+    settings_manager.base[ref("macro.test1")] = 42
+    assert settings_manager.list_settings(ref("macro")) == ["test1"]
 
-    settings_manager.base[ref('micro.test1')] = 43
-    assert settings_manager.list_settings(ref('macro')) == ['test1']
+    settings_manager.base[ref("micro.test1")] = 43
+    assert settings_manager.list_settings(ref("macro")) == ["test1"]
 
-    settings_manager.base[ref('test2')] = 'test2'
-    assert settings_manager.list_settings(ref('macro')) == ['test1', 'test2']
+    settings_manager.base[ref("test2")] = "test2"
+    assert settings_manager.list_settings(ref("macro")) == ["test1", "test2"]
 
 
 def test_list_settings_overlay(settings_manager):
     ref = Reference
-    settings_manager.base[ref('test1')] = 'test1'
-    settings_manager.overlay[ref('test1')] = 'test1'
-    assert settings_manager.list_settings(ref('macro')) == ['test1']
+    settings_manager.base[ref("test1")] = "test1"
+    settings_manager.overlay[ref("test1")] = "test1"
+    assert settings_manager.list_settings(ref("macro")) == ["test1"]
 
-    settings_manager.overlay[ref('test2')] = 'test2'
-    assert settings_manager.list_settings(ref('macro')) == ['test1', 'test2']
+    settings_manager.overlay[ref("test2")] = "test2"
+    assert settings_manager.list_settings(ref("macro")) == ["test1", "test2"]
 
 
 def test_list_settings_overlay_override(settings_manager):
     ref = Reference
-    settings_manager.base[ref('test1')] = 'test1'
-    settings_manager.base[ref('micro.test2')] = 1
-    settings_manager.overlay[ref('macro.test1')] = 13
-    settings_manager.overlay[ref('micro.test2')] = 2
+    settings_manager.base[ref("test1")] = "test1"
+    settings_manager.base[ref("micro.test2")] = 1
+    settings_manager.overlay[ref("macro.test1")] = 13
+    settings_manager.overlay[ref("micro.test2")] = 2
 
-    assert settings_manager.list_settings(ref('macro')) == ['test1']
-    assert settings_manager.list_settings(ref('micro')) == ['test1', 'test2']
-    assert settings_manager.list_settings(ref('meso')) == ['test1']
+    assert settings_manager.list_settings(ref("macro")) == ["test1"]
+    assert settings_manager.list_settings(ref("micro")) == ["test1", "test2"]
+    assert settings_manager.list_settings(ref("meso")) == ["test1"]
 
 
 def test_get_setting(settings_manager):
     ref = Reference
-    settings_manager.base[ref('test')] = 13
-    assert settings_manager.get_setting(ref('instance'), ref('test')) == 13
+    settings_manager.base[ref("test")] = 13
+    assert settings_manager.get_setting(ref("instance"), ref("test")) == 13
 
-    settings_manager.overlay[ref('test2')] = 14
-    assert settings_manager.get_setting(ref('instance'), ref('test2')) == 14
+    settings_manager.overlay[ref("test2")] = 14
+    assert settings_manager.get_setting(ref("instance"), ref("test2")) == 14
 
-    settings_manager.base[ref('test2')] = 'test'
-    assert settings_manager.get_setting(ref('instance'), ref('test2')) == 14
+    settings_manager.base[ref("test2")] = "test"
+    assert settings_manager.get_setting(ref("instance"), ref("test2")) == 14
 
     settings_manager.overlay = Settings()
-    assert settings_manager.get_setting(ref('instance'), ref('test2')) == \
-        'test'
+    assert settings_manager.get_setting(ref("instance"), ref("test2")) == "test"
 
-    settings_manager.base[ref('test3')] = 'base_test3'
-    settings_manager.base[ref('instance.test3')] = 'base_instance_test3'
-    assert settings_manager.get_setting(ref('instance'), ref('test3')) == \
-        'base_instance_test3'
-    assert settings_manager.get_setting(ref('instance2'), ref('test3')) == \
-        'base_test3'
+    settings_manager.base[ref("test3")] = "base_test3"
+    settings_manager.base[ref("instance.test3")] = "base_instance_test3"
+    assert (
+        settings_manager.get_setting(ref("instance"), ref("test3"))
+        == "base_instance_test3"
+    )
+    assert settings_manager.get_setting(ref("instance2"), ref("test3")) == "base_test3"
 
-    settings_manager.overlay[ref('test3')] = 'overlay_test3'
-    settings_manager.overlay[ref('instance.test3')] = 'overlay_instance_test3'
-    assert settings_manager.get_setting(ref('instance'), ref('test3')) == \
-        'overlay_instance_test3'
-    assert settings_manager.get_setting(ref('instance2'), ref('test3')) == \
-        'overlay_test3'
+    settings_manager.overlay[ref("test3")] = "overlay_test3"
+    settings_manager.overlay[ref("instance.test3")] = "overlay_instance_test3"
+    assert (
+        settings_manager.get_setting(ref("instance"), ref("test3"))
+        == "overlay_instance_test3"
+    )
+    assert (
+        settings_manager.get_setting(ref("instance2"), ref("test3")) == "overlay_test3"
+    )
 
-    settings_manager.base[ref('instance.test4')] = 'base_test4'
-    settings_manager.overlay[ref('test4')] = 'overlay_test4'
-    assert settings_manager.get_setting(ref('instance'), ref('test4')) == \
-        'base_test4'
+    settings_manager.base[ref("instance.test4")] = "base_test4"
+    settings_manager.overlay[ref("test4")] = "overlay_test4"
+    assert settings_manager.get_setting(ref("instance"), ref("test4")) == "base_test4"
 
-    assert settings_manager.get_setting(ref('instance[10]'), ref('test4')
-                                        ) == 'base_test4'
+    assert (
+        settings_manager.get_setting(ref("instance[10]"), ref("test4")) == "base_test4"
+    )
 
-    settings_manager.base[ref('instance[10].test5')] = 'base_test5'
-    settings_manager.overlay[ref('test5')] = 'overlay_test5'
-    assert settings_manager.get_setting(ref('instance'), ref('test5')) == \
-        'overlay_test5'
-    assert settings_manager.get_setting(ref('instance[10]'), ref('test5')
-                                        ) == 'base_test5'
-    assert settings_manager.get_setting(ref('instance[11]'), ref('test5')
-                                        ) == 'overlay_test5'
+    settings_manager.base[ref("instance[10].test5")] = "base_test5"
+    settings_manager.overlay[ref("test5")] = "overlay_test5"
+    assert (
+        settings_manager.get_setting(ref("instance"), ref("test5")) == "overlay_test5"
+    )
+    assert (
+        settings_manager.get_setting(ref("instance[10]"), ref("test5")) == "base_test5"
+    )
+    assert (
+        settings_manager.get_setting(ref("instance[11]"), ref("test5"))
+        == "overlay_test5"
+    )
 
 
 def test_get_setting_without_default_raises_keyerror(settings_manager):
     ref = Reference
     with pytest.raises(KeyError, match='Value for setting "nonexistent" was not set'):
-        settings_manager.get_setting(ref('instance'), ref('nonexistent'))
+        settings_manager.get_setting(ref("instance"), ref("nonexistent"))

--- a/libmuscle/python/libmuscle/test/test_snapshot.py
+++ b/libmuscle/python/libmuscle/test/test_snapshot.py
@@ -7,21 +7,26 @@ from libmuscle.snapshot import MsgPackSnapshot, Snapshot, SnapshotMetadata
 
 @pytest.fixture
 def snapshot() -> Snapshot:
-    triggers = ['test triggers']
+    triggers = ["test triggers"]
     wallclock_time = 15.3
-    port_message_counts = {'in': [1], 'out': [4], 'muscle_settings_in': [0]}
+    port_message_counts = {"in": [1], "out": [4], "muscle_settings_in": [0]}
     is_final = True
-    message = Message(1.2, data='test_data')
+    message = Message(1.2, data="test_data")
     snapshot = MsgPackSnapshot(
-            triggers, wallclock_time, port_message_counts, is_final, message,
-            Settings({'test': 1}))
+        triggers,
+        wallclock_time,
+        port_message_counts,
+        is_final,
+        message,
+        Settings({"test": 1}),
+    )
     assert snapshot.triggers == triggers
     assert snapshot.wallclock_time == wallclock_time
     assert snapshot.port_message_counts == port_message_counts
     assert snapshot.is_final_snapshot == is_final
     assert snapshot.message == message
-    assert snapshot.settings_overlay.keys() == {'test'}
-    assert snapshot.settings_overlay['test'] == 1
+    assert snapshot.settings_overlay.keys() == {"test"}
+    assert snapshot.settings_overlay["test"] == 1
     return snapshot
 
 
@@ -43,7 +48,7 @@ def test_snapshot(snapshot: Snapshot) -> None:
 
 
 def test_snapshot_metadata(snapshot: Snapshot) -> None:
-    metadata = SnapshotMetadata.from_snapshot(snapshot, 'test')
+    metadata = SnapshotMetadata.from_snapshot(snapshot, "test")
 
     assert metadata.triggers == snapshot.triggers
     assert metadata.wallclock_time == snapshot.wallclock_time
@@ -51,19 +56,19 @@ def test_snapshot_metadata(snapshot: Snapshot) -> None:
     assert metadata.is_final_snapshot == snapshot.is_final_snapshot
     assert metadata.timestamp == snapshot.message.timestamp
     assert metadata.next_timestamp == snapshot.message.next_timestamp
-    assert metadata.snapshot_filename == 'test'
+    assert metadata.snapshot_filename == "test"
 
 
 def test_message_with_settings() -> None:
-    message = Message(1.0, 2.0, 'test_data', Settings({'setting': True}))
+    message = Message(1.0, 2.0, "test_data", Settings({"setting": True}))
     snapshot = MsgPackSnapshot([], 0, {}, False, message, Settings())
-    assert snapshot.message.settings.get('setting') is True
+    assert snapshot.message.settings.get("setting") is True
 
     binary_snapshot = snapshot.to_bytes()
     assert isinstance(binary_snapshot, bytes)
 
     snapshot2 = MsgPackSnapshot.from_bytes(binary_snapshot)
-    assert snapshot2.message.settings.get('setting') is True
+    assert snapshot2.message.settings.get("setting") is True
 
 
 def test_implicit_snapshot() -> None:

--- a/libmuscle/python/libmuscle/test/test_snapshot_manager.py
+++ b/libmuscle/python/libmuscle/test/test_snapshot_manager.py
@@ -12,7 +12,7 @@ def test_no_checkpointing(tmp_path: Path) -> None:
     manager = MagicMock()
     port_manager = MagicMock()
     port_manager.get_message_counts.return_value = {}
-    snapshot_manager = SnapshotManager(Reference('test'), manager, port_manager)
+    snapshot_manager = SnapshotManager(Reference("test"), manager, port_manager)
 
     snapshot_manager.prepare_resume(None, tmp_path)
     assert not snapshot_manager.resuming_from_intermediate()
@@ -22,10 +22,10 @@ def test_no_checkpointing(tmp_path: Path) -> None:
 def test_save_load_snapshot(tmp_path: Path) -> None:
     manager = MagicMock()
     port_manager = MagicMock()
-    port_message_counts = {'in': [1], 'out': [2], 'muscle_settings_in': [0]}
+    port_message_counts = {"in": [1], "out": [2], "muscle_settings_in": [0]}
     port_manager.get_message_counts.return_value = port_message_counts
 
-    instance_id = Reference('test[1]')
+    instance_id = Reference("test[1]")
     snapshot_manager = SnapshotManager(instance_id, manager, port_manager)
 
     snapshot_manager.prepare_resume(None, tmp_path)
@@ -33,14 +33,14 @@ def test_save_load_snapshot(tmp_path: Path) -> None:
     assert not snapshot_manager.resuming_from_final()
 
     snapshot_manager.save_snapshot(
-            Message(0.2, None, 'test data'), False, ['test'], 13.0, None,
-            Settings())
+        Message(0.2, None, "test data"), False, ["test"], 13.0, None, Settings()
+    )
 
     port_manager.get_message_counts.assert_called_with()
     manager.submit_snapshot_metadata.assert_called()
-    metadata, = manager.submit_snapshot_metadata.call_args[0]
+    (metadata,) = manager.submit_snapshot_metadata.call_args[0]
     assert isinstance(metadata, SnapshotMetadata)
-    assert metadata.triggers == ['test']
+    assert metadata.triggers == ["test"]
     assert metadata.wallclock_time == 13.0
     assert metadata.timestamp == 0.2
     assert metadata.next_timestamp is None
@@ -48,7 +48,7 @@ def test_save_load_snapshot(tmp_path: Path) -> None:
     assert not metadata.is_final_snapshot
     snapshot_path = Path(metadata.snapshot_filename)
     assert snapshot_path.parent == tmp_path
-    assert snapshot_path.name == 'test-1_1.pack'
+    assert snapshot_path.name == "test-1_1.pack"
 
     snapshot_manager2 = SnapshotManager(instance_id, manager, port_manager)
 
@@ -60,15 +60,15 @@ def test_save_load_snapshot(tmp_path: Path) -> None:
     msg = snapshot_manager2.load_snapshot()
     assert msg.timestamp == 0.2
     assert msg.next_timestamp is None
-    assert msg.data == 'test data'
+    assert msg.data == "test data"
 
     snapshot_manager2.save_snapshot(
-            Message(0.6, None, 'test data2'), True, ['test'], 42.2, 1.2,
-            Settings())
+        Message(0.6, None, "test data2"), True, ["test"], 42.2, 1.2, Settings()
+    )
 
-    metadata, = manager.submit_snapshot_metadata.call_args[0]
+    (metadata,) = manager.submit_snapshot_metadata.call_args[0]
     assert isinstance(metadata, SnapshotMetadata)
-    assert metadata.triggers == ['test']
+    assert metadata.triggers == ["test"]
     assert metadata.wallclock_time == 42.2
     assert metadata.timestamp == 0.6
     assert metadata.next_timestamp is None
@@ -76,16 +76,16 @@ def test_save_load_snapshot(tmp_path: Path) -> None:
     assert metadata.is_final_snapshot
     snapshot_path = Path(metadata.snapshot_filename)
     assert snapshot_path.parent == tmp_path
-    assert snapshot_path.name == 'test-1_3.pack'
+    assert snapshot_path.name == "test-1_3.pack"
 
 
 def test_save_load_implicit_snapshot(tmp_path: Path) -> None:
     manager = MagicMock()
     port_manager = MagicMock()
-    port_message_counts = {'in': [1], 'out': [2], 'muscle_settings_in': [0]}
+    port_message_counts = {"in": [1], "out": [2], "muscle_settings_in": [0]}
     port_manager.get_message_counts.return_value = port_message_counts
 
-    instance_id = Reference('test[1]')
+    instance_id = Reference("test[1]")
     snapshot_manager = SnapshotManager(instance_id, manager, port_manager)
 
     snapshot_manager.prepare_resume(None, tmp_path)
@@ -93,11 +93,10 @@ def test_save_load_implicit_snapshot(tmp_path: Path) -> None:
     assert not snapshot_manager.resuming_from_intermediate()
     assert not snapshot_manager.resuming_from_final()
     # save implicit snapshot
-    snapshot_manager.save_snapshot(
-            None, True, ['implicit'], 1.0, 1.5, Settings())
+    snapshot_manager.save_snapshot(None, True, ["implicit"], 1.0, 1.5, Settings())
 
     manager.submit_snapshot_metadata.assert_called_once()
-    metadata, = manager.submit_snapshot_metadata.call_args[0]
+    (metadata,) = manager.submit_snapshot_metadata.call_args[0]
     assert isinstance(metadata, SnapshotMetadata)
     snapshot_path = Path(metadata.snapshot_filename)
     manager.submit_snapshot_metadata.reset_mock()
@@ -111,6 +110,5 @@ def test_save_load_implicit_snapshot(tmp_path: Path) -> None:
 
     assert not snapshot_manager2.resuming_from_intermediate()
     assert not snapshot_manager2.resuming_from_final()
-    snapshot_manager2.save_snapshot(
-            None, True, ['implicit'], 12.3, 2.5, Settings())
+    snapshot_manager2.save_snapshot(None, True, ["implicit"], 12.3, 2.5, Settings())
     manager.submit_snapshot_metadata.assert_called_once()

--- a/libmuscle/python/libmuscle/test/test_util.py
+++ b/libmuscle/python/libmuscle/test/test_util.py
@@ -7,21 +7,22 @@ from libmuscle.util import instance_indices, instance_to_kernel
 @pytest.fixture
 def instances() -> list[Reference]:
     return [
-        Reference('test'),
-        Reference('test.test'),
-        Reference('test[4]'),
-        Reference('test[3][2]'),
-        Reference('test.test[3]'),
-        Reference('test.test[1][2]')]
+        Reference("test"),
+        Reference("test.test"),
+        Reference("test[4]"),
+        Reference("test[3][2]"),
+        Reference("test.test[3]"),
+        Reference("test.test[1][2]"),
+    ]
 
 
 def test_instance_to_kernel(instances: list[Reference]) -> None:
-    assert instance_to_kernel(instances[0]) == 'test'
-    assert instance_to_kernel(instances[1]) == 'test.test'
-    assert instance_to_kernel(instances[2]) == 'test'
-    assert instance_to_kernel(instances[3]) == 'test'
-    assert instance_to_kernel(instances[4]) == 'test.test'
-    assert instance_to_kernel(instances[5]) == 'test.test'
+    assert instance_to_kernel(instances[0]) == "test"
+    assert instance_to_kernel(instances[1]) == "test.test"
+    assert instance_to_kernel(instances[2]) == "test"
+    assert instance_to_kernel(instances[3]) == "test"
+    assert instance_to_kernel(instances[4]) == "test.test"
+    assert instance_to_kernel(instances[5]) == "test.test"
 
 
 def test_instance_indices(instances: list[Reference]) -> None:

--- a/libmuscle/python/libmuscle/timestamp.py
+++ b/libmuscle/python/libmuscle/timestamp.py
@@ -9,6 +9,7 @@ class Timestamp:
     Args:
         seconds: The number of seconds since the start of 1970.
     """
+
     def __init__(self, seconds: Optional[float] = None) -> None:
         """Create a Timestamp representing the given time, or now.
 
@@ -26,6 +27,8 @@ class Timestamp:
             by Python's logging subsystem.
         """
         date_time = datetime.datetime.fromtimestamp(self.seconds)
-        whole_part = date_time.strftime('%Y-%m-%d %H:%M:%S')
-        return '%s,%03d' % (    # noqa: UP031
-                whole_part, date_time.time().microsecond / 1000)
+        whole_part = date_time.strftime("%Y-%m-%d %H:%M:%S")
+        return "%s,%03d" % (  # noqa: UP031
+            whole_part,
+            date_time.time().microsecond / 1000,
+        )

--- a/libmuscle/python/libmuscle/util.py
+++ b/libmuscle/python/libmuscle/util.py
@@ -75,11 +75,11 @@ def extract_log_file_location(filename: str) -> Optional[Path]:
     # Neither getopt, optparse, or argparse will let me pick out
     # just one option from the command line and ignore the rest.
     # So we do it by hand.
-    prefix = '--muscle-log-file='
+    prefix = "--muscle-log-file="
     given_path_str = None
     for arg in sys.argv[1:]:
         if arg.startswith(prefix):
-            given_path_str = arg[len(prefix):]
+            given_path_str = arg[len(prefix) :]
 
     if not given_path_str:
         return None
@@ -102,10 +102,10 @@ class Retrier:
     This backs off exponentially, immediately retrying on the first attempt, then
     waiting 2**tries * base_delay seconds between tries.
     """
+
     def __init__(
-            self, timeout: float = _DEFAULT_TIMEOUT,
-            base_delay: float = _DEFAULT_BASE_DELAY
-            ) -> None:
+        self, timeout: float = _DEFAULT_TIMEOUT, base_delay: float = _DEFAULT_BASE_DELAY
+    ) -> None:
         """Create a Retrier.
 
         Args:

--- a/muscle3/conftest.py
+++ b/muscle3/conftest.py
@@ -3,4 +3,4 @@ from pathlib import Path
 
 # Add libmuscle to the Python path, it seems pytest doesn't add it
 # automatically if you're in a parallel directory like here.
-sys.path.append(str(Path(__file__).parent / '..' / 'libmuscle' / 'python'))
+sys.path.append(str(Path(__file__).parent / ".." / "libmuscle" / "python"))

--- a/muscle3/muscle3.py
+++ b/muscle3/muscle3.py
@@ -31,17 +31,25 @@ def muscle3() -> None:
     pass
 
 
-@muscle3.command(short_help='Visualise profiling information')
+@muscle3.command(short_help="Visualise profiling information")
 @click.argument(
-        'performance_file', nargs=1, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True))
-@click.option('-i', '--instances', is_flag=True, help='Show per-instance statistics')
-@click.option('-r', '--resources', is_flag=True, help='Show per-resource statistics')
-@click.option('-t', '--timeline', is_flag=True, help='Show a timeline of events')
+    "performance_file",
+    nargs=1,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+    ),
+)
+@click.option("-i", "--instances", is_flag=True, help="Show per-instance statistics")
+@click.option("-r", "--resources", is_flag=True, help="Show per-resource statistics")
+@click.option("-t", "--timeline", is_flag=True, help="Show a timeline of events")
 def profile(
-        performance_file: str, instances: bool, resources: bool, timeline: bool
-        ) -> None:
+    performance_file: str, instances: bool, resources: bool, timeline: bool
+) -> None:
     """Visualise profiling information.
 
     Takes data from a performance.sqlite file written by the manager,
@@ -72,34 +80,45 @@ def profile(
     if timeline:
         plot_timeline(Path(performance_file))
         click.echo(
-                'Hint: To inspect the timeline in more detail, use the'
-                ' pan and zoom buttons at the bottom of the window.')
+            "Hint: To inspect the timeline in more detail, use the"
+            " pan and zoom buttons at the bottom of the window."
+        )
 
     if instances or resources or timeline:
         show_plots()
     else:
         click.echo(
-                'Please specify -i, -r or -t to choose which data'
-                ' you would like to see.')
+            "Please specify -i, -r or -t to choose which data you would like to see."
+        )
         sys.exit(1)
 
     sys.exit(0)
 
 
-@muscle3.command(short_help='Calculate resources needed for a simulation')
+@muscle3.command(short_help="Calculate resources needed for a simulation")
 @click.argument(
-        'ymmsl_files', nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True))
+    "ymmsl_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+    ),
+)
 @click.option(
-        '-c', '--cores-per-node', nargs=1, type=int, required=True,
-        help='Set number of cores per cluster node.')
-@click.option(
-        '-v', '--verbose', is_flag=True, help='Show instance allocations.')
-def resources(
-        ymmsl_files: Sequence[str],
-        cores_per_node: int, verbose: bool
-        ) -> None:
+    "-c",
+    "--cores-per-node",
+    nargs=1,
+    type=int,
+    required=True,
+    help="Set number of cores per cluster node.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Show instance allocations.")
+def resources(ymmsl_files: Sequence[str], cores_per_node: int, verbose: bool) -> None:
     """Calculate the number of nodes needed to run the simulation.
 
     In order to run a MUSCLE3 simulation on a cluster, a batch job has
@@ -133,9 +152,13 @@ def resources(
         click.echo(_RESOURCES_INCOMPLETE_MODEL, err=True)
         sys.exit(1)
 
-    resources = Resources([
-        OnNodeResources(
-            'node000001', CoreSet([Core(i, {i}) for i in range(cores_per_node)]))])
+    resources = Resources(
+        [
+            OnNodeResources(
+                "node000001", CoreSet([Core(i, {i}) for i in range(cores_per_node)])
+            )
+        ]
+    )
 
     planner = Planner(resources)
     try:
@@ -149,33 +172,42 @@ def resources(
     if verbose:
         click.echo()
         if num_nodes == 1:
-            click.echo('A total of 1 node will be needed, as follows:')
+            click.echo("A total of 1 node will be needed, as follows:")
         else:
-            click.echo(
-                    f'A total of {num_nodes} nodes will be needed,'
-                    ' as follows:')
+            click.echo(f"A total of {num_nodes} nodes will be needed, as follows:")
 
         click.echo()
         for instance in sorted(allocations):
-            click.echo(f'{instance}: {str(allocations[instance])}')
+            click.echo(f"{instance}: {str(allocations[instance])}")
     else:
-        click.echo(f'{num_nodes}', nl=False)
+        click.echo(f"{num_nodes}", nl=False)
 
     sys.exit(0)
 
 
-@muscle3.command(short_help='Display details of a stored snapshot')
+@muscle3.command(short_help="Display details of a stored snapshot")
 @click.argument(
-        'snapshot_files', nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True, path_type=Path))
+    "snapshot_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+        path_type=Path,
+    ),
+)
 @click.option(
-        '-d', '--data', is_flag=True,
-        help='Display stored data. Note this may result in a lot of output!')
-@click.option(
-        '-v', '--verbose', is_flag=True, help='Display more metadata.')
-def snapshot(
-        snapshot_files: Sequence[Path], data: bool, verbose: bool) -> None:
+    "-d",
+    "--data",
+    is_flag=True,
+    help="Display stored data. Note this may result in a lot of output!",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Display more metadata.")
+def snapshot(snapshot_files: Sequence[Path], data: bool, verbose: bool) -> None:
     """Display information about stored snapshots.
 
     Per provided snapshot, display metadata. Stored data can also be output by
@@ -184,24 +216,30 @@ def snapshot(
     """
     for file in snapshot_files:
         snapshot = SnapshotManager.load_snapshot_from_file(file)
-        click.echo(f'Snapshot at {file}:')
-        typ = 'Final' if snapshot.is_final_snapshot else 'Intermediate'
-        properties = OrderedDict([
-            ('Snapshot type', typ),
-            ('Snapshot timestamp',
-             snapshot.message.timestamp if snapshot.message else float('-inf')),
-            ('Snapshot wallclock time', snapshot.wallclock_time),
-            ('Snapshot triggers', snapshot.triggers),
-        ])
+        click.echo(f"Snapshot at {file}:")
+        typ = "Final" if snapshot.is_final_snapshot else "Intermediate"
+        properties = OrderedDict(
+            [
+                ("Snapshot type", typ),
+                (
+                    "Snapshot timestamp",
+                    snapshot.message.timestamp if snapshot.message else float("-inf"),
+                ),
+                ("Snapshot wallclock time", snapshot.wallclock_time),
+                ("Snapshot triggers", snapshot.triggers),
+            ]
+        )
         if verbose:
-            properties.update([
-                ('Internal: Port message counts', snapshot.port_message_counts),
-            ])
+            properties.update(
+                [
+                    ("Internal: Port message counts", snapshot.port_message_counts),
+                ]
+            )
         for prop_name, prop_value in properties.items():
-            click.secho(f'{prop_name}: ', nl=False, bold=True)
+            click.secho(f"{prop_name}: ", nl=False, bold=True)
             click.echo(prop_value)
         if data:
-            click.secho('Snapshot data:', bold=True)
+            click.secho("Snapshot data:", bold=True)
             if snapshot.message is not None:
                 click.echo(snapshot.message.data)
             else:
@@ -224,5 +262,5 @@ def _load_ymmsl_files(ymmsl_files: Sequence[str]) -> Configuration:
     return configuration
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     muscle3()

--- a/muscle3/muscle_manager.py
+++ b/muscle3/muscle_manager.py
@@ -23,58 +23,88 @@ from ymmsl.v0_2 import ExecutionModel
 
 @click.command(no_args_is_help=True)
 @click.argument(
-        'ymmsl_files', nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True))
+    "ymmsl_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+    ),
+)
 @click.option(
-        '--log-level', nargs=1, type=str, default='INFO', show_default=True,
-        help='Set the local log level. Try DEBUG for (much) more output.')
+    "--log-level",
+    nargs=1,
+    type=str,
+    default="INFO",
+    show_default=True,
+    help="Set the local log level. Try DEBUG for (much) more output.",
+)
 @click.option(
-        '--run-dir', nargs=1, type=click.Path(
-            exists=True, file_okay=False, dir_okay=True, readable=True,
-            writable=True, allow_dash=False, resolve_path=True),
-        help=(
-            'Directory to write logs, run metadata and output to. By default,'
-            ' a directory with the name run_<model>_<date>-<time> will be'
-            ' created.')
-        )
+    "--run-dir",
+    nargs=1,
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        writable=True,
+        allow_dash=False,
+        resolve_path=True,
+    ),
+    help=(
+        "Directory to write logs, run metadata and output to. By default,"
+        " a directory with the name run_<model>_<date>-<time> will be"
+        " created."
+    ),
+)
 @click.option(
-        '--location-file', nargs=1, type=click.Path(
-            exists=False, file_okay=True, dir_okay=True, readable=False,
-            allow_dash=True),
-        help=(
-            'File to write the network location of the manager to. This is'
-            ' useful when --start-all is not specified, or when --start-all'
-            ' is used together with manually started instances. If a relative'
-            ' path is given, then it will be resolved relative to the'
-            ' directory in which the manager was started.'
-            '\b\n\n'
-            ' The manager will write to this file a single line of text,'
-            ' which should be passed to the instances via the'
-            ' MUSCLE_MANAGER environment variable or on their command line'
-            ' using the --muscle-manager=<contents> option.'
-            '\b\n\n'
-            ' If --start-all is not specified (or if there are manual'
-            ' components) and --location-file is also not given, then the'
-            ' location will be printed on standard output.'
-            '\b\n\n')
-        )
+    "--location-file",
+    nargs=1,
+    type=click.Path(
+        exists=False, file_okay=True, dir_okay=True, readable=False, allow_dash=True
+    ),
+    help=(
+        "File to write the network location of the manager to. This is"
+        " useful when --start-all is not specified, or when --start-all"
+        " is used together with manually started instances. If a relative"
+        " path is given, then it will be resolved relative to the"
+        " directory in which the manager was started."
+        "\b\n\n"
+        " The manager will write to this file a single line of text,"
+        " which should be passed to the instances via the"
+        " MUSCLE_MANAGER environment variable or on their command line"
+        " using the --muscle-manager=<contents> option."
+        "\b\n\n"
+        " If --start-all is not specified (or if there are manual"
+        " components) and --location-file is also not given, then the"
+        " location will be printed on standard output."
+        "\b\n\n"
+    ),
+)
 @click.option(
-        '--start-all/--no-start-all', default=False, help=(
-            'Start all submodel instances listed in the configuration file(s).')
-        )
+    "--start-all/--no-start-all",
+    default=False,
+    help=("Start all submodel instances listed in the configuration file(s)."),
+)
 @click.option(
-        '-m', '--model', nargs=1, type=str, help=(
-            'Start the specified model, which must be present in the ymmsl files')
-        )
+    "-m",
+    "--model",
+    nargs=1,
+    type=str,
+    help=("Start the specified model, which must be present in the ymmsl files"),
+)
 def manage_simulation(
-        ymmsl_files: Sequence[str],
-        start_all: bool,
-        model: Optional[str],
-        run_dir: Optional[str],
-        log_level: Optional[str],
-        location_file: Optional[str]
-        ) -> None:
+    ymmsl_files: Sequence[str],
+    start_all: bool,
+    model: Optional[str],
+    run_dir: Optional[str],
+    log_level: Optional[str],
+    location_file: Optional[str],
+) -> None:
     """Run the MUSCLE3 Manager.
 
     This is a thin wrapper so that we can call the implementation directly for testing
@@ -85,13 +115,13 @@ def manage_simulation(
 
 
 def _manage_simulation(
-        ymmsl_files: Sequence[str],
-        start_all: bool,
-        model: Optional[str],
-        run_dir: Optional[str],
-        log_level: Optional[str],
-        location_file: Optional[str]
-        ) -> None:
+    ymmsl_files: Sequence[str],
+    start_all: bool,
+    model: Optional[str],
+    run_dir: Optional[str],
+    log_level: Optional[str],
+    location_file: Optional[str],
+) -> None:
     """Run the MUSCLE3 Manager.
 
     The MUSCLE manager manages a coupled simulation. It can start the
@@ -109,14 +139,17 @@ def _manage_simulation(
         configuration = load_configuration(ymmsl_files)
         v0_2.resolve(v0_2.Reference([]), configuration)
     except RuntimeError as e:
-        print(f'An error occurred while loading the ymmsl files:\n{e}')
+        print(f"An error occurred while loading the ymmsl files:\n{e}")
         sys.exit(1)
 
     try:
         configuration.check_consistent(start_all, model)
     except Exception as exc:
-        print('Failed to start the simulation, found a configuration error:\n' +
-              textwrap.indent(str(exc), 4*' '), file=sys.stderr)
+        print(
+            "Failed to start the simulation, found a configuration error:\n"
+            + textwrap.indent(str(exc), 4 * " "),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # find root models, error if multiple
@@ -125,15 +158,16 @@ def _manage_simulation(
         try:
             model_ref = v0_2.Reference(model)
         except RuntimeError as e:
-            raise RuntimeError(f'An invalid model name was given: {e}') from None
+            raise RuntimeError(f"An invalid model name was given: {e}") from None
 
     try:
         root_model = configuration.root_model(model_ref)
     except RuntimeError as e:
         print(e, file=sys.stderr)
         print(
-                'Please add or remove models, or select one using the -m option.',
-                file=sys.stderr)
+            "Please add or remove models, or select one using the -m option.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     run_dir_obj = create_run_dir(run_dir, root_model)
@@ -151,11 +185,11 @@ def _manage_simulation(
             manager.start_instances()
         except Exception as exc:
             manager.stop()
-            print('Failed to start the simulation:', file=sys.stderr)
-            print(textwrap.indent(str(exc), 4*' '), file=sys.stderr)
+            print("Failed to start the simulation:", file=sys.stderr)
+            print(textwrap.indent(str(exc), 4 * " "), file=sys.stderr)
             print(file=sys.stderr)
-            print('Check the manager log for more details:', file=sys.stderr)
-            print('   ', run_dir_obj.path / 'muscle3_manager.log', file=sys.stderr)
+            print("Check the manager log for more details:", file=sys.stderr)
+            print("   ", run_dir_obj.path / "muscle3_manager.log", file=sys.stderr)
             sys.exit(1)
 
     if not start_all or has_manual_components:
@@ -168,27 +202,27 @@ def _manage_simulation(
     success = manager.wait()
 
     if not success:
-        log_file = run_dir_obj.path / 'muscle3_manager.log'
+        log_file = run_dir_obj.path / "muscle3_manager.log"
 
         print()
-        print('An error occurred during execution, and the simulation was')
-        print('shut down. The manager log should tell you what happened.')
-        print('Here are the final lines of the manager log:')
+        print("An error occurred during execution, and the simulation was")
+        print("shut down. The manager log should tell you what happened.")
+        print("Here are the final lines of the manager log:")
         print()
-        print('-' * 80)
-        print(last_lines(log_file, 50), '    ')
-        print('-' * 80)
+        print("-" * 80)
+        print(last_lines(log_file, 50), "    ")
+        print("-" * 80)
         print()
-        print('You can find the full log at')
+        print("You can find the full log at")
         print(str(log_file))
         print()
     else:
-        print('Simulation completed successfully.')
+        print("Simulation completed successfully.")
         try:
             rel_run_dir = run_dir_obj.path.relative_to(Path.cwd())
-            print(f'Output may be found in {rel_run_dir}')
+            print(f"Output may be found in {rel_run_dir}")
         except ValueError:
-            print(f'Output may be found in {run_dir_obj.path}')
+            print(f"Output may be found in {run_dir_obj.path}")
 
     sys.exit(0 if success else 1)
 
@@ -208,14 +242,14 @@ def load_configuration(paths: Sequence[str]) -> v0_2.Configuration:
             config_v1.update(cast(v0_1.PartialConfiguration, d))
 
         with catch_warnings():
-            filterwarnings('ignore', 'In yMMSL v0.2.*')
-            filterwarnings('ignore', 'Comments can unfortunately.*')
+            filterwarnings("ignore", "In yMMSL v0.2.*")
+            filterwarnings("ignore", "Comments can unfortunately.*")
             return ymmsl.convert_to(v0_2.Configuration, config_v1)
     else:
         # convert to v0.2 if needed and merge v0.2 style
         with catch_warnings():
-            filterwarnings('ignore', 'In yMMSL v0.2.*')
-            filterwarnings('ignore', 'Comments can unfortunately.*')
+            filterwarnings("ignore", "In yMMSL v0.2.*")
+            filterwarnings("ignore", "Comments can unfortunately.*")
             config_v2 = ymmsl.convert_to(v0_2.Configuration, docs[0])
 
             for d in docs[1:]:
@@ -239,9 +273,10 @@ def load_files(paths: Sequence[str]) -> list[Document]:
             # - value errors thrown by constructors (e.g. specifying duplicate port
             #   names)
             print(
-                    f"Recognition error while loading configuration file '{path}':",
-                    file=sys.stderr)
-            print(textwrap.indent(str(exc), 4*' '), file=sys.stderr)
+                f"Recognition error while loading configuration file '{path}':",
+                file=sys.stderr,
+            )
+            print(textwrap.indent(str(exc), 4 * " "), file=sys.stderr)
             sys.exit(1)
         except Exception:
             # Any other error is not anticipated
@@ -249,8 +284,10 @@ def load_files(paths: Sequence[str]) -> list[Document]:
             traceback.print_exc()
             print(file=sys.stderr)
             print(
-                    'This error could indicate a bug in libmuscle, please make an issue'
-                    ' on GitHub.', file=sys.stderr)
+                "This error could indicate a bug in libmuscle, please make an issue"
+                " on GitHub.",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
     return docs
@@ -269,19 +306,20 @@ def create_run_dir(run_dir: Optional[str], model: v0_2.Model) -> RunDir:
     if run_dir is None:
         for _ in range(10):
             timestamp = datetime.now()
-            timestr = timestamp.strftime('%Y%m%d_%H%M%S')
-            run_dir_path = Path.cwd() / f'run_{model.name}_{timestr}'
+            timestr = timestamp.strftime("%Y%m%d_%H%M%S")
+            run_dir_path = Path.cwd() / f"run_{model.name}_{timestr}"
             if not run_dir_path.exists():
                 break
             sleep(1.0)
         else:
             raise RuntimeError(
-                    f'Tried to create run dir at {run_dir_path} but it already exists')
+                f"Tried to create run dir at {run_dir_path} but it already exists"
+            )
     else:
         run_dir_path = Path(run_dir).resolve()
 
     return RunDir(run_dir_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     manage_simulation()

--- a/muscle3/profiling.py
+++ b/muscle3/profiling.py
@@ -29,18 +29,18 @@ def plot_instances(performance_file: Path) -> None:
 
     width = 0.5
     bottom = np.zeros(len(instances))
-    ax.bar(instances, compute, width, label='Compute', bottom=bottom)
+    ax.bar(instances, compute, width, label="Compute", bottom=bottom)
     bottom += compute
-    ax.bar(instances, transfer, width, label='Transfer', bottom=bottom)
+    ax.bar(instances, transfer, width, label="Transfer", bottom=bottom)
     bottom += transfer
-    ax.bar(instances, wait, width, label='Wait', bottom=bottom)
-    ax.set_title('Simulation component time breakdown')
-    ax.set_xlabel('Instance')
-    ax.tick_params(axis='x', labelrotation = 45)
+    ax.bar(instances, wait, width, label="Wait", bottom=bottom)
+    ax.set_title("Simulation component time breakdown")
+    ax.set_xlabel("Instance")
+    ax.tick_params(axis="x", labelrotation=45)
     for label in ax.xaxis.get_ticklabels():
-        label.set_horizontalalignment('right')
-    ax.set_ylabel('Total time (s)')
-    fig.legend(loc='outside right center')
+        label.set_horizontalalignment("right")
+    ax.set_ylabel("Total time (s)")
+    fig.legend(loc="outside right center")
     # bottom=0.3 leaves space for x-axis labels
     # right=0.8 leaves 20% for the legend
     fig.subplots_adjust(bottom=0.3, right=0.8)
@@ -65,7 +65,7 @@ def plot_resources(performance_file: Path) -> None:
     for data in stats.values():
         for instance in data.keys():
             if instance not in palette:
-                palette[instance] = f'C{next_color}'
+                palette[instance] = f"C{next_color}"
                 next_color += 1
 
     fig, ax = plt.subplots()
@@ -78,54 +78,64 @@ def plot_resources(performance_file: Path) -> None:
                 label: Optional[str] = instance
                 seen_instances.add(instance)
             else:
-                label = '_'
+                label = "_"
 
             ax.bar(
-                    i, time, _BAR_WIDTH,
-                    label=label, bottom=bottom, color=palette[instance])
+                i, time, _BAR_WIDTH, label=label, bottom=bottom, color=palette[instance]
+            )
             bottom += time
 
     ax.set_xticks(range(len(stats)))
     ax.set_xticklabels(stats.keys())
 
-    ax.set_title('Per-core time breakdown')
-    ax.set_xlabel('Core')
-    ax.tick_params(axis='x', labelrotation = 45)
+    ax.set_title("Per-core time breakdown")
+    ax.set_xlabel("Core")
+    ax.tick_params(axis="x", labelrotation=45)
     for tick_label in ax.xaxis.get_ticklabels():
-        tick_label.set_horizontalalignment('right')
-    ax.set_ylabel('Total time (s)')
-    fig.legend(loc='outside right center')
+        tick_label.set_horizontalalignment("right")
+    ax.set_ylabel("Total time (s)")
+    fig.legend(loc="outside right center")
     # bottom=0.3 leaves space for x-axis labels
     # right=0.8 leaves 20% for the legend
     fig.subplots_adjust(bottom=0.3, right=0.8)
 
 
 _EVENT_TYPES = (
-        'REGISTER', 'CONNECT', 'SHUTDOWN_WAIT', 'DISCONNECT_WAIT', 'SHUTDOWN',
-        'DEREGISTER', 'SEND', 'RECEIVE_WAIT', 'RECEIVE_TRANSFER', 'RECEIVE_DECODE')
+    "REGISTER",
+    "CONNECT",
+    "SHUTDOWN_WAIT",
+    "DISCONNECT_WAIT",
+    "SHUTDOWN",
+    "DEREGISTER",
+    "SEND",
+    "RECEIVE_WAIT",
+    "RECEIVE_TRANSFER",
+    "RECEIVE_DECODE",
+)
 
 
 _EVENT_PALETTE = {
-        'REGISTER': '#910f33',
-        'CONNECT': '#c85172',
-        'SHUTDOWN_WAIT': '#ffdddd',
-        'DISCONNECT_WAIT': '#eedddd',
-        'SHUTDOWN': '#c85172',
-        'DEREGISTER': '#910f33',
-        'RECEIVE_WAIT': '#cccccc',
-        'RECEIVE_TRANSFER': '#ff7d00',
-        'RECEIVE_DECODE': '#ccff00',
-        'SEND': '#0095bf'}
+    "REGISTER": "#910f33",
+    "CONNECT": "#c85172",
+    "SHUTDOWN_WAIT": "#ffdddd",
+    "DISCONNECT_WAIT": "#eedddd",
+    "SHUTDOWN": "#c85172",
+    "DEREGISTER": "#910f33",
+    "RECEIVE_WAIT": "#cccccc",
+    "RECEIVE_TRANSFER": "#ff7d00",
+    "RECEIVE_DECODE": "#ccff00",
+    "SEND": "#0095bf",
+}
 
 
 _MAX_EVENTS = 5000
 
 
 _CUTOFF_TEXT = (
-        'Warning: data was omitted from the plot in the\n crosshatched'
-        ' areas to improve performance.\n Please zoom or pan using the'
-        ' tools at the bottom\n of the window to see the missing events.'
-        )
+    "Warning: data was omitted from the plot in the\n crosshatched"
+    " areas to improve performance.\n Please zoom or pan using the"
+    " tools at the bottom\n of the window to see the missing events."
+)
 
 
 _BAR_WIDTH = 0.8
@@ -137,6 +147,7 @@ class TimelinePlot:
     This implements on-demand loading of events as the user pans and
     zooms.
     """
+
     def __init__(self, performance_file: Path) -> None:
         """Create a TimelinePlot
 
@@ -164,17 +175,21 @@ class TimelinePlot:
         self._min_db_time = self._cur.fetchall()[0][0]
 
         self._cur.execute(
-                "SELECT instance_oid, (start_time - ?) * 1e-9"
-                " FROM events AS e"
-                " JOIN event_types AS et ON (e.event_type_oid = et.oid)"
-                " WHERE et.name = 'REGISTER'", (self._min_db_time,))
+            "SELECT instance_oid, (start_time - ?) * 1e-9"
+            " FROM events AS e"
+            " JOIN event_types AS et ON (e.event_type_oid = et.oid)"
+            " WHERE et.name = 'REGISTER'",
+            (self._min_db_time,),
+        )
         begin_times = dict(self._cur.fetchall())
 
         self._cur.execute(
-                "SELECT instance_oid, (stop_time - ?) * 1e-9"
-                " FROM events AS e"
-                " JOIN event_types AS et ON (e.event_type_oid = et.oid)"
-                " WHERE et.name = 'DEREGISTER'", (self._min_db_time,))
+            "SELECT instance_oid, (stop_time - ?) * 1e-9"
+            " FROM events AS e"
+            " JOIN event_types AS et ON (e.event_type_oid = et.oid)"
+            " WHERE et.name = 'DEREGISTER'",
+            (self._min_db_time,),
+        )
         end_times = dict(self._cur.fetchall())
 
         instances = sorted(begin_times.keys())
@@ -182,69 +197,90 @@ class TimelinePlot:
 
         if not begin_times:
             raise RuntimeError(
-                    'This database appears to be empty. Did the simulation crash'
-                    ' before any data were generated?')
+                "This database appears to be empty. Did the simulation crash"
+                " before any data were generated?"
+            )
 
         # Rest of plot
-        ax.set_title('Execution timeline')
-        ax.set_xlabel('Wallclock time (s)')
+        ax.set_title("Execution timeline")
+        ax.set_xlabel("Wallclock time (s)")
 
         # Background
         running_artist = ax.barh(
-                instances,
-                [end_times[i] - begin_times[i] for i in instances],
-                _BAR_WIDTH,
-                left=[begin_times[i] for i in instances],
-                label='RUNNING', color='#444444'
-                )
+            instances,
+            [end_times[i] - begin_times[i] for i in instances],
+            _BAR_WIDTH,
+            left=[begin_times[i] for i in instances],
+            label="RUNNING",
+            color="#444444",
+        )
 
         # Initial events plot
         xmin = min(begin_times.values())
         self._global_xmax = max(end_times.values())
 
-        first_cutoff = float('inf')
+        first_cutoff = float("inf")
         self._bars = dict()
         for event_type in _EVENT_TYPES:
             instances, start_times, durations, cutoff = self.get_data(
-                    event_type, xmin, self._global_xmax)
+                event_type, xmin, self._global_xmax
+            )
 
             if not instances:
                 # Work around https://github.com/matplotlib/matplotlib/issues/21506
-                instances = ['']
-                start_times = [float('NaN')]
-                durations = [float('NaN')]
+                instances = [""]
+                start_times = [float("NaN")]
+                durations = [float("NaN")]
 
             self._bars[event_type] = ax.barh(
-                    instances, durations, _BAR_WIDTH,
-                    label=event_type, left=start_times,
-                    color=_EVENT_PALETTE[event_type])
+                instances,
+                durations,
+                _BAR_WIDTH,
+                label=event_type,
+                left=start_times,
+                color=_EVENT_PALETTE[event_type],
+            )
             if cutoff:
                 first_cutoff = min(first_cutoff, cutoff)
 
         # Initial cut-off area
-        if first_cutoff != float('inf'):
-            self._bars['_CUTOFF'] = ax.barh(
-                    self._instances, self._global_xmax - first_cutoff, _BAR_WIDTH,
-                    label='Not shown', left=first_cutoff,
-                    color='#FFFFFF', hatch='x')
+        if first_cutoff != float("inf"):
+            self._bars["_CUTOFF"] = ax.barh(
+                self._instances,
+                self._global_xmax - first_cutoff,
+                _BAR_WIDTH,
+                label="Not shown",
+                left=first_cutoff,
+                color="#FFFFFF",
+                hatch="x",
+            )
             self._cutoff_warning = ax.text(
-                    0.02, 0.02, _CUTOFF_TEXT, transform=ax.transAxes, fontsize=12,
-                    verticalalignment='bottom', horizontalalignment='left', wrap=True,
-                    bbox={
-                        'facecolor': '#ffcccc', 'alpha': 0.75})
+                0.02,
+                0.02,
+                _CUTOFF_TEXT,
+                transform=ax.transAxes,
+                fontsize=12,
+                verticalalignment="bottom",
+                horizontalalignment="left",
+                wrap=True,
+                bbox={"facecolor": "#ffcccc", "alpha": 0.75},
+            )
 
         ax.set_autoscale_on(True)
-        ax.callbacks.connect('xlim_changed', self.update_data)
+        ax.callbacks.connect("xlim_changed", self.update_data)
 
         ordered_artists = [self._bars[event_type][0] for event_type in _EVENT_TYPES]
         ordered_names = list(_EVENT_TYPES)
 
         ordered_artists.insert(6, running_artist)
-        ordered_names.insert(6, 'RUNNING')
+        ordered_names.insert(6, "RUNNING")
 
         fig.legend(
-                ordered_artists, ordered_names, loc='outside right center',
-                bbox_to_anchor=(1.0, 0.6))
+            ordered_artists,
+            ordered_names,
+            loc="outside right center",
+            bbox_to_anchor=(1.0, 0.6),
+        )
         cast(Figure, ax.figure).canvas.draw_idle()
 
     def close(self) -> None:
@@ -252,8 +288,8 @@ class TimelinePlot:
         self._cur.close()
 
     def get_data(
-            self, event_type: str, xmin: float, xmax: float
-            ) -> tuple[list[int], list[float], list[float], Optional[float]]:
+        self, event_type: str, xmin: float, xmax: float
+    ) -> tuple[list[int], list[float], list[float], Optional[float]]:
         """Get events from the database
 
         Returns three lists with instance oid, start time and duration, and
@@ -266,27 +302,34 @@ class TimelinePlot:
             xmax: Time point before which the event must have started
         """
         self._cur.execute(
-                "SELECT"
-                "  instance_oid, (start_time - ?) * 1e-9,"
-                "  (stop_time - start_time) * 1e-9"
-                " FROM events AS e"
-                " JOIN event_types AS et ON (e.event_type_oid = et.oid)"
-                " WHERE et.name = ?"
-                " AND (start_time - ?) * 1e-9 <= ?"
-                " AND ? <= (stop_time - ?) * 1e-9"
-                " ORDER BY start_time ASC"
-                " LIMIT ?",
-                (
-                    self._min_db_time, event_type, self._min_db_time, xmax,
-                    xmin, self._min_db_time, _MAX_EVENTS))
+            "SELECT"
+            "  instance_oid, (start_time - ?) * 1e-9,"
+            "  (stop_time - start_time) * 1e-9"
+            " FROM events AS e"
+            " JOIN event_types AS et ON (e.event_type_oid = et.oid)"
+            " WHERE et.name = ?"
+            " AND (start_time - ?) * 1e-9 <= ?"
+            " AND ? <= (stop_time - ?) * 1e-9"
+            " ORDER BY start_time ASC"
+            " LIMIT ?",
+            (
+                self._min_db_time,
+                event_type,
+                self._min_db_time,
+                xmax,
+                xmin,
+                self._min_db_time,
+                _MAX_EVENTS,
+            ),
+        )
         results = self._cur.fetchall()
         if not results:
             return list(), list(), list(), None
 
         if len(results) == _MAX_EVENTS:
-            return tuple(zip(*results)) + (results[-1][1],)    # type: ignore
+            return tuple(zip(*results)) + (results[-1][1],)  # type: ignore
 
-        return tuple(zip(*results)) + (None,)    # type: ignore
+        return tuple(zip(*results)) + (None,)  # type: ignore
 
     def update_data(self, ax: Axes) -> None:
         """Update the plot after the axes have changed
@@ -301,7 +344,8 @@ class TimelinePlot:
 
         for event_type in _EVENT_TYPES:
             instances, start_times, durations, cutoff = self.get_data(
-                    event_type, xmin, xmax)
+                event_type, xmin, xmax
+            )
             if instances:
                 # update existing rectangles
                 bars = self._bars[event_type].patches
@@ -319,8 +363,8 @@ class TimelinePlot:
                     bars[i].set_visible(False)
 
             # update cutoff bars, if any
-            if '_CUTOFF' in self._bars:
-                bars = self._bars['_CUTOFF'].patches
+            if "_CUTOFF" in self._bars:
+                bars = self._bars["_CUTOFF"].patches
                 if cutoff:
                     for bar in bars:
                         bar.set_x(cutoff)
@@ -333,7 +377,7 @@ class TimelinePlot:
                     self._cutoff_warning.set_visible(False)
 
 
-tplot = None    # type: Optional[TimelinePlot]
+tplot = None  # type: Optional[TimelinePlot]
 
 
 def plot_timeline(performance_file: Path) -> None:
@@ -343,6 +387,6 @@ def plot_timeline(performance_file: Path) -> None:
 
 def show_plots() -> None:
     """Actually show the plots on screen"""
-    plt.show()      # type: ignore
+    plt.show()  # type: ignore
     if tplot:
         tplot.close()

--- a/scripts/api_generator.py
+++ b/scripts/api_generator.py
@@ -7,32 +7,32 @@ from textwrap import dedent, indent
 from typing import Any, Callable, Optional, Union, cast
 
 error_codes = {
-        'success': 0,
-        'domain_error': 1,
-        'out_of_range': 2,
-        'logic_error': 3,
-        'runtime_error': 4,
-        'bad_cast': 5
-        }
+    "success": 0,
+    "domain_error": 1,
+    "out_of_range": 2,
+    "logic_error": 3,
+    "runtime_error": 4,
+    "bad_cast": 5,
+}
 
 
 kinds = {
-        'int1': 'selected_int_kind(2)',
-        'int2': 'selected_int_kind(4)',
-        'int4': 'selected_int_kind(9)',
-        'int8': 'selected_int_kind(18)',
-        'size': 'c_size_t',
-        'real4': 'selected_real_kind(6)',
-        'real8': 'selected_real_kind(15)'
-        }
+    "int1": "selected_int_kind(2)",
+    "int2": "selected_int_kind(4)",
+    "int4": "selected_int_kind(9)",
+    "int8": "selected_int_kind(18)",
+    "size": "c_size_t",
+    "real4": "selected_real_kind(6)",
+    "real8": "selected_real_kind(15)",
+}
 
 
 def banner(comment_mark: str) -> str:
-    """Generate a warning banner.
-    """
+    """Generate a warning banner."""
     return (
-            f'{comment_mark} This is generated code. If it\'s broken, then you should\n'
-            f'{comment_mark} fix the generation script, not this file.\n\n\n')
+        f"{comment_mark} This is generated code. If it's broken, then you should\n"
+        f"{comment_mark} fix the generation script, not this file.\n\n\n"
+    )
 
 
 class Par(abc.ABC):
@@ -79,7 +79,7 @@ class Par(abc.ABC):
     - f_chain_arg: Fortran API, arguments to supply to the Fortran C call.
     """
 
-    def __init__(self, name: str = 'ret_val') -> None:
+    def __init__(self, name: str = "ret_val") -> None:
         """Create a parameter description.
 
         Args:
@@ -89,8 +89,8 @@ class Par(abc.ABC):
         self.class_name = ""
 
     def set_ns_prefix(
-            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
-            ) -> None:
+        self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
+    ) -> None:
         """Sets the namespace prefix correctly for all members.
 
         Args:
@@ -110,29 +110,24 @@ class Par(abc.ABC):
         Used when generating a name for instantiated templates."""
 
     @abc.abstractmethod
-    def fc_cpp_type(self) -> str:
-        ...
+    def fc_cpp_type(self) -> str: ...
 
     @abc.abstractmethod
-    def fc_cpp_arg(self) -> str:
-        ...
+    def fc_cpp_arg(self) -> str: ...
 
     @abc.abstractmethod
     def fc_type(self) -> list[tuple[str, str]]:
-        """Format: [(C type, name_postfix), ...]
-        """
+        """Format: [(C type, name_postfix), ...]"""
         ...
 
     @abc.abstractmethod
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        """Format: [(C type, name_postfix), ...]
-        """
+        """Format: [(C type, name_postfix), ...]"""
         ...
 
     @abc.abstractmethod
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        """Format: [(F type, name_postfix), ...]
-        """
+        """Format: [(F type, name_postfix), ...]"""
         ...
 
     @abc.abstractmethod
@@ -144,32 +139,28 @@ class Par(abc.ABC):
         """
 
     @abc.abstractmethod
-    def fi_type(self) -> list[tuple[str, str]]:
-        ...
+    def fi_type(self) -> list[tuple[str, str]]: ...
 
     @abc.abstractmethod
-    def f_type(self) -> list[tuple[str, str]]:
-        ...
+    def f_type(self) -> list[tuple[str, str]]: ...
 
     @abc.abstractmethod
-    def fc_get_result(self, cpp_chain_call: str) -> str:
-        ...
+    def fc_get_result(self, cpp_chain_call: str) -> str: ...
 
     @abc.abstractmethod
-    def fc_return(self) -> str:
-        ...
+    def fc_return(self) -> str: ...
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    {result_name} = {call}\n'
+        return f"    {result_name} = {call}\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return f'    {return_name} = {result_name}\n'
+        return f"    {return_name} = {result_name}\n"
 
     def fc_return_default(self) -> str:
-        return 'return {};'
+        return "return {};"
 
     def fc_convert_input(self) -> str:
-        return ''
+        return ""
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
         return list()
@@ -178,11 +169,11 @@ class Par(abc.ABC):
         return self.name
 
     def f_return_dummy_result(self, return_name: str) -> str:
-        return ''
+        return ""
 
-    def _regular_type(self,
-                      short_type: Union[str, list[Union[str, tuple[str, str]]]]
-                      ) -> list[tuple[str, str]]:
+    def _regular_type(
+        self, short_type: Union[str, list[Union[str, tuple[str, str]]]]
+    ) -> list[tuple[str, str]]:
         """Converts brief type description to more regular format.
 
         This is a helper function for derived classes. Output is a list
@@ -201,30 +192,30 @@ class Par(abc.ABC):
         The name_prefix defaults to an empty string where not given.
         """
         if isinstance(short_type, str):
-            return [(short_type, '')]
+            return [(short_type, "")]
         elif isinstance(short_type, list):
             result = list()  # type: list[tuple[str, str]]
             for st in short_type:
                 if isinstance(st, str):
-                    result.append((st, ''))
+                    result.append((st, ""))
                 else:
                     result.append(st)
             return result
-        raise ValueError(f'Invalid short type {short_type}')
+        raise ValueError(f"Invalid short type {short_type}")
 
 
 class Void(Par):
     def tname(self) -> str:
-        return 'void'
+        return "void"
 
     def fc_cpp_type(self) -> str:
-        return 'void'
+        return "void"
 
     def fc_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("Cannot use void as argument")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('void')
+        return self._regular_type("void")
 
     def fi_type(self) -> list[tuple[str, str]]:
         raise NotImplementedError("Cannot use void as argument")
@@ -245,468 +236,489 @@ class Void(Par):
         return cpp_chain_call
 
     def fc_return(self) -> str:
-        return '    return;\n'
+        return "    return;\n"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n'
+        return f"    call {call}\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ''
+        return ""
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class String(Par):
-    """Represents a string-typed parameter.
-    """
+    """Represents a string-typed parameter."""
 
     def tname(self) -> str:
-        return 'character'
+        return "character"
 
     def fc_cpp_type(self) -> str:
-        return 'std::string'
+        return "std::string"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('character (len=*)')
+        return self._regular_type("character (len=*)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type('character(:), allocatable')
+        return True, self._regular_type("character(:), allocatable")
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [('character (c_char), dimension(:), pointer', 'f_ret_ptr'),
-                ('integer', 'i_loop')]
+        return [
+            ("character (c_char), dimension(:), pointer", "f_ret_ptr"),
+            ("integer", "i_loop"),
+        ]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(len({self.name}), c_size_t)'
+        return f"{self.name}, int(len({self.name}), c_size_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                f'    allocate (character(ret_val_size) :: {return_name})\n'
-                '    do i_loop = 1, ret_val_size\n'
-                f'        {return_name}(i_loop:i_loop) = f_ret_ptr(i_loop)\n'
-                '    end do\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n"
+            f"    allocate (character(ret_val_size) :: {return_name})\n"
+            "    do i_loop = 1, ret_val_size\n"
+            f"        {return_name}(i_loop:i_loop) = f_ret_ptr(i_loop)\n"
+            "    end do\n"
+        )
 
     def f_return_dummy_result(self, return_name: str) -> str:
-        return f'            allocate (character(0) :: {return_name})\n'
+        return f"            allocate (character(0) :: {return_name})\n"
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                ['character',
-                 ('integer (c_size_t), value', '_size')])
+        return self._regular_type(["character", ("integer (c_size_t), value", "_size")])
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_size_t)', '_size')])
+        return self._regular_type(["type (c_ptr)", ("integer (c_size_t)", "_size")])
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['char *', ('std::size_t', '_size')])
+        return self._regular_type(["char *", ("std::size_t", "_size")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['char **', ('std::size_t *', '_size')])
+        return self._regular_type(["char **", ("std::size_t *", "_size")])
 
     def fc_convert_input(self) -> str:
-        return f'    std::string {self.name}_s({self.name}, {self.name}_size);\n'
+        return f"    std::string {self.name}_s({self.name}, {self.name}_size);\n"
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_s'
+        return self.name + "_s"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return ('static std::string result;\n'
-                f'    result = {cpp_chain_call}')
+        return f"static std::string result;\n    result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return (f'    *{self.name} = const_cast<char*>(result.c_str());\n'
-                f'    *{self.name}_size = result.size();\n'
-                '    return;\n')
+        return (
+            f"    *{self.name} = const_cast<char*>(result.c_str());\n"
+            f"    *{self.name}_size = result.size();\n"
+            "    return;\n"
+        )
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class VecInt64t(Par):
-    """Represents a vector of int64_t parameter.
-    """
+    """Represents a vector of int64_t parameter."""
+
     def tname(self) -> str:
-        return 'int8array'
+        return "int8array"
 
     def fc_cpp_type(self) -> str:
-        return 'std::vector<int64_t>'
+        return "std::vector<int64_t>"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (selected_int_kind(18)), dimension(:)')
+        return self._regular_type("integer (selected_int_kind(18)), dimension(:)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [('integer (selected_int_kind(18)), dimension(:)', self.name)])
+            [("integer (selected_int_kind(18)), dimension(:)", self.name)]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [(
-            'integer (selected_int_kind(18)), pointer, dimension(:)',
-            'f_ret_ptr')]
+        return [("integer (selected_int_kind(18)), pointer, dimension(:)", "f_ret_ptr")]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(size({self.name}), c_int64_t)'
+        return f"{self.name}, int(size({self.name}), c_int64_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                f'    {return_name}(1:ret_val_size) = f_ret_ptr\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n"
+            f"    {return_name}(1:ret_val_size) = f_ret_ptr\n"
+        )
 
     def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['integer (c_int64_t), dimension(*)',
-                 ('integer (c_int64_t), value', '_size')])
+            [
+                "integer (c_int64_t), dimension(*)",
+                ("integer (c_int64_t), value", "_size"),
+            ]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_int64_t)', '_size')])
+        return self._regular_type(["type (c_ptr)", ("integer (c_int64_t)", "_size")])
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['std::int64_t *', ('std::int64_t', '_size')])
+        return self._regular_type(["std::int64_t *", ("std::int64_t", "_size")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['std::int64_t **', ('std::size_t *', '_size')])
+        return self._regular_type(["std::int64_t **", ("std::size_t *", "_size")])
 
     def fc_convert_input(self) -> str:
-        return (f'    std::vector<std::int64_t> {self.name}_v({self.name}, {self.name}'
-                f' + {self.name}_size);\n')
+        return (
+            f"    std::vector<std::int64_t> {self.name}_v({self.name}, {self.name}"
+            f" + {self.name}_size);\n"
+        )
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_v'
+        return self.name + "_v"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return ('static std::vector<std::int64_t> result;\n'
-                f'    result = {cpp_chain_call}')
+        return (
+            f"static std::vector<std::int64_t> result;\n    result = {cpp_chain_call}"
+        )
 
     def fc_return(self) -> str:
-        return (f'    *{self.name} = result.data();\n'
-                f'    *{self.name}_size = result.size();\n'
-                '    return;\n')
+        return (
+            f"    *{self.name} = result.data();\n"
+            f"    *{self.name}_size = result.size();\n"
+            "    return;\n"
+        )
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class VecDbl(Par):
-    """Represents a vector of double parameter.
-    """
+    """Represents a vector of double parameter."""
+
     def tname(self) -> str:
-        return 'real8array'
+        return "real8array"
 
     def fc_cpp_type(self) -> str:
-        return 'std::vector<double>'
+        return "std::vector<double>"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                f'real ({self.f_prefix}_real8), dimension(:)')
+        return self._regular_type(f"real ({self.f_prefix}_real8), dimension(:)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [(f'real ({self.f_prefix}_real8), dimension(:)', self.name)])
+            [(f"real ({self.f_prefix}_real8), dimension(:)", self.name)]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [(
-            f'real ({self.f_prefix}_real8), pointer, dimension(:)', 'f_ret_ptr')]
+        return [(f"real ({self.f_prefix}_real8), pointer, dimension(:)", "f_ret_ptr")]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(size({self.name}), c_size_t)'
+        return f"{self.name}, int(size({self.name}), c_size_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                f'    {return_name} = f_ret_ptr\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n"
+            f"    {return_name} = f_ret_ptr\n"
+        )
 
     def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['real (c_double), dimension(*)',
-                 ('integer (c_size_t), value', '_size')])
+            ["real (c_double), dimension(*)", ("integer (c_size_t), value", "_size")]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_size_t)', '_size')])
+        return self._regular_type(["type (c_ptr)", ("integer (c_size_t)", "_size")])
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['double *', ('std::size_t', '_size')])
+        return self._regular_type(["double *", ("std::size_t", "_size")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['double **', ('std::size_t *', '_size')])
+        return self._regular_type(["double **", ("std::size_t *", "_size")])
 
     def fc_convert_input(self) -> str:
-        return (f'    std::vector<double> {self.name}_v({self.name}, {self.name} +'
-                f' {self.name}_size);\n')
+        return (
+            f"    std::vector<double> {self.name}_v({self.name}, {self.name} +"
+            f" {self.name}_size);\n"
+        )
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_v'
+        return self.name + "_v"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return ('static std::vector<double> result;\n'
-                f'    result = {cpp_chain_call}')
+        return f"static std::vector<double> result;\n    result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return (f'    *{self.name} = result.data();\n'
-                f'    *{self.name}_size = result.size();\n'
-                '    return;\n')
+        return (
+            f"    *{self.name} = result.data();\n"
+            f"    *{self.name}_size = result.size();\n"
+            "    return;\n"
+        )
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class Vec2Dbl(Par):
-    """Represents a vector of vector of double parameter.
-    """
+    """Represents a vector of vector of double parameter."""
+
     def tname(self) -> str:
-        return 'real8array2'
+        return "real8array2"
 
     def fc_cpp_type(self) -> str:
-        return 'std::vector<std::vector<double>>'
+        return "std::vector<std::vector<double>>"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'real ({self.f_prefix}_real8), dimension(:,:)')
+        return self._regular_type(f"real ({self.f_prefix}_real8), dimension(:,:)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [(f'real ({self.f_prefix}_real8), dimension(:,:)', self.name)])
+            [(f"real ({self.f_prefix}_real8), dimension(:,:)", self.name)]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [(f'real ({self.f_prefix}_real8), pointer, dimension(:,:)', 'f_ret_ptr')]
+        return [(f"real ({self.f_prefix}_real8), pointer, dimension(:,:)", "f_ret_ptr")]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(shape({self.name}), c_size_t)'
+        return f"{self.name}, int(shape({self.name}), c_size_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)\n'
-                f'    {return_name} = f_ret_ptr\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)\n"
+            f"    {return_name} = f_ret_ptr\n"
+        )
 
     def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['real (c_double), dimension(*)',
-                 ('integer (c_size_t), dimension(2)', '_shape')])
+            [
+                "real (c_double), dimension(*)",
+                ("integer (c_size_t), dimension(2)", "_shape"),
+            ]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_size_t), dimension(2)', '_shape')])
+            ["type (c_ptr)", ("integer (c_size_t), dimension(2)", "_shape")]
+        )
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['double *', ('std::size_t *', '_shape')])
+        return self._regular_type(["double *", ("std::size_t *", "_shape")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['double **', ('std::size_t *', '_shape')])
+        return self._regular_type(["double **", ("std::size_t *", "_shape")])
 
     def fc_convert_input(self) -> str:
         result = (
-                'std::vector<std::vector<double>> {0}_v(\n'
-                '        {0}_shape[0], std::vector<double>({0}_shape[1]));\n'
-                'for (std::size_t i = 0; i < {0}_shape[0]; ++i)\n'
-                '    for (std::size_t j = 0; j < {0}_shape[1]; ++j)\n'
-                '        {0}_v[i][j] = {0}[j * {0}_shape[0] + i];\n'
-                )
+            "std::vector<std::vector<double>> {0}_v(\n"
+            "        {0}_shape[0], std::vector<double>({0}_shape[1]));\n"
+            "for (std::size_t i = 0; i < {0}_shape[0]; ++i)\n"
+            "    for (std::size_t j = 0; j < {0}_shape[1]; ++j)\n"
+            "        {0}_v[i][j] = {0}[j * {0}_shape[0] + i];\n"
+        )
 
-        return indent(result.format(self.name), '    ')
+        return indent(result.format(self.name), "    ")
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_v'
+        return self.name + "_v"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'std::vector<std::vector<double>> result = {cpp_chain_call}'
+        return f"std::vector<std::vector<double>> result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
         result = (
-                'std::size_t max_len = 0u;\n'
-                'for (auto const & v : result)\n'
-                '    max_len = std::max(max_len, v.size());\n'
-                '\n'
-                'static std::vector<double> ret;\n'
-                'ret.resize(result.size() * max_len);\n'
-                'for (std::size_t i = 0; i < result.size(); ++i)\n'
-                '    for (std::size_t j = 0; j < result[i].size(); ++j)\n'
-                '        ret[j * result.size() + i] = result[i][j];\n'
-                '\n'
-                '*{0} = ret.data();\n'
-                '{0}_shape[0] = result.size();\n'
-                '{0}_shape[1] = max_len;\n'
-                'return;\n'
-                )
+            "std::size_t max_len = 0u;\n"
+            "for (auto const & v : result)\n"
+            "    max_len = std::max(max_len, v.size());\n"
+            "\n"
+            "static std::vector<double> ret;\n"
+            "ret.resize(result.size() * max_len);\n"
+            "for (std::size_t i = 0; i < result.size(); ++i)\n"
+            "    for (std::size_t j = 0; j < result[i].size(); ++j)\n"
+            "        ret[j * result.size() + i] = result[i][j];\n"
+            "\n"
+            "*{0} = ret.data();\n"
+            "{0}_shape[0] = result.size();\n"
+            "{0}_shape[1] = max_len;\n"
+            "return;\n"
+        )
 
-        return indent(result.format(self.name), '    ')
+        return indent(result.format(self.name), "    ")
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class VecSizet(Par):
-    """Represents a vector of size_t parameter.
-    """
+    """Represents a vector of size_t parameter."""
+
     def tname(self) -> str:
-        return 'sizearray'
+        return "sizearray"
 
     def fc_cpp_type(self) -> str:
-        return 'std::vector<std::size_t>'
+        return "std::vector<std::size_t>"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'integer ({self.f_prefix}_size), dimension(:)')
+        return self._regular_type(f"integer ({self.f_prefix}_size), dimension(:)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [(f'integer ({self.f_prefix}_size), dimension(:)', self.name)])
+            [(f"integer ({self.f_prefix}_size), dimension(:)", self.name)]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [(
-            f'integer ({self.f_prefix}_size), pointer, dimension(:)', 'f_ret_ptr')]
+        return [(f"integer ({self.f_prefix}_size), pointer, dimension(:)", "f_ret_ptr")]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(size({self.name}), c_size_t)'
+        return f"{self.name}, int(size({self.name}), c_size_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                f'    {return_name}(1:ret_val_size) = f_ret_ptr\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n"
+            f"    {return_name}(1:ret_val_size) = f_ret_ptr\n"
+        )
 
     def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['integer (c_size_t), dimension(*)',
-                 ('integer (c_size_t), value', '_size')])
+            ["integer (c_size_t), dimension(*)", ("integer (c_size_t), value", "_size")]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_size_t)', '_size')])
+        return self._regular_type(["type (c_ptr)", ("integer (c_size_t)", "_size")])
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['std::size_t *', ('std::size_t', '_size')])
+        return self._regular_type(["std::size_t *", ("std::size_t", "_size")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['std::size_t **', ('std::size_t *', '_size')])
+        return self._regular_type(["std::size_t **", ("std::size_t *", "_size")])
 
     def fc_convert_input(self) -> str:
-        return (f'    std::vector<std::size_t> {self.name}_v({self.name}, {self.name}'
-                f' + {self.name}_size);\n')
+        return (
+            f"    std::vector<std::size_t> {self.name}_v({self.name}, {self.name}"
+            f" + {self.name}_size);\n"
+        )
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_v'
+        return self.name + "_v"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return ('static std::vector<std::size_t> result;\n'
-                f'    result = {cpp_chain_call}')
+        return f"static std::vector<std::size_t> result;\n    result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return (f'    *{self.name} = result.data();\n'
-                f'    *{self.name}_size = result.size();\n'
-                '    return;\n')
+        return (
+            f"    *{self.name} = result.data();\n"
+            f"    *{self.name}_size = result.size();\n"
+            "    return;\n"
+        )
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class VecString(Par):
-    """Represents a vector of string parameter.
-    """
+    """Represents a vector of string parameter."""
+
     def tname(self) -> str:
-        return 'characterarray'
+        return "characterarray"
 
     def fc_cpp_type(self) -> str:
-        return 'std::vector<std::string>'
+        return "std::vector<std::string>"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('character, dimension(:,:)')
+        return self._regular_type("character, dimension(:,:)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return True, self._regular_type(
-                [('character(:), dimension(:), allocatable', self.name)])
+            [("character(:), dimension(:), allocatable", self.name)]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [('character, pointer, dimension(:,:)', 'f_ret_ptr'),
-                ('integer', 'i_loop, j_loop'),
-                ('character(:), allocatable', 'tmp_s')]
+        return [
+            ("character, pointer, dimension(:,:)", "f_ret_ptr"),
+            ("integer", "i_loop, j_loop"),
+            ("character(:), allocatable", "tmp_s"),
+        ]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(shape({self.name}), c_size_t)'
+        return f"{self.name}, int(shape({self.name}), c_size_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)\n'
-                '    allocate (character(ret_val_shape(2)) ::'
-                f' {return_name}(ret_val_shape(1)))\n'
-                '    allocate (character(ret_val_shape(2)) :: tmp_s)\n'
-                '    do i_loop = 1, ret_val_shape(1)\n'
-                '        do j_loop = 1, ret_val_shape(2)\n'
-                '            tmp_s(j_loop:j_loop) = f_ret_ptr(i_loop, j_loop)\n'
-                '        end do\n'
-                f'        {return_name}(i_loop) = tmp_s\n'
-                '    end do\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)\n"
+            "    allocate (character(ret_val_shape(2)) ::"
+            f" {return_name}(ret_val_shape(1)))\n"
+            "    allocate (character(ret_val_shape(2)) :: tmp_s)\n"
+            "    do i_loop = 1, ret_val_shape(1)\n"
+            "        do j_loop = 1, ret_val_shape(2)\n"
+            "            tmp_s(j_loop:j_loop) = f_ret_ptr(i_loop, j_loop)\n"
+            "        end do\n"
+            f"        {return_name}(i_loop) = tmp_s\n"
+            "    end do\n"
+        )
 
     def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['character, dimension(*)',
-                 ('integer (c_size_t), dimension(2)', '_shape')])
+            ["character, dimension(*)", ("integer (c_size_t), dimension(2)", "_shape")]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_size_t), dimension(2)', '_shape')])
+            ["type (c_ptr)", ("integer (c_size_t), dimension(2)", "_shape")]
+        )
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['char *', ('std::size_t *', '_shape')])
+        return self._regular_type(["char *", ("std::size_t *", "_shape")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['char **', ('std::size_t *', '_shape')])
+        return self._regular_type(["char **", ("std::size_t *", "_shape")])
 
     def fc_convert_input(self) -> str:
         raise NotImplementedError()
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_s'
+        return self.name + "_s"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'std::vector<std::string> result = {cpp_chain_call}'
+        return f"std::vector<std::string> result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
         result = (
-                'std::size_t max_len = 0u;\n'
-                'for (auto const & v : result)\n'
-                '    max_len = std::max(max_len, v.size());\n'
-                '\n'
-                'static std::string ret;\n'
-                # Note: "empty" spots in the array are a space, to work with Fortran
-                'ret.resize(result.size() * max_len, \' \');\n'
-                'for (std::size_t i = 0; i < result.size(); ++i)\n'
-                '    for (std::size_t j = 0; j < result[i].size(); ++j)\n'
-                '        ret[j * result.size() + i] = result[i][j];\n'
-                '\n'
-                '*{0} = const_cast<char*>(ret.c_str());\n'
-                '{0}_shape[0] = result.size();\n'
-                '{0}_shape[1] = max_len;\n'
-                'return;\n'
-                )
+            "std::size_t max_len = 0u;\n"
+            "for (auto const & v : result)\n"
+            "    max_len = std::max(max_len, v.size());\n"
+            "\n"
+            "static std::string ret;\n"
+            # Note: "empty" spots in the array are a space, to work with Fortran
+            "ret.resize(result.size() * max_len, ' ');\n"
+            "for (std::size_t i = 0; i < result.size(); ++i)\n"
+            "    for (std::size_t j = 0; j < result[i].size(); ++j)\n"
+            "        ret[j * result.size() + i] = result[i][j];\n"
+            "\n"
+            "*{0} = const_cast<char*>(ret.c_str());\n"
+            "{0}_shape[0] = result.size();\n"
+            "{0}_shape[1] = max_len;\n"
+            "return;\n"
+        )
 
-        return indent(result.format(self.name), '    ')
+        return indent(result.format(self.name), "    ")
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class Array(Par):
-    def __init__(
-            self, ndims: int, elem_type: Par, name: Optional[str] = None
-            ) -> None:
+    def __init__(self, ndims: int, elem_type: Par, name: Optional[str] = None) -> None:
         """Create an array parameter description.
 
         Args:
@@ -725,46 +737,58 @@ class Array(Par):
         self.ndims = ndims
 
     def set_ns_prefix(
-            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
-            ) -> None:
+        self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
+    ) -> None:
         self.c_prefix = c_ns
         self.f_prefix = f_ns
         self.elem_type.set_ns_prefix(ns_for_name, c_ns, f_ns)
 
     def tname(self) -> str:
-        return f'{self.elem_type.tname()}array{self.ndims}'
+        return f"{self.elem_type.tname()}array{self.ndims}"
 
     def fc_cpp_type(self) -> str:
-        return f'{self.elem_type.fc_cpp_type()} const *'
+        return f"{self.elem_type.fc_cpp_type()} const *"
 
     def f_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                f'{self.elem_type.f_type()[0][0]}, dimension({self._f_dims()})')
+            f"{self.elem_type.f_type()[0][0]}, dimension({self._f_dims()})"
+        )
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [(f'{self.elem_type.f_type()[0][0]}, dimension({self._f_dims()})',
-                  self.name)])
+            [
+                (
+                    f"{self.elem_type.f_type()[0][0]}, dimension({self._f_dims()})",
+                    self.name,
+                )
+            ]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [(
-                    f'{self.elem_type.fi_ret_type()[0][0]}, pointer,'
-                    f' dimension({self._f_dims()})' , 'f_ret_ptr'),
-                (
-                    f'{self.elem_type.fi_ret_type()[0][0]}, pointer,'
-                    ' dimension(:)', 'f_ret_ptr_linear')]
+        return [
+            (
+                f"{self.elem_type.fi_ret_type()[0][0]}, pointer,"
+                f" dimension({self._f_dims()})",
+                "f_ret_ptr",
+            ),
+            (
+                f"{self.elem_type.fi_ret_type()[0][0]}, pointer, dimension(:)",
+                "f_ret_ptr_linear",
+            ),
+        ]
 
     def f_chain_arg(self) -> str:
-        tmpl = '{0}, int(shape({0}), c_size_t), {1}_{2}_size'
+        tmpl = "{0}, int(shape({0}), c_size_t), {1}_{2}_size"
         return tmpl.format(self.elem_type.f_chain_arg(), self.ndims, self.f_prefix)
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        dims = ', '.join(map(str, reversed(range(1, self.ndims+1))))
-        c_order = f'f(/{dims}/)'
-        tmpl = indent(dedent("""\
+        dims = ", ".join(map(str, reversed(range(1, self.ndims + 1))))
+        c_order = f"f(/{dims}/)"
+        tmpl = indent(
+            dedent("""\
             if (ret_val_format .eq. 0) then
                 call c_f_pointer(ret_val, f_ret_ptr, ret_val_shape)
                 {0} = f_ret_ptr
@@ -772,50 +796,64 @@ class Array(Par):
                 call c_f_pointer(ret_val, f_ret_ptr_linear, (/product(ret_val_shape)/))
                 {0} = reshape(f_ret_ptr_linear, ret_val_shape, (/ {2}:: /), {1})
             end if
-            """), 4*' ')
+            """),
+            4 * " ",
+        )
         return tmpl.format(return_name, c_order, self.elem_type.fi_ret_type()[0][0])
 
     def fi_type(self) -> list[tuple[str, str]]:
-        base_type = self.elem_type.fi_type()[0][0].split(',')[0]
+        base_type = self.elem_type.fi_type()[0][0].split(",")[0]
         return self._regular_type(
-                [f'{base_type}, dimension(*)',
-                 (f'integer (c_size_t), dimension({self.ndims})', '_shape'),
-                 ('integer (c_size_t), value', '_ndims')])
+            [
+                f"{base_type}, dimension(*)",
+                (f"integer (c_size_t), dimension({self.ndims})", "_shape"),
+                ("integer (c_size_t), value", "_ndims"),
+            ]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['type (c_ptr)',
-                 (f'integer (c_size_t), dimension({self.ndims})', '_shape'),
-                 ('integer (c_int)', '_format')])
+            [
+                "type (c_ptr)",
+                (f"integer (c_size_t), dimension({self.ndims})", "_shape"),
+                ("integer (c_int)", "_format"),
+            ]
+        )
 
     def fc_type(self) -> list[tuple[str, str]]:
         elem_fc_type = self.elem_type.fc_type()[0][0]
         return self._regular_type(
-                [f'{elem_fc_type} *',
-                    ('std::size_t *', '_shape'),
-                    ('std::size_t', '_ndims')])
+            [
+                f"{elem_fc_type} *",
+                ("std::size_t *", "_shape"),
+                ("std::size_t", "_ndims"),
+            ]
+        )
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
         # TODO: add ndims
         return self._regular_type(
-            [f'{self.elem_type.fc_cpp_type()} **',
-             ('std::size_t *', '_shape'),
-             ('int *', '_format')])
+            [
+                f"{self.elem_type.fc_cpp_type()} **",
+                ("std::size_t *", "_shape"),
+                ("int *", "_format"),
+            ]
+        )
 
     def fc_convert_input(self) -> str:
         tmpl = (
-                'std::vector<std::size_t> {0}_shape_v(\n'
-                '        {0}_shape, {0}_shape + {0}_ndims);\n'
-                'auto {0}_p = const_cast<{1} const *>({0});\n'
-                )
+            "std::vector<std::size_t> {0}_shape_v(\n"
+            "        {0}_shape, {0}_shape + {0}_ndims);\n"
+            "auto {0}_p = const_cast<{1} const *>({0});\n"
+        )
         result = tmpl.format(self.name, self.elem_type.fc_cpp_type())
-        return indent(result, '    ')
+        return indent(result, "    ")
 
     def fc_cpp_arg(self) -> str:
-        return f'{self.name}_p, {self.name}_shape_v'
+        return f"{self.name}_p, {self.name}_shape_v"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'{self.fc_cpp_type()} result = {cpp_chain_call}'
+        return f"{self.fc_cpp_type()} result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
         result = dedent("""\
@@ -832,95 +870,96 @@ class Array(Par):
             """)
 
         return indent(
-                result.format(self.name, self.elem_type.fc_cpp_type(), self.ndims),
-                '    ')
+            result.format(self.name, self.elem_type.fc_cpp_type(), self.ndims), "    "
+        )
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
     def _f_dims(self) -> str:
-        return ', '.join([':'] * self.ndims)
+        return ", ".join([":"] * self.ndims)
 
 
 class Bytes(Par):
-    """Represents a vector of bytes.
-    """
+    """Represents a vector of bytes."""
+
     def tname(self) -> str:
-        return 'bytes'
+        return "bytes"
 
     def fc_cpp_type(self) -> str:
-        return 'std::vector<char>'
+        return "std::vector<char>"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                'character(len=1), dimension(:)')
+        return self._regular_type("character(len=1), dimension(:)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
         return False, self._regular_type(
-                [('character(len=1), dimension(:)', self.name)])
+            [("character(len=1), dimension(:)", self.name)]
+        )
 
     def f_aux_variables(self) -> list[tuple[str, str]]:
-        return [('character(len=1), pointer, dimension(:)',
-                 'f_ret_ptr')]
+        return [("character(len=1), pointer, dimension(:)", "f_ret_ptr")]
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}, int(size({self.name}), c_size_t)'
+        return f"{self.name}, int(size({self.name}), c_size_t)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    call {call}\n\n'
+        return f"    call {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return ('    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n'
-                f'    {return_name} = f_ret_ptr\n')
+        return (
+            "    call c_f_pointer(ret_val, f_ret_ptr, (/ret_val_size/))\n"
+            f"    {return_name} = f_ret_ptr\n"
+        )
 
     def fi_type(self) -> list[tuple[str, str]]:
         return self._regular_type(
-                ['character(len=1), dimension(*)',
-                 ('integer (c_size_t), value', '_size')])
+            ["character(len=1), dimension(*)", ("integer (c_size_t), value", "_size")]
+        )
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(
-                ['type (c_ptr)',
-                 ('integer (c_size_t)', '_size')])
+        return self._regular_type(["type (c_ptr)", ("integer (c_size_t)", "_size")])
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['char *', ('std::size_t', '_size')])
+        return self._regular_type(["char *", ("std::size_t", "_size")])
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(['char **', ('std::size_t *', '_size')])
+        return self._regular_type(["char **", ("std::size_t *", "_size")])
 
     def fc_convert_input(self) -> str:
         return (
-                f'    std::vector<char> {self.name}_v({self.name}, {self.name} +'
-                f' {self.name}_size);\n')
+            f"    std::vector<char> {self.name}_v({self.name}, {self.name} +"
+            f" {self.name}_size);\n"
+        )
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_v'
+        return self.name + "_v"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return ('static std::vector<char> result;\n'
-                f'result = {cpp_chain_call}')
+        return f"static std::vector<char> result;\nresult = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return (f'    *{self.name} = result.data();\n'
-                f'    *{self.name}_size = result.size();\n'
-                '    return;\n')
+        return (
+            f"    *{self.name} = result.data();\n"
+            f"    *{self.name}_size = result.size();\n"
+            "    return;\n"
+        )
 
     def fc_return_default(self) -> str:
-        return ''  # memfun has void signature
+        return ""  # memfun has void signature
 
 
 class Obj(Par):
-    """Represents an object of a type to pass.
-    """
-    def __init__(self, class_name: str, name: str = '') -> None:
+    """Represents an object of a type to pass."""
+
+    def __init__(self, class_name: str, name: str = "") -> None:
         super().__init__(name)
 
         self.class_name = class_name
 
     def set_ns_prefix(
-            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
-            ) -> None:
+        self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
+    ) -> None:
         self.c_prefix, self.f_prefix = ns_for_name[self.class_name]
 
     def tname(self) -> str:
@@ -930,109 +969,111 @@ class Obj(Par):
         return self.class_name
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'class({self.f_prefix}_{self.class_name})')
+        return self._regular_type(f"class({self.f_prefix}_{self.class_name})")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'type({self.f_prefix}_{self.class_name})')
+        return True, self._regular_type(f"type({self.f_prefix}_{self.class_name})")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_intptr_t), value')
+        return self._regular_type("integer (c_intptr_t), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_intptr_t)')
+        return self._regular_type("integer (c_intptr_t)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('std::intptr_t')
+        return self._regular_type("std::intptr_t")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('std::intptr_t')
+        return self._regular_type("std::intptr_t")
 
     def fc_convert_input(self) -> str:
-        return (f'    {self.class_name} * {self.name}_p ='
-                f' reinterpret_cast<{self.class_name} *>({self.name});\n')
+        return (
+            f"    {self.class_name} * {self.name}_p ="
+            f" reinterpret_cast<{self.class_name} *>({self.name});\n"
+        )
 
     def fc_cpp_arg(self) -> str:
-        return f'*{self.name}_p'
+        return f"*{self.name}_p"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'{self.class_name} * result = new {self.class_name}({cpp_chain_call})'
+        return f"{self.class_name} * result = new {self.class_name}({cpp_chain_call})"
 
     def fc_return(self) -> str:
-        return '    return reinterpret_cast<std::intptr_t>(result);\n'
+        return "    return reinterpret_cast<std::intptr_t>(result);\n"
 
     def f_chain_arg(self) -> str:
-        return f'{self.name}%ptr'
+        return f"{self.name}%ptr"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    {result_name} = {call}\n\n'
+        return f"    {result_name} = {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return f'    {return_name}%ptr = {result_name}\n'
+        return f"    {return_name}%ptr = {result_name}\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Bool(Par):
-    """Represents a bool-typed parameter.
-    """
+    """Represents a bool-typed parameter."""
+
     def tname(self) -> str:
-        return 'logical'
+        return "logical"
 
     def fc_cpp_type(self) -> str:
-        return 'bool'
+        return "bool"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('logical')
+        return self._regular_type("logical")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type('logical')
+        return True, self._regular_type("logical")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('logical (c_bool), value')
+        return self._regular_type("logical (c_bool), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('logical (c_bool)')
+        return self._regular_type("logical (c_bool)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('bool')
+        return self._regular_type("bool")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('bool')
+        return self._regular_type("bool")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'bool result = {cpp_chain_call}'
+        return f"bool result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def f_chain_arg(self) -> str:
-        return f'logical({self.name}, c_bool)'
+        return f"logical({self.name}, c_bool)"
 
     def f_call_c(self, result_name: str, call: str) -> str:
-        return f'    {result_name} = {call}\n\n'
+        return f"    {result_name} = {call}\n\n"
 
     def f_return_result(self, return_name: str, result_name: str) -> str:
-        return f'    {return_name} = {result_name}\n'
+        return f"    {return_name} = {result_name}\n"
 
     def fc_return_default(self) -> str:
-        return '    return false;\n'
+        return "    return false;\n"
 
 
 class EnumVal(Par):
-    """Represents an enum-typed parameter.
-    """
-    def __init__(self, class_name: str, name: str = '') -> None:
+    """Represents an enum-typed parameter."""
+
+    def __init__(self, class_name: str, name: str = "") -> None:
         super().__init__(name)
 
         self.class_name = class_name
 
     def set_ns_prefix(
-            self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
-            ) -> None:
+        self, ns_for_name: dict[str, tuple[str, str]], c_ns: str, f_ns: str
+    ) -> None:
         self.c_prefix, self.f_prefix = ns_for_name[self.class_name]
 
     def tname(self) -> str:
@@ -1042,364 +1083,365 @@ class EnumVal(Par):
         return self.class_name
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'integer({self.f_prefix}_{self.class_name})')
+        return self._regular_type(f"integer({self.f_prefix}_{self.class_name})")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'integer({self.f_prefix}_{self.class_name})')
+        return True, self._regular_type(f"integer({self.f_prefix}_{self.class_name})")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int), value')
+        return self._regular_type("integer (c_int), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int)')
+        return self._regular_type("integer (c_int)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int')
+        return self._regular_type("int")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int')
+        return self._regular_type("int")
 
     def fc_convert_input(self) -> str:
         return (
-                f'    {self.class_name} {self.name}_e ='
-                f' static_cast<{self.class_name}>({self.name});\n')
+            f"    {self.class_name} {self.name}_e ="
+            f" static_cast<{self.class_name}>({self.name});\n"
+        )
 
     def fc_cpp_arg(self) -> str:
-        return self.name + '_e'
+        return self.name + "_e"
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'{self.class_name} result = {cpp_chain_call}'
+        return f"{self.class_name} result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return static_cast<int>(result);\n'
+        return "    return static_cast<int>(result);\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Int(Par):
-    """Represents an int-typed parameter.
-    """
+    """Represents an int-typed parameter."""
+
     def tname(self) -> str:
-        return 'int'
+        return "int"
 
     def fc_cpp_type(self) -> str:
-        return 'int'
+        return "int"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer')
+        return self._regular_type("integer")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type('integer')
+        return True, self._regular_type("integer")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int), value')
+        return self._regular_type("integer (c_int), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int)')
+        return self._regular_type("integer (c_int)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int')
+        return self._regular_type("int")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int')
+        return self._regular_type("int")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'int result = {cpp_chain_call}'
+        return f"int result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Char(Par):
-    """Represents an char-typed parameter.
-    """
+    """Represents an char-typed parameter."""
+
     def tname(self) -> str:
-        return 'int1'
+        return "int1"
 
     def fc_cpp_type(self) -> str:
-        return 'char'
+        return "char"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'integer ({self.f_prefix}_int1)')
+        return self._regular_type(f"integer ({self.f_prefix}_int1)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'integer ({self.f_prefix}_int1)')
+        return True, self._regular_type(f"integer ({self.f_prefix}_int1)")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int8_t), value')
+        return self._regular_type("integer (c_int8_t), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int8_t)')
+        return self._regular_type("integer (c_int8_t)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('char')
+        return self._regular_type("char")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('char')
+        return self._regular_type("char")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'char result = {cpp_chain_call}'
+        return f"char result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Int16t(Par):
-    """Represents an int16_t-typed parameter.
-    """
+    """Represents an int16_t-typed parameter."""
+
     def tname(self) -> str:
-        return 'int2'
+        return "int2"
 
     def fc_cpp_type(self) -> str:
-        return 'int16_t'
+        return "int16_t"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (selected_int_kind(4))')
+        return self._regular_type("integer (selected_int_kind(4))")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type('integer (selected_int_kind(4))')
+        return True, self._regular_type("integer (selected_int_kind(4))")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_short), value')
+        return self._regular_type("integer (c_short), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_short)')
+        return self._regular_type("integer (c_short)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('short int')
+        return self._regular_type("short int")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('short int')
+        return self._regular_type("short int")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'short int result = {cpp_chain_call}'
+        return f"short int result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Int32t(Par):
-    """Represents an int32_t-typed parameter.
-    """
+    """Represents an int32_t-typed parameter."""
+
     def tname(self) -> str:
-        return 'int4'
+        return "int4"
 
     def fc_cpp_type(self) -> str:
-        return 'int32_t'
+        return "int32_t"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'integer ({self.f_prefix}_int4)')
+        return self._regular_type(f"integer ({self.f_prefix}_int4)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'integer ({self.f_prefix}_int4)')
+        return True, self._regular_type(f"integer ({self.f_prefix}_int4)")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int32_t), value')
+        return self._regular_type("integer (c_int32_t), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int32_t)')
+        return self._regular_type("integer (c_int32_t)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int32_t')
+        return self._regular_type("int32_t")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int32_t')
+        return self._regular_type("int32_t")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'int32_t result = {cpp_chain_call}'
+        return f"int32_t result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Int64t(Par):
-    """Represents an int64_t-typed parameter.
-    """
+    """Represents an int64_t-typed parameter."""
+
     def tname(self) -> str:
-        return 'int8'
+        return "int8"
 
     def fc_cpp_type(self) -> str:
-        return 'int64_t'
+        return "int64_t"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (selected_int_kind(18))')
+        return self._regular_type("integer (selected_int_kind(18))")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type('integer (selected_int_kind(18))')
+        return True, self._regular_type("integer (selected_int_kind(18))")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int64_t), value')
+        return self._regular_type("integer (c_int64_t), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_int64_t)')
+        return self._regular_type("integer (c_int64_t)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int64_t')
+        return self._regular_type("int64_t")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('int64_t')
+        return self._regular_type("int64_t")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'int64_t result = {cpp_chain_call}'
+        return f"int64_t result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Sizet(Par):
-    """Represents an size_t-typed parameter.
-    """
+    """Represents an size_t-typed parameter."""
+
     def tname(self) -> str:
-        return 'size'
+        return "size"
 
     def fc_cpp_type(self) -> str:
-        return 'std::size_t'
+        return "std::size_t"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'integer ({self.f_prefix}_size)')
+        return self._regular_type(f"integer ({self.f_prefix}_size)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'integer ({self.f_prefix}_size)')
+        return True, self._regular_type(f"integer ({self.f_prefix}_size)")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_size_t), value')
+        return self._regular_type("integer (c_size_t), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('integer (c_size_t)')
+        return self._regular_type("integer (c_size_t)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('std::size_t')
+        return self._regular_type("std::size_t")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('std::size_t')
+        return self._regular_type("std::size_t")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'std::size_t result = {cpp_chain_call}'
+        return f"std::size_t result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0;\n'
+        return "    return 0;\n"
 
 
 class Float(Par):
-    """Represents a single precision float parameter.
-    """
+    """Represents a single precision float parameter."""
+
     def tname(self) -> str:
-        return 'real4'
+        return "real4"
 
     def fc_cpp_type(self) -> str:
-        return 'float'
+        return "float"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'real ({self.f_prefix}_real4)')
+        return self._regular_type(f"real ({self.f_prefix}_real4)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'real ({self.f_prefix}_real4)')
+        return True, self._regular_type(f"real ({self.f_prefix}_real4)")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('real (c_float), value')
+        return self._regular_type("real (c_float), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('real (c_float)')
+        return self._regular_type("real (c_float)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('float')
+        return self._regular_type("float")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('float')
+        return self._regular_type("float")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'float result = {cpp_chain_call}'
+        return f"float result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0.0;\n'
+        return "    return 0.0;\n"
 
 
 class Double(Par):
-    """Represents a double precision float parameter.
-    """
+    """Represents a double precision float parameter."""
+
     def tname(self) -> str:
-        return 'real8'
+        return "real8"
 
     def fc_cpp_type(self) -> str:
-        return 'double'
+        return "double"
 
     def f_type(self) -> list[tuple[str, str]]:
-        return self._regular_type(f'real ({self.f_prefix}_real8)')
+        return self._regular_type(f"real ({self.f_prefix}_real8)")
 
     def f_ret_type(self) -> tuple[bool, list[tuple[str, str]]]:
-        return True, self._regular_type(f'real ({self.f_prefix}_real8)')
+        return True, self._regular_type(f"real ({self.f_prefix}_real8)")
 
     def fi_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('real (c_double), value')
+        return self._regular_type("real (c_double), value")
 
     def fi_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('real (c_double)')
+        return self._regular_type("real (c_double)")
 
     def fc_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('double')
+        return self._regular_type("double")
 
     def fc_ret_type(self) -> list[tuple[str, str]]:
-        return self._regular_type('double')
+        return self._regular_type("double")
 
     def fc_cpp_arg(self) -> str:
         return self.name
 
     def fc_get_result(self, cpp_chain_call: str) -> str:
-        return f'double result = {cpp_chain_call}'
+        return f"double result = {cpp_chain_call}"
 
     def fc_return(self) -> str:
-        return '    return result;\n'
+        return "    return result;\n"
 
     def fc_return_default(self) -> str:
-        return '    return 0.0;\n'
+        return "    return 0.0;\n"
 
 
 class T(Par):
-    """Represents a template dummy type.
-    """
+    """Represents a template dummy type."""
+
     def tname(self) -> str:
         raise NotImplementedError("T is a dummy type")
 
@@ -1454,39 +1496,35 @@ class Member(abc.ABC):
         self.public = public
 
     @abc.abstractmethod
-    def fortran_c_wrapper(self) -> str:
-        ...
+    def fortran_c_wrapper(self) -> str: ...
 
     @abc.abstractmethod
-    def fortran_interface(self) -> str:
-        ...
+    def fortran_interface(self) -> str: ...
 
     @abc.abstractmethod
-    def fortran_function(self) -> str:
-        ...
+    def fortran_function(self) -> str: ...
 
     @abc.abstractmethod
-    def fortran_public_declaration(self) -> str:
-        ...
+    def fortran_public_declaration(self) -> str: ...
 
     @abc.abstractmethod
-    def fortran_contains_definition(self) -> str:
-        ...
+    def fortran_contains_definition(self) -> str: ...
 
 
 class MemFun(Member):
-    def __init__(self,
-                 ret_type: Par,
-                 name: str,
-                 params: Optional[list[Par]] = None,
-                 may_throw: bool = False,
-                 *,
-                 cpp_func_name: Optional[str] = None,
-                 cpp_chain_call: Optional[Callable[..., str]] = None,
-                 fc_override: Optional[str] = None,
-                 fc_chain_call: Optional[Callable[..., str]] = None,
-                 f_override: Optional[str] = None
-                 ) -> None:
+    def __init__(
+        self,
+        ret_type: Par,
+        name: str,
+        params: Optional[list[Par]] = None,
+        may_throw: bool = False,
+        *,
+        cpp_func_name: Optional[str] = None,
+        cpp_chain_call: Optional[Callable[..., str]] = None,
+        fc_override: Optional[str] = None,
+        fc_chain_call: Optional[Callable[..., str]] = None,
+        f_override: Optional[str] = None,
+    ) -> None:
         """Create a member function description.
 
         This can be a Constructor or a Destructor as well, see those
@@ -1524,9 +1562,8 @@ class MemFun(Member):
         self.f_override = f_override
         self.cpp_func_name = cpp_func_name or name
 
-    def __copy__(self) -> 'MemFun':
-        result = MemFun(
-                self.ret_type, self.name, copy(self.params), self.may_throw)
+    def __copy__(self) -> "MemFun":
+        result = MemFun(self.ret_type, self.name, copy(self.params), self.may_throw)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
         result.public = self.public
@@ -1540,13 +1577,13 @@ class MemFun(Member):
 
     def set_class_name(self, class_name: str) -> None:
         self.class_name = class_name
-        self.params.insert(0, Obj(class_name, 'self'))
+        self.params.insert(0, Obj(class_name, "self"))
 
     def reset_class_name(self, class_name: str) -> None:
         self.class_name = class_name
         if len(self.params) > 0:
-            if self.params[0].name == 'self':
-                self.params[0] = Obj(class_name, 'self')
+            if self.params[0].name == "self":
+                self.params[0] = Obj(class_name, "self")
 
     def set_ns_prefix(self, ns_for_name: dict[str, tuple[str, str]]) -> None:
         """Sets the namespace prefix correctly for all members.
@@ -1560,182 +1597,186 @@ class MemFun(Member):
             param.set_ns_prefix(ns_for_name, self.c_prefix, self.f_prefix)
 
     def fortran_c_wrapper(self) -> str:
-        """Create a C wrapper for calling by Fortran.
-        """
+        """Create a C wrapper for calling by Fortran."""
         if self.fc_override is not None:
-            return self.fc_override.replace('$CLASSNAME$', self.class_name).replace(
-                    "$C_PREFIX$", self.c_prefix).replace("$F_PREFIX$", self.f_prefix)
+            return (
+                self.fc_override.replace("$CLASSNAME$", self.class_name)
+                .replace("$C_PREFIX$", self.c_prefix)
+                .replace("$F_PREFIX$", self.f_prefix)
+            )
 
-        result = ''
+        result = ""
 
         # declaration
         in_parameters = self._fc_in_parameters()
         return_type, out_parameters = self._fc_out_parameters()
         if self.may_throw:
-            out_parameters.append('int * err_code')
-            out_parameters.append('char ** err_msg')
-            out_parameters.append('std::size_t * err_msg_len')
+            out_parameters.append("int * err_code")
+            out_parameters.append("char ** err_msg")
+            out_parameters.append("std::size_t * err_msg_len")
 
-        func_name = f'{self.c_prefix}_{self.class_name}_{self.name}_'
+        func_name = f"{self.c_prefix}_{self.class_name}_{self.name}_"
 
-        par_str = ', '.join(in_parameters + out_parameters)
-        result += f'{return_type} {func_name}({par_str}) {{\n'
+        par_str = ", ".join(in_parameters + out_parameters)
+        result += f"{return_type} {func_name}({par_str}) {{\n"
 
         # convert input
         for par in self.params:
-            result += f'{par.fc_convert_input()}'
+            result += f"{par.fc_convert_input()}"
 
         # call C++ function and return result
         if self.may_throw:
-            result += '    try {\n'
-            result += '        *err_code = 0;\n'
-            result += indent(self._fc_cpp_call(), 4*' ')
-            result += indent(self._fc_return(), 4*' ')
-            result += '    }\n'
+            result += "    try {\n"
+            result += "        *err_code = 0;\n"
+            result += indent(self._fc_cpp_call(), 4 * " ")
+            result += indent(self._fc_return(), 4 * " ")
+            result += "    }\n"
             for exception, code in error_codes.items():
                 if code != 0:
-                    catch = ''
-                    catch += f'catch (std::{exception} const & e) {{\n'
-                    catch += f'    *err_code = {code};\n'
-                    catch += '    static std::string msg;\n'
-                    catch += '    msg = e.what();\n'
-                    catch += '    *err_msg = const_cast<char*>(msg.data());\n'
-                    catch += '    *err_msg_len = msg.size();\n'
-                    catch += '}\n'
-                    result += indent(catch, 4*' ')
+                    catch = ""
+                    catch += f"catch (std::{exception} const & e) {{\n"
+                    catch += f"    *err_code = {code};\n"
+                    catch += "    static std::string msg;\n"
+                    catch += "    msg = e.what();\n"
+                    catch += "    *err_msg = const_cast<char*>(msg.data());\n"
+                    catch += "    *err_msg_len = msg.size();\n"
+                    catch += "}\n"
+                    result += indent(catch, 4 * " ")
             result += self._fc_return_default()
         else:
             result += self._fc_cpp_call()
             result += self._fc_return()
-        result += '}\n\n'
+        result += "}\n\n"
         return result
 
     def fortran_interface(self) -> str:
-        """Create a Fortran interface declaration for the C wrapper.
-        """
-        result = ''
-        if self.fc_override == '':
+        """Create a Fortran interface declaration for the C wrapper."""
+        result = ""
+        if self.fc_override == "":
             return result
 
-        func_name = f'{self.c_prefix}_{self.class_name}_{self.name}_'
+        func_name = f"{self.c_prefix}_{self.class_name}_{self.name}_"
 
         # declaration
         in_parameters = self._fi_in_parameters()
         return_type, out_parameters = self._fi_out_parameters()
         if self.may_throw:
-            out_parameters.append(('integer (c_int)', 'err_code'))
-            out_parameters.append(('type (c_ptr)', 'err_msg'))
-            out_parameters.append(('integer (c_size_t)', 'err_msg_len'))
+            out_parameters.append(("integer (c_int)", "err_code"))
+            out_parameters.append(("type (c_ptr)", "err_msg"))
+            out_parameters.append(("integer (c_size_t)", "err_msg_len"))
 
         arg_list = [par_name for _, par_name in in_parameters + out_parameters]
         if len(arg_list) > 1:
-            arg_vlist = ' &\n' + indent(', &\n'.join(arg_list), 8*' ')
+            arg_vlist = " &\n" + indent(", &\n".join(arg_list), 8 * " ")
         else:
-            arg_vlist = ', '.join(arg_list)
+            arg_vlist = ", ".join(arg_list)
 
-        if return_type != '':
-            result += f'{return_type} function {func_name}({arg_vlist}) &\n'
+        if return_type != "":
+            result += f"{return_type} function {func_name}({arg_vlist}) &\n"
         else:
-            result += f'subroutine {func_name}({arg_vlist}) &\n'
+            result += f"subroutine {func_name}({arg_vlist}) &\n"
         result += f'        bind(C, name="{func_name}")\n'
-        result += '\n'
-        result += '    use iso_c_binding\n'
+        result += "\n"
+        result += "    use iso_c_binding\n"
 
         # parameter declarations
         for par_type, par_name in in_parameters:
-            result += f'    {par_type}, intent(in) :: {par_name}\n'
+            result += f"    {par_type}, intent(in) :: {par_name}\n"
         for par_type, par_name in out_parameters:
-            result += f'    {par_type}, intent(out) :: {par_name}\n'
+            result += f"    {par_type}, intent(out) :: {par_name}\n"
 
         # end
-        if return_type != '':
-            result += f'end function {func_name}\n\n'
+        if return_type != "":
+            result += f"end function {func_name}\n\n"
         else:
-            result += f'end subroutine {func_name}\n\n'
-        return indent(result, 8*' ')
+            result += f"end subroutine {func_name}\n\n"
+        return indent(result, 8 * " ")
 
     def fortran_function(self) -> str:
-        """Create the Fortran function definition for this member.
-        """
+        """Create the Fortran function definition for this member."""
         if self.f_override is not None:
             return indent(
-                    self.f_override.replace('$CLASSNAME$', self.class_name).replace(
-                            "$C_PREFIX$", self.c_prefix).replace(
-                            "$F_PREFIX$", self.f_prefix),
-                    4*' ')
+                self.f_override.replace("$CLASSNAME$", self.class_name)
+                .replace("$C_PREFIX$", self.c_prefix)
+                .replace("$F_PREFIX$", self.f_prefix),
+                4 * " ",
+            )
 
-        result = ''
+        result = ""
 
         # declaration
-        func_name = f'{self.f_prefix}_{self.class_name}_{self.name}'
+        func_name = f"{self.f_prefix}_{self.class_name}_{self.name}"
         in_parameters = self._f_in_parameters()
         return_type, out_parameters = self._f_out_parameters()
         if self.may_throw:
-            out_parameters.append(('integer, optional', 'err_code'))
-            out_parameters.append(('character(:), allocatable, optional',
-                                   'err_msg'))
+            out_parameters.append(("integer, optional", "err_code"))
+            out_parameters.append(("character(:), allocatable, optional", "err_msg"))
 
         all_parameters = in_parameters + out_parameters
-        arg_list = ', &\n'.join([par_name for _, par_name in all_parameters])
-        arg_ilist = indent(arg_list, 8*' ')
-        if return_type != '':
-            result += f'function {func_name}( &\n{arg_ilist})\n'
+        arg_list = ", &\n".join([par_name for _, par_name in all_parameters])
+        arg_ilist = indent(arg_list, 8 * " ")
+        if return_type != "":
+            result += f"function {func_name}( &\n{arg_ilist})\n"
         else:
-            result += f'subroutine {func_name}( &\n{arg_ilist})\n'
+            result += f"subroutine {func_name}( &\n{arg_ilist})\n"
 
         # parameter declarations
-        result += '    implicit none\n'
+        result += "    implicit none\n"
         for par_type, par_name in in_parameters:
-            result += f'    {par_type}, intent(in) :: {par_name}\n'
+            result += f"    {par_type}, intent(in) :: {par_name}\n"
         for par_type, par_name in out_parameters:
-            result += f'    {par_type}, intent(out) :: {par_name}\n'
-        if return_type != '':
-            result += f'    {return_type} :: {func_name}\n'
-        result += '\n'
+            result += f"    {par_type}, intent(out) :: {par_name}\n"
+        if return_type != "":
+            result += f"    {return_type} :: {func_name}\n"
+        result += "\n"
 
         # variable declarations
         c_return_type, fi_out_parameters = self._fi_out_parameters()
         if c_return_type:
-            result += f'    {c_return_type} :: ret_val\n'
+            result += f"    {c_return_type} :: ret_val\n"
         for par_type, par_name in fi_out_parameters:
-            result += f'    {par_type} :: {par_name}\n'
+            result += f"    {par_type} :: {par_name}\n"
         for par_type, par_name in self.ret_type.f_aux_variables():
-            result += f'    {par_type} :: {par_name}\n'
+            result += f"    {par_type} :: {par_name}\n"
         if self.may_throw:
-            result += '    integer (c_int) :: err_code_v\n'
-            result += '    type (c_ptr) :: err_msg_v\n'
-            result += '    integer (c_size_t) :: err_msg_len_v\n'
-            result += '    character (c_char), dimension(:), pointer :: err_msg_f\n'
-            result += '    character(:), allocatable :: err_msg_p\n'
-            result += '    integer (c_size_t) :: err_msg_i\n'
+            result += "    integer (c_int) :: err_code_v\n"
+            result += "    type (c_ptr) :: err_msg_v\n"
+            result += "    integer (c_size_t) :: err_msg_len_v\n"
+            result += "    character (c_char), dimension(:), pointer :: err_msg_f\n"
+            result += "    character(:), allocatable :: err_msg_p\n"
+            result += "    integer (c_size_t) :: err_msg_i\n"
         if c_return_type or fi_out_parameters or self.may_throw:
-            result += '\n'
+            result += "\n"
 
         # convert input
         args = [param.f_chain_arg() for param in self.params]
         args += [par_name for _, par_name in fi_out_parameters]
         if self.may_throw:
-            args += ['err_code_v', 'err_msg_v', 'err_msg_len_v']
-        arg_str = ', &\n'.join([8*' ' + arg for arg in args])
+            args += ["err_code_v", "err_msg_v", "err_msg_len_v"]
+        arg_str = ", &\n".join([8 * " " + arg for arg in args])
 
         # call C function
-        fc_func_name = f'{self.c_prefix}_{self.class_name}_{self.name}_'
+        fc_func_name = f"{self.c_prefix}_{self.class_name}_{self.name}_"
         chain_call = self.fc_chain_call(
-                ns_prefix=self.c_prefix, class_name=self.class_name,
-                fc_func_name=fc_func_name, fc_args=arg_str)
-        result_name = ''
-        if return_type != '':
+            ns_prefix=self.c_prefix,
+            class_name=self.class_name,
+            fc_func_name=fc_func_name,
+            fc_args=arg_str,
+        )
+        result_name = ""
+        if return_type != "":
             result_name = func_name
         elif out_parameters:
             result_name = out_parameters[0][1]
-        result += self.ret_type.f_call_c('ret_val', chain_call)
+        result += self.ret_type.f_call_c("ret_val", chain_call)
 
         # handle errors if necessary
         if self.may_throw:
             # Note: I tried to factor this out into a function, but Fortran
             # makes that near-impossible. Since we're generating anyway, it's
             # not really duplication, so leave it as is.
-            result += indent(dedent(f"""\
+            result += indent(
+                dedent(f"""\
                 if (err_code_v .ne. 0) then
                     if (present(err_code)) then
                         err_code = err_code_v
@@ -1746,8 +1787,7 @@ class MemFun(Member):
                                 err_msg(err_msg_i:err_msg_i) = err_msg_f(err_msg_i)
                             end do
                         end if
-                        {dedent(
-                            self.ret_type.f_return_dummy_result(result_name))}
+                        {dedent(self.ret_type.f_return_dummy_result(result_name))}
                         return
                     else
                         call c_f_pointer(err_msg_v, err_msg_f, (/err_msg_len_v/))
@@ -1764,50 +1804,48 @@ class MemFun(Member):
                     end if
                 end if
 
-                """), 4*' ')
+                """),
+                4 * " ",
+            )
 
         # convert and return result
-        result += self.ret_type.f_return_result(result_name, 'ret_val')
+        result += self.ret_type.f_return_result(result_name, "ret_val")
 
         # end
-        if return_type != '':
-            result += f'end function {func_name}\n\n'
+        if return_type != "":
+            result += f"end function {func_name}\n\n"
         else:
-            result += f'end subroutine {func_name}\n\n'
-        return indent(result, 4*' ')
+            result += f"end subroutine {func_name}\n\n"
+        return indent(result, 4 * " ")
 
     def fortran_public_declaration(self) -> str:
-        """Create a Fortran statement declaring us public.
-        """
-        if self.f_override == '':
-            return ''
+        """Create a Fortran statement declaring us public."""
+        if self.f_override == "":
+            return ""
 
-        func_name = f'{self.f_prefix}_{self.class_name}_{self.name}'
-        return f'    public :: {func_name}\n'
+        func_name = f"{self.f_prefix}_{self.class_name}_{self.name}"
+        return f"    public :: {func_name}\n"
 
     def fortran_contains_definition(self) -> str:
-        if self.f_override == '':
-            return ''
-        full_name = f'{self.f_prefix}_{self.class_name}_{self.name}'
-        return f'    procedure :: {self.name} => {full_name}\n'
+        if self.f_override == "":
+            return ""
+        full_name = f"{self.f_prefix}_{self.class_name}_{self.name}"
+        return f"    procedure :: {self.name} => {full_name}\n"
 
     @staticmethod
     def _default_fc_chain_call(**kwargs: str) -> str:
-        return '{fc_func_name}( &\n{fc_args})'.format(**kwargs)
+        return "{fc_func_name}( &\n{fc_args})".format(**kwargs)
 
     @staticmethod
     def _default_cpp_chain_call(**kwargs: str) -> str:
-        return 'self_p->{cpp_func_name}({cpp_args})'.format(**kwargs)
+        return "self_p->{cpp_func_name}({cpp_args})".format(**kwargs)
 
     def _fc_cpp_call(self) -> str:
-        cpp_args = ', '.join([par.fc_cpp_arg() for par in self.params[1:]])
-        chain_args = {
-                'cpp_func_name': self.cpp_func_name,
-                'cpp_args': cpp_args
-                }
+        cpp_args = ", ".join([par.fc_cpp_arg() for par in self.params[1:]])
+        chain_args = {"cpp_func_name": self.cpp_func_name, "cpp_args": cpp_args}
         cpp_chain_call = self.cpp_chain_call(**chain_args)
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return f'    {result};\n'
+        return f"    {result};\n"
 
     def _fc_return(self) -> str:
         return self.ret_type.fc_return()
@@ -1816,14 +1854,13 @@ class MemFun(Member):
         return self.ret_type.fc_return_default()
 
     def _fc_in_parameters(self) -> list[str]:
-        """Create a list of input parameters.
-        """
-        result = list()     # type: list[str]
+        """Create a list of input parameters."""
+        result = list()  # type: list[str]
 
         for param in self.params:
             type_list = param.fc_type()
             for type_name, postfix in type_list:
-                result.append(f'{type_name} {param.name + postfix}')
+                result.append(f"{type_name} {param.name + postfix}")
 
         return result
 
@@ -1836,17 +1873,17 @@ class MemFun(Member):
         if len(out_pars) == 1:
             return (out_pars[0][0], [])
 
-        out_par_strl = list()       # type: list[str]
+        out_par_strl = list()  # type: list[str]
         for type_name, postfix in out_pars:
-            out_par_strl.append(f'{type_name} {self.ret_type.name + postfix}')
-        return ('void', out_par_strl)
+            out_par_strl.append(f"{type_name} {self.ret_type.name + postfix}")
+        return ("void", out_par_strl)
 
     def _fi_in_parameters(self) -> list[tuple[str, str]]:
         """Returns Fortran interface input parameters.
 
         The result is a list of (type, name) tuples.
         """
-        result = list()     # type: list[tuple[str, str]]
+        result = list()  # type: list[tuple[str, str]]
         for param in self.params:
             type_list = param.fi_type()
             for type_name, postfix in type_list:
@@ -1862,18 +1899,18 @@ class MemFun(Member):
         if len(out_pars) == 1:
             return (out_pars[0][0], [])
 
-        out_par_list = list()       # type: list[tuple[str, str]]
+        out_par_list = list()  # type: list[tuple[str, str]]
         for par_type, par_name in out_pars:
-            out_par_list.append((par_type, 'ret_val' + par_name))
+            out_par_list.append((par_type, "ret_val" + par_name))
 
-        return ('', out_par_list)
+        return ("", out_par_list)
 
     def _f_in_parameters(self) -> list[tuple[str, str]]:
         """Returns Fortran input parameters.
 
         The result is a list of (type, name) tuples.
         """
-        result = list()     # type: list[tuple[str, str]]
+        result = list()  # type: list[tuple[str, str]]
         for param in self.params:
             type_list = param.f_type()
             for type_name, postfix in type_list:
@@ -1889,11 +1926,11 @@ class MemFun(Member):
         if is_function:
             return (out_pars[0][0], [])
 
-        out_par_list = list()       # type: list[tuple[str, str]]
+        out_par_list = list()  # type: list[tuple[str, str]]
         for par_type, par_name in out_pars:
             out_par_list.append((par_type, par_name))
 
-        return ('', out_par_list)
+        return ("", out_par_list)
 
 
 class Constructor(MemFun):
@@ -1902,14 +1939,15 @@ class Constructor(MemFun):
     This generates code suitable for a constructor, rather than
     the default code.
     """
+
     def __init__(
-            self, params: Optional[list[Par]] = None, name: str = 'create',
-            **args: Any) -> None:
+        self, params: Optional[list[Par]] = None, name: str = "create", **args: Any
+    ) -> None:
         if params is None:
             params = list()
-        super().__init__(Obj('<deferred>'), name, params, **args)
+        super().__init__(Obj("<deferred>"), name, params, **args)
 
-    def __copy__(self) -> 'Constructor':
+    def __copy__(self) -> "Constructor":
         result = Constructor(copy(self.params), self.name)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -1934,25 +1972,29 @@ class Constructor(MemFun):
 
     def fortran_overload(self) -> str:
         if self.name != "create":
-            return ''
-        return indent(dedent(f"""\
+            return ""
+        return indent(
+            dedent(f"""\
             interface {self.f_prefix}_{self.class_name}
                 module procedure {self.f_prefix}_{self.class_name}_{self.name}
             end interface
 
-            """), 4*' ')
+            """),
+            4 * " ",
+        )
 
     def fortran_contains_definition(self) -> str:
-        return ''
+        return ""
 
     def _fc_cpp_call(self) -> str:
         # Create object instead of calling something
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return '    {} * result = new {}({});\n'.format(
-                self.class_name, self.class_name, ', '.join(cpp_args))
+        return "    {} * result = new {}({});\n".format(
+            self.class_name, self.class_name, ", ".join(cpp_args)
+        )
 
     def _fc_return(self) -> str:
-        return '    return reinterpret_cast<std::intptr_t>(result);\n'
+        return "    return reinterpret_cast<std::intptr_t>(result);\n"
 
 
 class EqualsOperator(MemFun):
@@ -1961,10 +2003,11 @@ class EqualsOperator(MemFun):
     This generates code suitable for an equality comparison operator, rather
     than the default code.
     """
-    def __init__(self, param: Par, name: str = 'equals', **args: Any) -> None:
+
+    def __init__(self, param: Par, name: str = "equals", **args: Any) -> None:
         super().__init__(Bool(), name, [param], False, **args)
 
-    def __copy__(self) -> 'EqualsOperator':
+    def __copy__(self) -> "EqualsOperator":
         result = EqualsOperator(copy(self.params[0]), self.name)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -1981,9 +2024,9 @@ class EqualsOperator(MemFun):
     def _fc_cpp_call(self) -> str:
         # Call operator instead of function
         rhs = self.params[1].fc_cpp_arg()
-        cpp_chain_call = f'((*self_p) == {rhs})'
+        cpp_chain_call = f"((*self_p) == {rhs})"
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return f'    {result};\n'
+        return f"    {result};\n"
 
 
 class AssignmentOperator(MemFun):
@@ -1992,14 +2035,11 @@ class AssignmentOperator(MemFun):
     This generates code suitable for an assignment operator, rather than
     the default code.
     """
-    def __init__(self,
-                 name: str,
-                 param: Par,
-                 **args: Any
-                 ) -> None:
+
+    def __init__(self, name: str, param: Par, **args: Any) -> None:
         super().__init__(Void(), name, [param], False, **args)
 
-    def __copy__(self) -> 'AssignmentOperator':
+    def __copy__(self) -> "AssignmentOperator":
         result = AssignmentOperator(self.name, copy(self.params[0]))
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -2016,7 +2056,7 @@ class AssignmentOperator(MemFun):
     def _fc_cpp_call(self) -> str:
         # Create object instead of calling something
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return f'    *self_p = {cpp_args[1]};\n'
+        return f"    *self_p = {cpp_args[1]};\n"
 
 
 class IndexAssignmentOperator(MemFun):
@@ -2025,13 +2065,12 @@ class IndexAssignmentOperator(MemFun):
     This generates code suitable for assigning to a subobject accessed
     via the square brackets operator, i.e. self[key] = value.
     """
-    def __init__(self, name: str, params: list[Par], may_throw: bool = False
-                 ) -> None:
+
+    def __init__(self, name: str, params: list[Par], may_throw: bool = False) -> None:
         super().__init__(Void(), name, params, may_throw)
 
-    def __copy__(self) -> 'IndexAssignmentOperator':
-        result = IndexAssignmentOperator(
-                self.name, copy(self.params), self.may_throw)
+    def __copy__(self) -> "IndexAssignmentOperator":
+        result = IndexAssignmentOperator(self.name, copy(self.params), self.may_throw)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
         result.public = self.public
@@ -2046,7 +2085,7 @@ class IndexAssignmentOperator(MemFun):
     def _fc_cpp_call(self) -> str:
         # Call operator[] instead of a function
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return f'    (*self_p)[{cpp_args[1]}] = {cpp_args[2]};\n'
+        return f"    (*self_p)[{cpp_args[1]}] = {cpp_args[2]};\n"
 
 
 class ShiftedIndexAssignmentOperator(IndexAssignmentOperator):
@@ -2058,9 +2097,11 @@ class ShiftedIndexAssignmentOperator(IndexAssignmentOperator):
     The index is shifted as necessary, e.g. to make it 1-based in
     Fortran and 0-based in C++.
     """
-    def __copy__(self) -> 'ShiftedIndexAssignmentOperator':
+
+    def __copy__(self) -> "ShiftedIndexAssignmentOperator":
         result = ShiftedIndexAssignmentOperator(
-                self.name, copy(self.params), self.may_throw)
+            self.name, copy(self.params), self.may_throw
+        )
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
         result.public = self.public
@@ -2075,7 +2116,7 @@ class ShiftedIndexAssignmentOperator(IndexAssignmentOperator):
     def _fc_cpp_call(self) -> str:
         # Call operator[] instead of a function
         cpp_args = [par.fc_cpp_arg() for par in self.params]
-        return f'    (*self_p)[{cpp_args[1]} - 1u] = {cpp_args[2]};\n'
+        return f"    (*self_p)[{cpp_args[1]} - 1u] = {cpp_args[2]};\n"
 
 
 class NamedConstructor(Constructor):
@@ -2087,14 +2128,14 @@ class NamedConstructor(Constructor):
     For name, pass the name of the static function, the Fortran name
     will then be create_<name>.
     """
-    def __init__(self, params: list[Par], name: str, **args: Any) -> None:
-        if 'cpp_func_name' not in args:
-            args['cpp_func_name'] = name
-        super().__init__(params, 'create_' + name, **args)
-        self.cpp_chain_call = args.get(
-                'cpp_chain_call', self._default_cpp_chain_call)
 
-    def __copy__(self) -> 'NamedConstructor':
+    def __init__(self, params: list[Par], name: str, **args: Any) -> None:
+        if "cpp_func_name" not in args:
+            args["cpp_func_name"] = name
+        super().__init__(params, "create_" + name, **args)
+        self.cpp_chain_call = args.get("cpp_chain_call", self._default_cpp_chain_call)
+
+    def __copy__(self) -> "NamedConstructor":
         result = NamedConstructor(copy(self.params), self.name)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -2112,31 +2153,31 @@ class NamedConstructor(Constructor):
 
     @staticmethod
     def _default_cpp_chain_call(**kwargs: Any) -> str:
-        return '{}::{}({})'.format(
-                kwargs['class_name'], kwargs['cpp_func_name'],
-                kwargs['cpp_args'])
+        return "{}::{}({})".format(
+            kwargs["class_name"], kwargs["cpp_func_name"], kwargs["cpp_args"]
+        )
 
     def _fc_cpp_call(self) -> str:
         # Create object instead of calling something
-        cpp_args = ', '.join([par.fc_cpp_arg() for par in self.params])
+        cpp_args = ", ".join([par.fc_cpp_arg() for par in self.params])
         chain_args = {
-                'class_name': self.class_name,
-                'cpp_func_name': self.cpp_func_name,
-                'cpp_args': cpp_args
-                }
+            "class_name": self.class_name,
+            "cpp_func_name": self.cpp_func_name,
+            "cpp_args": cpp_args,
+        }
         cpp_chain_call = self.cpp_chain_call(**chain_args)
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return f'    {result};\n'
+        return f"    {result};\n"
 
     def _fc_return(self) -> str:
-        return '    return reinterpret_cast<std::intptr_t>(result);\n'
+        return "    return reinterpret_cast<std::intptr_t>(result);\n"
 
 
 class Destructor(MemFun):
     def __init__(self, **args: Any) -> None:
-        super().__init__(Void(), 'free', **args)
+        super().__init__(Void(), "free", **args)
 
-    def __copy__(self) -> 'MemFun':
+    def __copy__(self) -> "MemFun":
         result = Destructor()
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -2154,10 +2195,11 @@ class Destructor(MemFun):
 
     def _fc_cpp_call(self) -> str:
         # Destroy object instead of calling something
-        return '    delete self_p;\n'
+        return "    delete self_p;\n"
 
     def fortran_function(self) -> str:
-        return indent(dedent(f"""\
+        return indent(
+            dedent(f"""\
             subroutine {self.f_prefix}_{self.class_name}_{self.name}(self)
                 implicit none
                 type({self.f_prefix}_{self.class_name}), intent(inout) :: self
@@ -2166,7 +2208,9 @@ class Destructor(MemFun):
                 self%ptr = 0
             end subroutine {self.f_prefix}_{self.class_name}_{self.name}
 
-            """), 4*' ')
+            """),
+            4 * " ",
+        )
 
     def fortran_contains_definition(self) -> str:
         # Disabled until compilers stop giving errors and/or producing crashing
@@ -2174,7 +2218,7 @@ class Destructor(MemFun):
 
         # full_name = f'{self.f_prefix}_{self.class_name}_{self.name}'
         # return f'    final :: {full_name}\n'
-        return ''
+        return ""
 
 
 class MultiMemFun(Member):
@@ -2188,12 +2232,13 @@ class MultiMemFun(Member):
     Attributes:
         instances: A list of the instances in this MultiMemFun.
     """
+
     def __init__(self) -> None:
         """Create a MultiMemFun."""
         super().__init__("")
         self.instances: list[Member] = list()
 
-    def __copy__(self) -> 'MultiMemFun':
+    def __copy__(self) -> "MultiMemFun":
         result = MultiMemFun()
         result.instances = [copy(instance) for instance in self.instances]
         return result
@@ -2220,39 +2265,35 @@ class MultiMemFun(Member):
             instance.set_ns_prefix(ns_for_name)
 
     def fortran_c_wrapper(self) -> str:
-        """Create a C wrapper for calling by Fortran.
-        """
-        return ''.join([i.fortran_c_wrapper() for i in self.instances])
+        """Create a C wrapper for calling by Fortran."""
+        return "".join([i.fortran_c_wrapper() for i in self.instances])
 
     def fortran_interface(self) -> str:
-        """Create a Fortran interface declaration for the C wrapper.
-        """
-        return ''.join([i.fortran_interface() for i in self.instances])
+        """Create a Fortran interface declaration for the C wrapper."""
+        return "".join([i.fortran_interface() for i in self.instances])
 
     def fortran_function(self) -> str:
-        """Create the Fortran function definition for this member.
-        """
-        return ''.join([i.fortran_function() for i in self.instances])
+        """Create the Fortran function definition for this member."""
+        return "".join([i.fortran_function() for i in self.instances])
 
     def fortran_public_declaration(self) -> str:
-        """Create a Fortran statement declaring us public.
-        """
-        return ''.join(
-                [i.fortran_public_declaration() for i in self.instances])
+        """Create a Fortran statement declaring us public."""
+        return "".join([i.fortran_public_declaration() for i in self.instances])
 
     def fortran_contains_definition(self) -> str:
-        return ''.join(i.fortran_contains_definition() for i in self.instances)
+        return "".join(i.fortran_contains_definition() for i in self.instances)
 
 
 class MemFunTmplInstance(MemFun):
-    def __init__(self,
-                 ret_type: Par,
-                 name: str,
-                 targ: Par,
-                 params: Optional[list[Par]] = None,
-                 may_throw: bool = False,
-                 **args: Any
-                 ) -> None:
+    def __init__(
+        self,
+        ret_type: Par,
+        name: str,
+        targ: Par,
+        params: Optional[list[Par]] = None,
+        may_throw: bool = False,
+        **args: Any,
+    ) -> None:
         """Create a member function template instance.
 
         The _override arguments are for overriding the automatic code
@@ -2277,16 +2318,16 @@ class MemFunTmplInstance(MemFun):
             fc_override: Custom Fortran-C wrapper function.
             f_override: Custom Fortran function.
         """
-        instance_name = f'{name}_{targ.tname()}'
+        instance_name = f"{name}_{targ.tname()}"
         super().__init__(ret_type, instance_name, params, may_throw, **args)
 
         self.tpl_name = name
         self.targ = targ
 
-    def __copy__(self) -> 'MemFunTmplInstance':
+    def __copy__(self) -> "MemFunTmplInstance":
         result = MemFunTmplInstance(
-                self.ret_type, self.tpl_name, self.targ, copy(self.params),
-                self.may_throw)
+            self.ret_type, self.tpl_name, self.targ, copy(self.params), self.may_throw
+        )
 
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -2301,30 +2342,30 @@ class MemFunTmplInstance(MemFun):
 
     @staticmethod
     def _default_cpp_chain_call(**kwargs: Any) -> str:
-        return 'self_p->{cpp_func_name}<{tpl_type}>({cpp_args})'.format(
-                **kwargs)
+        return "self_p->{cpp_func_name}<{tpl_type}>({cpp_args})".format(**kwargs)
 
     def _fc_cpp_call(self) -> str:
-        cpp_args = ', '.join([par.fc_cpp_arg() for par in self.params[1:]])
+        cpp_args = ", ".join([par.fc_cpp_arg() for par in self.params[1:]])
         chain_args = {
-                'cpp_func_name': self.tpl_name,
-                'cpp_args': cpp_args,
-                'tpl_type': self.targ.fc_cpp_type()
-                }
+            "cpp_func_name": self.tpl_name,
+            "cpp_args": cpp_args,
+            "tpl_type": self.targ.fc_cpp_type(),
+        }
         cpp_chain_call = self.cpp_chain_call(**chain_args)
         result = self.ret_type.fc_get_result(cpp_chain_call)
-        return f'    {result};\n'
+        return f"    {result};\n"
 
 
 class MemFunTmpl(MultiMemFun):
-    def __init__(self,
-                 types: list[Par],
-                 ret_type: Par,
-                 name: str,
-                 params: Optional[list[Par]] = None,
-                 may_throw: bool = False,
-                 **args: Any
-                 ) -> None:
+    def __init__(
+        self,
+        types: list[Par],
+        ret_type: Par,
+        name: str,
+        params: Optional[list[Par]] = None,
+        may_throw: bool = False,
+        **args: Any,
+    ) -> None:
         """Create a member function template description.
 
         This class assumes that there is exactly one template
@@ -2365,7 +2406,7 @@ class MemFunTmpl(MultiMemFun):
                     instance_ret_type = copy(instance_ret_type)
                     instance_ret_type.elem_type = typ
 
-            instance_params = list()    # type: list[Par]
+            instance_params = list()  # type: list[Par]
             for param in self.params:
                 if isinstance(param, T):
                     new_param = copy(typ)
@@ -2374,14 +2415,16 @@ class MemFunTmpl(MultiMemFun):
                 else:
                     instance_params.append(param)
 
-            self.instances.append(MemFunTmplInstance(
-                instance_ret_type, name, typ, instance_params, may_throw,
-                **args))
+            self.instances.append(
+                MemFunTmplInstance(
+                    instance_ret_type, name, typ, instance_params, may_throw, **args
+                )
+            )
 
-    def __copy__(self) -> 'MemFunTmpl':
+    def __copy__(self) -> "MemFunTmpl":
         result = MemFunTmpl(
-                self.types, self.ret_type, self.name, copy(self.params),
-                self.may_throw)
+            self.types, self.ret_type, self.name, copy(self.params), self.may_throw
+        )
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
         result.public = self.public
@@ -2404,6 +2447,7 @@ class OverloadSet(Member):
     idea. This class specifies a set of member functions to aggregate
     under a single name.
     """
+
     def __init__(self, name: str, names: list[str], is_constructor: bool) -> None:
         """Create an OverloadSet.
 
@@ -2416,7 +2460,7 @@ class OverloadSet(Member):
         self.names = names
         self.is_constructor = is_constructor
 
-    def __copy__(self) -> 'OverloadSet':
+    def __copy__(self) -> "OverloadSet":
         result = OverloadSet(self.name, self.names, self.is_constructor)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -2425,46 +2469,44 @@ class OverloadSet(Member):
         return result
 
     def fortran_c_wrapper(self) -> str:
-        return ''
+        return ""
 
     def fortran_interface(self) -> str:
-        return ''
+        return ""
 
     def fortran_function(self) -> str:
-        return ''
+        return ""
 
     def fortran_overload(self) -> str:
-        prefix = f'{self.f_prefix}_{self.class_name}'
-        interfaces = [f'{prefix}_{self.name}']
+        prefix = f"{self.f_prefix}_{self.class_name}"
+        interfaces = [f"{prefix}_{self.name}"]
         # do not generate a fortran constructor for named constructors like create_grid
-        if self.is_constructor and self.name == 'create':
+        if self.is_constructor and self.name == "create":
             interfaces.append(f"{prefix}")
 
-        result = ''
+        result = ""
         for interface in interfaces:
-            result += f'    interface {interface}\n'
-            result += '        module procedure &\n'
+            result += f"    interface {interface}\n"
+            result += "        module procedure &\n"
 
-            names = ['{}{}_{}'.format(12*' ', prefix, name)
-                     for name in self.names]
-            result += '{}\n'.format(', &\n'.join(names))
+            names = ["{}{}_{}".format(12 * " ", prefix, name) for name in self.names]
+            result += "{}\n".format(", &\n".join(names))
 
-            result += '    end interface\n\n'
+            result += "    end interface\n\n"
 
         return result
 
     def fortran_public_declaration(self) -> str:
-        """Create a Fortran statement declaring us public.
-        """
+        """Create a Fortran statement declaring us public."""
         if self.public:
-            return f'    public :: {self.f_prefix}_{self.class_name}_{self.name}\n'
-        return ''
+            return f"    public :: {self.f_prefix}_{self.class_name}_{self.name}\n"
+        return ""
 
     def fortran_contains_definition(self) -> str:
         if self.is_constructor:
-            return ''
-        mem_fun_names = ', &\n        '.join(self.names)
-        return f'    generic :: {self.name} => {mem_fun_names}\n'
+            return ""
+        mem_fun_names = ", &\n        ".join(self.names)
+        return f"    generic :: {self.name} => {mem_fun_names}\n"
 
 
 class OverloadSetTmpl(MultiMemFun):
@@ -2474,9 +2516,10 @@ class OverloadSetTmpl(MultiMemFun):
     aggregates a set of member functions under a single name for each template argument
     value.
     """
+
     def __init__(
-            self, types: list[Par], name: str, names: list[str], is_constructor: bool
-            ) -> None:
+        self, types: list[Par], name: str, names: list[str], is_constructor: bool
+    ) -> None:
         """Create an OverloadSetTmpl.
 
         Args:
@@ -2488,13 +2531,14 @@ class OverloadSetTmpl(MultiMemFun):
         super().__init__()
 
         for typ in types:
-            generic_name = f'{name}_{typ.tname()}'
-            specific_names = [f'{n}_{typ.tname()}' for n in names]
+            generic_name = f"{name}_{typ.tname()}"
+            specific_names = [f"{n}_{typ.tname()}" for n in names]
             self.instances.append(
-                    OverloadSet(generic_name, specific_names, is_constructor))
+                OverloadSet(generic_name, specific_names, is_constructor)
+            )
 
-    def __copy__(self) -> 'OverloadSetTmpl':
-        result = OverloadSetTmpl([], '', [], False)
+    def __copy__(self) -> "OverloadSetTmpl":
+        result = OverloadSetTmpl([], "", [], False)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
         result.public = self.public
@@ -2506,7 +2550,7 @@ class OverloadSetTmpl(MultiMemFun):
         return result
 
     def fortran_overload(self) -> str:
-        return ''.join(cast(OverloadSet, i).fortran_overload() for i in self.instances)
+        return "".join(cast(OverloadSet, i).fortran_overload() for i in self.instances)
 
 
 class NamespaceMember(abc.ABC):
@@ -2536,41 +2580,33 @@ class NamespaceMember(abc.ABC):
         self.public = public
 
     @abc.abstractmethod
-    def fortran_type_definition(self) -> str:
-        ...
+    def fortran_type_definition(self) -> str: ...
 
     def fortran_public_declarations(self) -> str:
-        """Creates Fortran declarations making functions public.
-        """
-        return ''
+        """Creates Fortran declarations making functions public."""
+        return ""
 
     def fortran_interface(self) -> str:
-        """Create a Fortran interface definition for the C ABI.
-        """
-        return ''
+        """Create a Fortran interface definition for the C ABI."""
+        return ""
 
     def fortran_overloads(self) -> str:
-        """Create Fortran overload declarations for any OverloadSets.
-        """
-        return ''
+        """Create Fortran overload declarations for any OverloadSets."""
+        return ""
 
     def fortran_functions(self) -> str:
-        """Create Fortran function definitions for this class.
-        """
-        return ''
+        """Create Fortran function definitions for this class."""
+        return ""
 
     def fortran_c_wrapper(self) -> str:
-        """Create C functions for the members.
-        """
-        return ''
+        """Create C functions for the members."""
+        return ""
 
 
 class Class(NamespaceMember):
     def __init__(
-            self,
-            name: str, parent: Optional['Class'],
-            members: list[Member]
-            ) -> None:
+        self, name: str, parent: Optional["Class"], members: list[Member]
+    ) -> None:
         """Create a class description.
 
         Args:
@@ -2608,56 +2644,50 @@ class Class(NamespaceMember):
             member.set_public(public)
 
     def fortran_c_wrapper(self) -> str:
-        """Create C functions for the members.
-        """
-        result = ''
+        """Create C functions for the members."""
+        result = ""
         for member in self.members:
             result += member.fortran_c_wrapper()
         return result
 
     def fortran_interface(self) -> str:
-        """Create a Fortran interface definition for the C ABI.
-        """
-        result = ''
+        """Create a Fortran interface definition for the C ABI."""
+        result = ""
         for member in self.members:
             result += member.fortran_interface()
         return result
 
     def fortran_overloads(self) -> str:
-        """Create Fortran overload declarations for any OverloadSets.
-        """
-        result = ''
+        """Create Fortran overload declarations for any OverloadSets."""
+        result = ""
         for member in self.members:
             if isinstance(member, (OverloadSet, OverloadSetTmpl, Constructor)):
                 result += member.fortran_overload()
         return result
 
     def fortran_type_definition(self) -> str:
-        """Create a Fortran type/handle definition for this class.
-        """
-        result = f'type {self.f_prefix}_{self.name}\n'
-        result += '    integer (c_intptr_t) :: ptr = 0\n'
-        ctn = ''.join(member.fortran_contains_definition() for member in self.members)
+        """Create a Fortran type/handle definition for this class."""
+        result = f"type {self.f_prefix}_{self.name}\n"
+        result += "    integer (c_intptr_t) :: ptr = 0\n"
+        ctn = "".join(member.fortran_contains_definition() for member in self.members)
         if ctn:
-            result += 'contains\n' + ctn
-        result += f'end type {self.f_prefix}_{self.name}\n'
+            result += "contains\n" + ctn
+        result += f"end type {self.f_prefix}_{self.name}\n"
         if self.public:
-            result += f'public :: {self.f_prefix}_{self.name}\n'
-        result += '\n'
-        return indent(result, 4*' ')
+            result += f"public :: {self.f_prefix}_{self.name}\n"
+        result += "\n"
+        return indent(result, 4 * " ")
 
     def fortran_public_declarations(self) -> str:
-        """Creates Fortran declarations making functions public.
-        """
-        result = ''
+        """Creates Fortran declarations making functions public."""
+        result = ""
         for member in self.members:
             result += member.fortran_public_declaration()
         return result
 
     def fortran_functions(self) -> str:
-        """Create Fortran function definitions for this class.
-        """
-        result = ''
+        """Create Fortran function definitions for this class."""
+        result = ""
         for member in self.members:
             result += member.fortran_function()
         return result
@@ -2675,21 +2705,22 @@ class Enum(NamespaceMember):
         self.values = values
 
     def fortran_type_definition(self) -> str:
-        """Create a Fortran type definition for this enum.
-        """
-        result = ''
-        public = ''
+        """Create a Fortran type definition for this enum."""
+        result = ""
+        public = ""
         if self.public:
-            public = ', public'
+            public = ", public"
         for val_name, val_value in self.values:
             result += (
-                    f'integer, parameter{public} ::'
-                    f' {self.f_prefix}_{self.name}_{val_name} = {val_value}\n')
+                f"integer, parameter{public} ::"
+                f" {self.f_prefix}_{self.name}_{val_name} = {val_value}\n"
+            )
 
         result += (
-            f'integer, parameter{public} :: {self.f_prefix}_{self.name} ='
-            ' selected_int_kind(9)\n\n')
-        return indent(result, 4*' ')
+            f"integer, parameter{public} :: {self.f_prefix}_{self.name} ="
+            " selected_int_kind(9)\n\n"
+        )
+        return indent(result, 4 * " ")
 
 
 class Flags(NamespaceMember):
@@ -2707,43 +2738,46 @@ class Flags(NamespaceMember):
         self.values = values
 
     def fortran_type_definition(self) -> str:
-        """Create a Fortran type definition for this enum.
-        """
-        result = ''
+        """Create a Fortran type definition for this enum."""
+        result = ""
         if self.public:
-            result += f'public :: {self.f_prefix}_{self.name}\n'
+            result += f"public :: {self.f_prefix}_{self.name}\n"
 
-        result += f'type {self.f_prefix}_{self.name}\n'
+        result += f"type {self.f_prefix}_{self.name}\n"
         for value in self.values:
-            result += f'    logical :: {value} = .false.\n'
-        result += '\n'
-        result += 'contains\n'
-        result += f'    procedure :: to_int => {self.f_prefix}_{self.name}_to_int_\n'
-        result += 'end type\n'
-        return indent(result, 4*' ')
+            result += f"    logical :: {value} = .false.\n"
+        result += "\n"
+        result += "contains\n"
+        result += f"    procedure :: to_int => {self.f_prefix}_{self.name}_to_int_\n"
+        result += "end type\n"
+        return indent(result, 4 * " ")
 
     def fortran_functions(self) -> str:
-        """Create Fortran function definitions for this class.
-        """
-        fun_name = f'{self.f_prefix}_{self.name}_to_int_'
-        result = f'integer function {fun_name}(flags)\n'
-        result += '    implicit none\n'
-        result += '\n'
-        result += f'    class({self.f_prefix}_{self.name}), intent(in) :: flags\n'
-        result += '    integer :: ret_val\n'
-        result += '\n'
-        result += '    ret_val = 0\n'
+        """Create Fortran function definitions for this class."""
+        fun_name = f"{self.f_prefix}_{self.name}_to_int_"
+        result = f"integer function {fun_name}(flags)\n"
+        result += "    implicit none\n"
+        result += "\n"
+        result += f"    class({self.f_prefix}_{self.name}), intent(in) :: flags\n"
+        result += "    integer :: ret_val\n"
+        result += "\n"
+        result += "    ret_val = 0\n"
         for i, value in enumerate(self.values):
             result += f"    if (flags%{value}) ret_val = ret_val + {1 << i}\n"
-        result += f'    {fun_name} = ret_val\n'
-        result += f'end function {fun_name}\n'
-        return indent(result, 4*' ')
+        result += f"    {fun_name} = ret_val\n"
+        result += f"end function {fun_name}\n"
+        return indent(result, 4 * " ")
 
 
 class Namespace:
-    def __init__(self, name: str, public: Optional[bool], c_prefix: str, f_prefix: str,
-                 members: Sequence[NamespaceMember]
-                 ) -> None:
+    def __init__(
+        self,
+        name: str,
+        public: Optional[bool],
+        c_prefix: str,
+        f_prefix: str,
+        members: Sequence[NamespaceMember],
+    ) -> None:
         """Create a namespace description.
 
         Args:
@@ -2775,25 +2809,26 @@ class Namespace:
             member.set_ns_prefix(ns_for_name)
 
     def fortran_typedefs(self) -> str:
-        """Generates Fortran type definitions for public types.
-        """
-        result = ''
-        public = ''
+        """Generates Fortran type definitions for public types."""
+        result = ""
+        public = ""
         if self.public is None:
             return result
         if self.public:
-            public = ', public'
+            public = ", public"
         for err_name, err_code in error_codes.items():
             result += (
-                    f'    integer, parameter{public} :: {self.f_prefix}_{err_name} ='
-                    f' {err_code}\n')
-        result += '\n'
+                f"    integer, parameter{public} :: {self.f_prefix}_{err_name} ="
+                f" {err_code}\n"
+            )
+        result += "\n"
 
         for kind_name, kind_def in kinds.items():
             result += (
-                    f'    integer, parameter{public} :: {self.f_prefix}_{kind_name} ='
-                    f' {kind_def}\n')
-        result += '\n'
+                f"    integer, parameter{public} :: {self.f_prefix}_{kind_name} ="
+                f" {kind_def}\n"
+            )
+        result += "\n"
 
         for member in self.members:
             result += member.fortran_type_definition()
@@ -2809,20 +2844,19 @@ class Namespace:
         fortran_c_wrapper() so that Fortran can call them.
         """
         if self.public is None:
-            return ''
+            return ""
 
-        result = '    interface\n\n'
+        result = "    interface\n\n"
         result += "".join(member.fortran_interface() for member in self.members)
-        result += '    end interface\n\n'
+        result += "    end interface\n\n"
 
         for member in self.members:
             result += member.fortran_overloads()
         return result
 
     def fortran_functions(self) -> str:
-        """Generates the public Fortran functions for the module.
-        """
-        result = ''
+        """Generates the public Fortran functions for the module."""
+        result = ""
         if self.public is None:
             return result
 
@@ -2832,8 +2866,12 @@ class Namespace:
 
 class API:
     def __init__(
-            self, name: str, headers: list[str], uses: list[str],
-            namespaces: list[Namespace]) -> None:
+        self,
+        name: str,
+        headers: list[str],
+        uses: list[str],
+        namespaces: list[Namespace],
+    ) -> None:
         """Create an API description.
 
         The API name will be used as module name in Fortran.
@@ -2864,7 +2902,7 @@ class API:
         This wrapper wraps the C++ code in extern C functions that are
         suitable for calling by Fortran.
         """
-        result = banner('//')
+        result = banner("//")
         result += self._fc_includes()
         result += self._fc_using_statements()
         result += self._fc_function_definitions()
@@ -2876,36 +2914,35 @@ class API:
         The module contains an interface block for calling the C ABI
         created by fortran_c_wrapper(), and the public Fortran API.
         """
-        result = banner('!')
-        result += f'module {self.name}\n'
-        result += '    use iso_c_binding\n'
+        result = banner("!")
+        result += f"module {self.name}\n"
+        result += "    use iso_c_binding\n"
         for dep in self.uses:
-            result += f'    use {dep}\n'
-        result += '\n'
-        result += '    private\n\n'
+            result += f"    use {dep}\n"
+        result += "\n"
+        result += "    private\n\n"
 
         for ns in self.namespaces:
             result += ns.fortran_typedefs()
-            result += '\n'
+            result += "\n"
 
         for ns in self.namespaces:
             result += ns.fortran_interface()
-            result += '\n'
+            result += "\n"
 
-        result += 'contains\n\n'
+        result += "contains\n\n"
         for ns in self.namespaces:
             result += ns.fortran_functions()
-            result += '\n'
-        result += f'end module {self.name}\n'
+            result += "\n"
+        result += f"end module {self.name}\n"
         return result
 
     def _fc_includes(self) -> str:
-        """Generate header includes.
-        """
-        result = ''
+        """Generate header includes."""
+        result = ""
         for header in self.headers:
-            result += f'#include <{header}>\n'
-        result += '\n\n'
+            result += f"#include <{header}>\n"
+        result += "\n\n"
         return result
 
     def _fc_using_statements(self) -> str:
@@ -2913,20 +2950,19 @@ class API:
 
         This makes the rest of the code more readable and compact.
         """
-        result = ''
+        result = ""
         for namespace in self.namespaces:
             for member in namespace.members:
-                result += f'using {namespace.name}::{member.name};\n'
-        result += '\n\n'
+                result += f"using {namespace.name}::{member.name};\n"
+        result += "\n\n"
         return result
 
     def _fc_function_definitions(self) -> str:
-        """Generate a function for each wrapped member.
-        """
+        """Generate a function for each wrapped member."""
         result = 'extern "C" {\n\n'
         for namespace in self.namespaces:
             for member in namespace.members:
                 result += member.fortran_c_wrapper()
 
-        result += '}\n\n'
+        result += "}\n\n"
         return result

--- a/scripts/convert_fortran_source.py
+++ b/scripts/convert_fortran_source.py
@@ -4,10 +4,21 @@ import re
 import click
 
 
-@click.command(no_args_is_help=True)    # type: ignore
-@click.argument("fortran_files", nargs=-1, required=True, type=click.Path(
-            exists=True, file_okay=True, dir_okay=False, readable=True,
-            allow_dash=True, resolve_path=True, path_type=pathlib.Path))
+@click.command(no_args_is_help=True)  # type: ignore
+@click.argument(
+    "fortran_files",
+    nargs=-1,
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        allow_dash=True,
+        resolve_path=True,
+        path_type=pathlib.Path,
+    ),
+)
 def convert(fortran_files: list[pathlib.Path]) -> None:
     """Convert a Fortran file using the old-style Fortran libmuscle API to the new
     object-oriented API.
@@ -17,12 +28,13 @@ def convert(fortran_files: list[pathlib.Path]) -> None:
         indata = fname.read_text()
 
         for typ in [
-                "LIBMUSCLE_Instance",
-                "LIBMUSCLE_PortsDescription",
-                "LIBMUSCLE_Message",
-                "LIBMUSCLE_Data",
-                "LIBMUSCLE_DataConstRef",
-                "YMMSL_Settings"]:
+            "LIBMUSCLE_Instance",
+            "LIBMUSCLE_PortsDescription",
+            "LIBMUSCLE_Message",
+            "LIBMUSCLE_Data",
+            "LIBMUSCLE_DataConstRef",
+            "YMMSL_Settings",
+        ]:
             # Replace TYPE_create(...) with TYPE()
             indata = re.sub(rf"{typ}_create\(", f"{typ}(", indata)
 
@@ -33,12 +45,11 @@ def convert(fortran_files: list[pathlib.Path]) -> None:
             # Replace TYPE_method(instance, ...) with instance%method(...)
             # Note: create_ and free_ methods are not instance methods so are avoided
             indata = re.sub(
-                    rf"{typ}_(?!create)(?!free)(.*?)\((\w+),? ?",
-                    r"\2%\1(",
-                    indata)
+                rf"{typ}_(?!create)(?!free)(.*?)\((\w+),? ?", r"\2%\1(", indata
+            )
 
         fname.write_text(indata)
 
 
 if __name__ == "__main__":
-    convert()       # type: ignore
+    convert()  # type: ignore

--- a/scripts/make_libmuscle_api.py
+++ b/scripts/make_libmuscle_api.py
@@ -1158,8 +1158,8 @@ portsdescription_desc = Class(
                 return result;
             }
 
-            """),
-        ),  # noqa: E501
+            """),  # noqa: E501
+        ),
         MemFun(
             String(),
             "get",

--- a/scripts/make_libmuscle_api.py
+++ b/scripts/make_libmuscle_api.py
@@ -75,31 +75,40 @@ class GridConstructor(MultiMemFun):
         super().__init__()
         self.with_names = with_names
         self.types = [Bool(), Int32t(), Int64t(), Float(), Double()]
-        self.name = 'grid'
+        self.name = "grid"
 
         # generate flexible C functions
         for typ in self.types:
             # This is not set yet here, but f_type() needs it.
             # The dict is only used by Obj, which we don't have.
-            typ.name = 'data_array'
-            typ.set_ns_prefix({}, 'LIBMUSCLE', 'LIBMUSCLE')
+            typ.name = "data_array"
+            typ.set_ns_prefix({}, "LIBMUSCLE", "LIBMUSCLE")
 
-            instance_params: list[Par] = [Array(1, copy(typ), 'data_array')]
+            instance_params: list[Par] = [Array(1, copy(typ), "data_array")]
             if not with_names:
-                instance_name = f'grid_{typ.tname()}_a'
+                instance_name = f"grid_{typ.tname()}_a"
+
                 def flex_chain_call(**kwargs: str) -> str:
                     return (
-                        f'{kwargs["class_name"]}::grid(data_array_p,'
-                        ' data_array_shape_v, {},'
-                        ' libmuscle::StorageOrder::first_adjacent)')
-                self.instances.append(NamedConstructor(
-                    instance_params, instance_name, cpp_func_name='grid',
-                    cpp_chain_call=flex_chain_call, f_override=''))
+                        f"{kwargs['class_name']}::grid(data_array_p,"
+                        " data_array_shape_v, {},"
+                        " libmuscle::StorageOrder::first_adjacent)"
+                    )
+
+                self.instances.append(
+                    NamedConstructor(
+                        instance_params,
+                        instance_name,
+                        cpp_func_name="grid",
+                        cpp_chain_call=flex_chain_call,
+                        f_override="",
+                    )
+                )
             else:
                 for i in range(1, 8):
-                    arg_name = f'index_name_{i}'
+                    arg_name = f"index_name_{i}"
                     instance_params.append(String(arg_name))
-                instance_name = f'grid_{typ.tname()}_n'
+                instance_name = f"grid_{typ.tname()}_n"
 
                 tmpl = dedent("""\
                     std::intptr_t $C_PREFIX$_$CLASSNAME$_create_grid_{0}_n_(
@@ -141,42 +150,59 @@ class GridConstructor(MultiMemFun):
                     """)
                 fc_override = tmpl.format(typ.tname(), typ.fc_cpp_type())
 
-                self.instances.append(NamedConstructor(
-                    instance_params, instance_name, fc_override=fc_override,
-                    f_override=''))
+                self.instances.append(
+                    NamedConstructor(
+                        instance_params,
+                        instance_name,
+                        fc_override=fc_override,
+                        f_override="",
+                    )
+                )
 
         # generate instances
         for typ in self.types:
             for ndims in range(1, 8):
-                instance_params = [Array(ndims, copy(typ), 'data_array')]
+                instance_params = [Array(ndims, copy(typ), "data_array")]
                 if with_names:
-                    for i in range(1, ndims+1):
-                        arg_name = f'index_name_{i}'
+                    for i in range(1, ndims + 1):
+                        arg_name = f"index_name_{i}"
                         instance_params.append(String(arg_name))
 
                 instance_name = (
-                        f'grid_{ndims}_{typ.tname()}_{"n" if with_names else "a"}')
+                    f"grid_{ndims}_{typ.tname()}_{'n' if with_names else 'a'}"
+                )
 
                 if with_names:
-                    arg_list = [
-                            f'index_name_{i}'
-                            for i in range(1, ndims+1)]
-                    name_args = ', &\n        '.join(arg_list)
-                    name_types = ''.join([
-                            f'    character (len=*), intent(in) :: {arg}\n'
-                            for arg in arg_list])
-                    name_params = ', &\n'.join([(
-                        f'            index_name_{dim},'
-                        f' int(len(index_name_{dim}), c_size_t)')
-                        for dim in range(1, ndims+1)])
+                    arg_list = [f"index_name_{i}" for i in range(1, ndims + 1)]
+                    name_args = ", &\n        ".join(arg_list)
+                    name_types = "".join(
+                        [
+                            f"    character (len=*), intent(in) :: {arg}\n"
+                            for arg in arg_list
+                        ]
+                    )
+                    name_params = ", &\n".join(
+                        [
+                            (
+                                f"            index_name_{dim},"
+                                f" int(len(index_name_{dim}), c_size_t)"
+                            )
+                            for dim in range(1, ndims + 1)
+                        ]
+                    )
                     if ndims < 7:
-                        name_params += ', &\n'
-                    filler_params = ', &\n'.join([(
-                        '            index_name_1,'
-                        ' int(len(index_name_1), c_size_t)')
-                        for dim in range(ndims+1, 8)])
+                        name_params += ", &\n"
+                    filler_params = ", &\n".join(
+                        [
+                            (
+                                "            index_name_1,"
+                                " int(len(index_name_1), c_size_t)"
+                            )
+                            for dim in range(ndims + 1, 8)
+                        ]
+                    )
 
-                    dim_list = ', '.join([':'] * ndims)
+                    dim_list = ", ".join([":"] * ndims)
 
                     tmpl = dedent("""\
                         function $F_PREFIX$_$CLASSNAME$_create_grid_{0}_{1}_n( &
@@ -200,27 +226,46 @@ class GridConstructor(MultiMemFun):
                             $F_PREFIX$_$CLASSNAME$_create_grid_{0}_{1}_n%ptr = ret_val
                         end function $F_PREFIX$_$CLASSNAME$_create_grid_{0}_{1}_n
 
-                        """)    # noqa: E501 Line too long
+                        """)  # noqa: E501 Line too long
                     f_override = tmpl.format(
-                                ndims, typ.tname(), name_args, name_types.strip(),
-                                name_params, filler_params,
-                                typ.f_type()[0][0], typ.f_chain_arg(),
-                                dim_list)
+                        ndims,
+                        typ.tname(),
+                        name_args,
+                        name_types.strip(),
+                        name_params,
+                        filler_params,
+                        typ.f_type()[0][0],
+                        typ.f_chain_arg(),
+                        dim_list,
+                    )
 
-                    self.instances.append(NamedConstructor(
-                        instance_params, instance_name,
-                        f_override=f_override, fc_override=''))
+                    self.instances.append(
+                        NamedConstructor(
+                            instance_params,
+                            instance_name,
+                            f_override=f_override,
+                            fc_override="",
+                        )
+                    )
                 else:
+
                     def inst_chain_call(tname: str = typ.tname(), **a: str) -> str:
                         return (
-                            f'{a["ns_prefix"]}_{a["class_name"]}_create_grid_'
-                            f'{tname}_a_( &\n{a["fc_args"]})')
+                            f"{a['ns_prefix']}_{a['class_name']}_create_grid_"
+                            f"{tname}_a_( &\n{a['fc_args']})"
+                        )
 
-                    self.instances.append(NamedConstructor(
-                        instance_params, instance_name, cpp_func_name='grid',
-                        fc_chain_call=inst_chain_call, fc_override=''))
+                    self.instances.append(
+                        NamedConstructor(
+                            instance_params,
+                            instance_name,
+                            cpp_func_name="grid",
+                            fc_chain_call=inst_chain_call,
+                            fc_override="",
+                        )
+                    )
 
-    def __copy__(self) -> 'GridConstructor':
+    def __copy__(self) -> "GridConstructor":
         result = GridConstructor(self.with_names)
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -244,15 +289,15 @@ class Elements(MultiMemFun):
     def __init__(self) -> None:
         super().__init__()
         self.types = [Bool(), Int32t(), Int64t(), Float(), Double()]
-        self.name = 'elements'
+        self.name = "elements"
 
         # Generate ABI
         for typ in self.types:
             # This is not set yet here, but f_type() needs it.
             # The dict is only used by Obj, which we don't have.
-            typ.name = 'elements'
-            typ.set_ns_prefix({}, 'LIBMUSCLE', 'LIBMUSCLE')
-            func_name = f'elements_{typ.tname()}'
+            typ.name = "elements"
+            typ.set_ns_prefix({}, "LIBMUSCLE", "LIBMUSCLE")
+            func_name = f"elements_{typ.tname()}"
             tmpl = dedent("""\
                     void $C_PREFIX$_$CLASSNAME$_elements_{0}_(
                             std::intptr_t self,
@@ -285,19 +330,26 @@ class Elements(MultiMemFun):
                         }}
                     }}
 
-                    """)    # noqa: E501 Line too long
+                    """)  # noqa: E501 Line too long
             fc_override = tmpl.format(typ.tname(), typ.fc_cpp_type())
 
-            self.instances.append(MemFun(
-                    Array(1, copy(typ), 'elements'), func_name, [Sizet('ndims')],
-                    True, f_override='', fc_override=fc_override))
+            self.instances.append(
+                MemFun(
+                    Array(1, copy(typ), "elements"),
+                    func_name,
+                    [Sizet("ndims")],
+                    True,
+                    f_override="",
+                    fc_override=fc_override,
+                )
+            )
 
         # Generate API
         for typ in self.types:
             for ndims in range(1, 8):
-                func_name = f'elements_{ndims}_{typ.tname()}'
-                dims_list = ', '.join([':']*ndims)
-                rev_dims = ', '.join(map(str, reversed(range(1, ndims+1))))
+                func_name = f"elements_{ndims}_{typ.tname()}"
+                dims_list = ", ".join([":"] * ndims)
+                rev_dims = ", ".join(map(str, reversed(range(1, ndims + 1))))
                 tmpl = dedent("""\
                     subroutine $F_PREFIX$_$CLASSNAME$_elements_{0}_{1}( &
                             self, &
@@ -368,18 +420,28 @@ class Elements(MultiMemFun):
                         end if
                     end subroutine $F_PREFIX$_$CLASSNAME$_elements_{0}_{1}
 
-                    """)    # noqa: E501 Line too long
+                    """)  # noqa: E501 Line too long
                 f_override = tmpl.format(
-                        ndims, typ.tname(), typ.f_ret_type()[1][0][0],
-                        dims_list, typ.fi_ret_type()[0][0], rev_dims)
+                    ndims,
+                    typ.tname(),
+                    typ.f_ret_type()[1][0][0],
+                    dims_list,
+                    typ.fi_ret_type()[0][0],
+                    rev_dims,
+                )
 
                 self.instances.append(
-                        MemFun(
-                            Array(ndims, copy(typ), 'elements'),
-                            func_name, [], True,
-                            f_override=f_override, fc_override=''))
+                    MemFun(
+                        Array(ndims, copy(typ), "elements"),
+                        func_name,
+                        [],
+                        True,
+                        f_override=f_override,
+                        fc_override="",
+                    )
+                )
 
-    def __copy__(self) -> 'Elements':
+    def __copy__(self) -> "Elements":
         result = Elements()
         result.c_prefix = self.c_prefix
         result.f_prefix = self.f_prefix
@@ -393,56 +455,116 @@ class Elements(MultiMemFun):
 
 
 create_grid_overloads = [
-        f'create_grid_{ndims}_{typ}_{with_names_tag}'
-        for ndims in range(1, 8)
-        for typ in ['logical', 'int4', 'int8', 'real4', 'real8']
-        for with_names_tag in ['n', 'a']]
+    f"create_grid_{ndims}_{typ}_{with_names_tag}"
+    for ndims in range(1, 8)
+    for typ in ["logical", "int4", "int8", "real4", "real8"]
+    for with_names_tag in ["n", "a"]
+]
 
 
-dataconstref_desc = Class('DataConstRef', None, [
-    Constructor([], 'create_nil'),
-    Constructor([Bool('value')], 'create_logical'),
-    Constructor([String('value')], 'create_character'),
-    Constructor([Char('value')], 'create_int1'),
-    Constructor([Int16t('value')], 'create_int2'),
-    Constructor([Int32t('value')], 'create_int4'),
-    Constructor([Int64t('value')], 'create_int8'),
-    Constructor([Float('value')], 'create_real4'),
-    Constructor([Double('value')], 'create_real8'),
-    Constructor([Obj('Settings', 'value')], 'create_settings'),
-    Constructor([Obj('DataConstRef', 'value')], 'create_copy'),
-    OverloadSet('create', [
-        'create_nil', 'create_logical', 'create_character', 'create_int1',
-        'create_int2', 'create_int4', 'create_int8', 'create_real4',
-        'create_real8', 'create_settings', 'create_copy'], True),
-    GridConstructor(False),
-    GridConstructor(True),
-    OverloadSet('create_grid', create_grid_overloads, True),
-    Destructor(),
-    MemFun(String(), 'describe'),
-    MemFunTmpl(
-        [Bool(), String(), Int(), Char(), Int16t(), Int32t(), Int64t(),
-            Float(), Double()],
-        Bool(), 'is_a', [], False),
-    MemFun(Bool(), 'is_a_dict'),
-    MemFun(Bool(), 'is_a_list'),
-    MemFunTmpl(
-        [Bool(), Float(), Double(), Int32t(), Int64t()],
-        Bool(), 'is_a_grid_of', [], False),
-    MemFun(Bool(), 'is_a_byte_array'),
-    MemFun(Bool(), 'is_nil'),
-    MemFun(Bool(), 'is_a_settings', [], False,
-           cpp_chain_call=lambda **kwargs: 'self_p->is_a<Settings>()'),
-    MemFun(Sizet(), 'size'),
-    MemFunTmpl(
-        [Bool(), String(), Int(), Char(), Int16t(), Int32t(), Int64t(),
-            Float(), Double()],
-        T(), 'as', [], True),
-    MemFun(Obj('Settings', 'value'), 'as_settings', [], True,
-           cpp_chain_call=lambda **kwargs: 'self_p->as<Settings>()'),
-    MemFun(
-        Bytes('data'), 'as_byte_array', [], True,
-        fc_override=dedent("""\
+dataconstref_desc = Class(
+    "DataConstRef",
+    None,
+    [
+        Constructor([], "create_nil"),
+        Constructor([Bool("value")], "create_logical"),
+        Constructor([String("value")], "create_character"),
+        Constructor([Char("value")], "create_int1"),
+        Constructor([Int16t("value")], "create_int2"),
+        Constructor([Int32t("value")], "create_int4"),
+        Constructor([Int64t("value")], "create_int8"),
+        Constructor([Float("value")], "create_real4"),
+        Constructor([Double("value")], "create_real8"),
+        Constructor([Obj("Settings", "value")], "create_settings"),
+        Constructor([Obj("DataConstRef", "value")], "create_copy"),
+        OverloadSet(
+            "create",
+            [
+                "create_nil",
+                "create_logical",
+                "create_character",
+                "create_int1",
+                "create_int2",
+                "create_int4",
+                "create_int8",
+                "create_real4",
+                "create_real8",
+                "create_settings",
+                "create_copy",
+            ],
+            True,
+        ),
+        GridConstructor(False),
+        GridConstructor(True),
+        OverloadSet("create_grid", create_grid_overloads, True),
+        Destructor(),
+        MemFun(String(), "describe"),
+        MemFunTmpl(
+            [
+                Bool(),
+                String(),
+                Int(),
+                Char(),
+                Int16t(),
+                Int32t(),
+                Int64t(),
+                Float(),
+                Double(),
+            ],
+            Bool(),
+            "is_a",
+            [],
+            False,
+        ),
+        MemFun(Bool(), "is_a_dict"),
+        MemFun(Bool(), "is_a_list"),
+        MemFunTmpl(
+            [Bool(), Float(), Double(), Int32t(), Int64t()],
+            Bool(),
+            "is_a_grid_of",
+            [],
+            False,
+        ),
+        MemFun(Bool(), "is_a_byte_array"),
+        MemFun(Bool(), "is_nil"),
+        MemFun(
+            Bool(),
+            "is_a_settings",
+            [],
+            False,
+            cpp_chain_call=lambda **kwargs: "self_p->is_a<Settings>()",
+        ),
+        MemFun(Sizet(), "size"),
+        MemFunTmpl(
+            [
+                Bool(),
+                String(),
+                Int(),
+                Char(),
+                Int16t(),
+                Int32t(),
+                Int64t(),
+                Float(),
+                Double(),
+            ],
+            T(),
+            "as",
+            [],
+            True,
+        ),
+        MemFun(
+            Obj("Settings", "value"),
+            "as_settings",
+            [],
+            True,
+            cpp_chain_call=lambda **kwargs: "self_p->as<Settings>()",
+        ),
+        MemFun(
+            Bytes("data"),
+            "as_byte_array",
+            [],
+            True,
+            fc_override=dedent("""\
             void $C_PREFIX$_DataConstRef_as_byte_array_(
                     std::intptr_t self,
                     char ** data, std::size_t * data_size,
@@ -462,10 +584,14 @@ dataconstref_desc = Class('DataConstRef', None, [
                     *err_msg_len = msg.size();
                 }
             }
-            """)),
-    MemFun(
-        Obj('DataConstRef', 'value'), 'get_item_by_key', [String('key')], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        MemFun(
+            Obj("DataConstRef", "value"),
+            "get_item_by_key",
+            [String("key")],
+            True,
+            fc_override=dedent("""\
             std::intptr_t $C_PREFIX$_$CLASSNAME$_get_item_by_key_(
                     std::intptr_t self,
                     char * key, std::size_t key_size,
@@ -495,10 +621,14 @@ dataconstref_desc = Class('DataConstRef', None, [
                 return 0;
             }
 
-            """)),
-    MemFun(
-        Obj('DataConstRef', 'value'), 'get_item_by_index', [Sizet('i')], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        MemFun(
+            Obj("DataConstRef", "value"),
+            "get_item_by_index",
+            [Sizet("i")],
+            True,
+            fc_override=dedent("""\
             std::intptr_t $C_PREFIX$_$CLASSNAME$_get_item_by_index_(
                     std::intptr_t self,
                     std::size_t i,
@@ -527,11 +657,15 @@ dataconstref_desc = Class('DataConstRef', None, [
                 return 0;
             }
 
-            """)),
-    OverloadSet('get_item', ['get_item_by_key', 'get_item_by_index'], False),
-    MemFun(
-        Sizet(), 'num_dims', [], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        OverloadSet("get_item", ["get_item_by_key", "get_item_by_index"], False),
+        MemFun(
+            Sizet(),
+            "num_dims",
+            [],
+            True,
+            fc_override=dedent("""\
             std::size_t $C_PREFIX$_$CLASSNAME$_num_dims_(
                     std::intptr_t self,
                     int * err_code, char ** err_msg, std::size_t * err_msg_len
@@ -551,40 +685,79 @@ dataconstref_desc = Class('DataConstRef', None, [
                 return 0;
             }
 
-            """)),
-    MemFun(VecSizet('shp'), 'shape', [], True),
-    Elements(),
-    OverloadSet('elements', [
-        'elements_1_logical', 'elements_1_real4', 'elements_1_real8',
-        'elements_1_int4', 'elements_1_int8',
-        'elements_2_logical', 'elements_2_real4', 'elements_2_real8',
-        'elements_2_int4', 'elements_2_int8',
-        'elements_3_logical', 'elements_3_real4', 'elements_3_real8',
-        'elements_3_int4', 'elements_3_int8',
-        'elements_4_logical', 'elements_4_real4', 'elements_4_real8',
-        'elements_4_int4', 'elements_4_int8',
-        'elements_5_logical', 'elements_5_real4', 'elements_5_real8',
-        'elements_5_int4', 'elements_5_int8',
-        'elements_6_logical', 'elements_6_real4', 'elements_6_real8',
-        'elements_6_int4', 'elements_6_int8',
-        'elements_7_logical', 'elements_7_real4', 'elements_7_real8',
-        'elements_7_int4', 'elements_7_int8',
-        ], False),
-    MemFun(Bool(), 'has_indexes', [], True),
-    MemFun(String(), 'index', [Sizet('i')], True,
-           cpp_chain_call=lambda **kwargs: 'self_p->indexes().at(i - 1)'),
-    ])
+            """),
+        ),
+        MemFun(VecSizet("shp"), "shape", [], True),
+        Elements(),
+        OverloadSet(
+            "elements",
+            [
+                "elements_1_logical",
+                "elements_1_real4",
+                "elements_1_real8",
+                "elements_1_int4",
+                "elements_1_int8",
+                "elements_2_logical",
+                "elements_2_real4",
+                "elements_2_real8",
+                "elements_2_int4",
+                "elements_2_int8",
+                "elements_3_logical",
+                "elements_3_real4",
+                "elements_3_real8",
+                "elements_3_int4",
+                "elements_3_int8",
+                "elements_4_logical",
+                "elements_4_real4",
+                "elements_4_real8",
+                "elements_4_int4",
+                "elements_4_int8",
+                "elements_5_logical",
+                "elements_5_real4",
+                "elements_5_real8",
+                "elements_5_int4",
+                "elements_5_int8",
+                "elements_6_logical",
+                "elements_6_real4",
+                "elements_6_real8",
+                "elements_6_int4",
+                "elements_6_int8",
+                "elements_7_logical",
+                "elements_7_real4",
+                "elements_7_real8",
+                "elements_7_int4",
+                "elements_7_int8",
+            ],
+            False,
+        ),
+        MemFun(Bool(), "has_indexes", [], True),
+        MemFun(
+            String(),
+            "index",
+            [Sizet("i")],
+            True,
+            cpp_chain_call=lambda **kwargs: "self_p->indexes().at(i - 1)",
+        ),
+    ],
+)
 
 
-data_desc = Class('Data', dataconstref_desc, [
-    Constructor([Obj('Data', 'value')], 'create_copy'),
-    NamedConstructor([], 'dict'),
-    NamedConstructor([], 'list'),
-    NamedConstructor([Sizet('size')], 'nils'),
-    NamedConstructor([Sizet('size')], 'byte_array_empty', cpp_func_name='byte_array'),
-    NamedConstructor(
-        [Bytes('buf')], 'byte_array_from_buf', cpp_func_name='byte_array',
-        fc_override=dedent("""\
+data_desc = Class(
+    "Data",
+    dataconstref_desc,
+    [
+        Constructor([Obj("Data", "value")], "create_copy"),
+        NamedConstructor([], "dict"),
+        NamedConstructor([], "list"),
+        NamedConstructor([Sizet("size")], "nils"),
+        NamedConstructor(
+            [Sizet("size")], "byte_array_empty", cpp_func_name="byte_array"
+        ),
+        NamedConstructor(
+            [Bytes("buf")],
+            "byte_array_from_buf",
+            cpp_func_name="byte_array",
+            fc_override=dedent("""\
             std::intptr_t $C_PREFIX$_Data_create_byte_array_from_buf_(
                    char * buf, std::size_t buf_size
             ) {
@@ -592,13 +765,19 @@ data_desc = Class('Data', dataconstref_desc, [
                return reinterpret_cast<std::intptr_t>(result);
             }
 
-            """)),
-    OverloadSet('create_byte_array', [
-        'create_byte_array_empty', 'create_byte_array_from_buf'], True),
-
-    MemFun(
-        Bytes('data'), 'as_byte_array', [], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        OverloadSet(
+            "create_byte_array",
+            ["create_byte_array_empty", "create_byte_array_from_buf"],
+            True,
+        ),
+        MemFun(
+            Bytes("data"),
+            "as_byte_array",
+            [],
+            True,
+            fc_override=dedent("""\
             void $C_PREFIX$_Data_as_byte_array_(
                     std::intptr_t self,
                     char ** data, std::size_t * data_size,
@@ -618,33 +797,51 @@ data_desc = Class('Data', dataconstref_desc, [
                     *err_msg_len = msg.size();
                 }
             }
-            """)),
-
-    AssignmentOperator('set_logical', Bool('value')),
-    AssignmentOperator('set_character', String('value')),
-    AssignmentOperator('set_int1', Char('value')),
-    AssignmentOperator('set_int2', Int16t('value')),
-    AssignmentOperator('set_int4', Int32t('value')),
-    AssignmentOperator('set_int8', Int64t('value')),
-    AssignmentOperator('set_real4', Float('value')),
-    AssignmentOperator('set_real8', Double('value')),
-    AssignmentOperator('set_data', Obj('Data', 'value')),
-    OverloadSet('set', [
-        'set_logical', 'set_character', 'set_int1', 'set_int2', 'set_int4',
-        'set_int8', 'set_real4', 'set_real8', 'set_data'], False),
-    MemFun(
-        Void(), 'set_nil', [], False,
-        fc_override=dedent("""\
+            """),
+        ),
+        AssignmentOperator("set_logical", Bool("value")),
+        AssignmentOperator("set_character", String("value")),
+        AssignmentOperator("set_int1", Char("value")),
+        AssignmentOperator("set_int2", Int16t("value")),
+        AssignmentOperator("set_int4", Int32t("value")),
+        AssignmentOperator("set_int8", Int64t("value")),
+        AssignmentOperator("set_real4", Float("value")),
+        AssignmentOperator("set_real8", Double("value")),
+        AssignmentOperator("set_data", Obj("Data", "value")),
+        OverloadSet(
+            "set",
+            [
+                "set_logical",
+                "set_character",
+                "set_int1",
+                "set_int2",
+                "set_int4",
+                "set_int8",
+                "set_real4",
+                "set_real8",
+                "set_data",
+            ],
+            False,
+        ),
+        MemFun(
+            Void(),
+            "set_nil",
+            [],
+            False,
+            fc_override=dedent("""\
             void $C_PREFIX$_Data_set_nil_(std::intptr_t self) {
                 Data * self_p = reinterpret_cast<Data *>(self);
                 *self_p = Data();
             }
 
-            """)),
-
-    MemFun(
-        Obj('Data', 'value'), 'get_item_by_key', [String('key')], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        MemFun(
+            Obj("Data", "value"),
+            "get_item_by_key",
+            [String("key")],
+            True,
+            fc_override=dedent("""\
             std::intptr_t $C_PREFIX$_Data_get_item_by_key_(
                     std::intptr_t self,
                     char * key, std::size_t key_size,
@@ -674,10 +871,14 @@ data_desc = Class('Data', dataconstref_desc, [
                 return 0;
             }
 
-            """)),
-    MemFun(
-        Obj('Data', 'value'), 'get_item_by_index', [Sizet('i')], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        MemFun(
+            Obj("Data", "value"),
+            "get_item_by_index",
+            [Sizet("i")],
+            True,
+            fc_override=dedent("""\
             std::intptr_t $C_PREFIX$_Data_get_item_by_index_(
                     std::intptr_t self,
                     std::size_t i,
@@ -706,37 +907,93 @@ data_desc = Class('Data', dataconstref_desc, [
                 return 0;
             }
 
-            """)),
-    OverloadSet('get_item', ['get_item_by_key', 'get_item_by_index'], False),
-    IndexAssignmentOperator('set_item_key_logical',     [String('key'), Bool('value')],         True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_character',   [String('key'), String('value')],       True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_int1',        [String('key'), Char('value')],         True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_int2',        [String('key'), Int16t('value')],       True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_int4',        [String('key'), Int('value')],          True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_int8',        [String('key'), Int64t('value')],       True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_real4',       [String('key'), Float('value')],        True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_real8',       [String('key'), Double('value')],       True),  # noqa: E501
-    IndexAssignmentOperator('set_item_key_data',        [String('key'), Obj('Data', 'value')],  True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_logical',    [Sizet('i'), Bool('value')],        True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_character',  [Sizet('i'), String('value')],      True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_int1',       [Sizet('i'), Char('value')],        True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_int2',       [Sizet('i'), Int16t('value')],      True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_int4',       [Sizet('i'), Int('value')],         True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_int8',       [Sizet('i'), Int64t('value')],      True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_real4',      [Sizet('i'), Float('value')],       True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_real8',      [Sizet('i'), Double('value')],      True),  # noqa: E501
-    ShiftedIndexAssignmentOperator('set_item_index_data',       [Sizet('i'), Obj('Data', 'value')], True),  # noqa: E501
-    OverloadSet('set_item', [
-        'set_item_key_logical', 'set_item_key_character', 'set_item_key_int1',
-        'set_item_key_int2', 'set_item_key_int4', 'set_item_key_int8',
-        'set_item_key_real4', 'set_item_key_real8', 'set_item_key_data',
-        'set_item_index_logical', 'set_item_index_character', 'set_item_index_int1',
-        'set_item_index_int2', 'set_item_index_int4', 'set_item_index_int8',
-        'set_item_index_real4', 'set_item_index_real8', 'set_item_index_data'
-        ], False),
-    MemFun(
-        String(), 'key', [Sizet('i')], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        OverloadSet("get_item", ["get_item_by_key", "get_item_by_index"], False),
+        IndexAssignmentOperator(
+            "set_item_key_logical", [String("key"), Bool("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_character", [String("key"), String("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_int1", [String("key"), Char("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_int2", [String("key"), Int16t("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_int4", [String("key"), Int("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_int8", [String("key"), Int64t("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_real4", [String("key"), Float("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_real8", [String("key"), Double("value")], True
+        ),  # noqa: E501
+        IndexAssignmentOperator(
+            "set_item_key_data", [String("key"), Obj("Data", "value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_logical", [Sizet("i"), Bool("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_character", [Sizet("i"), String("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_int1", [Sizet("i"), Char("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_int2", [Sizet("i"), Int16t("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_int4", [Sizet("i"), Int("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_int8", [Sizet("i"), Int64t("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_real4", [Sizet("i"), Float("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_real8", [Sizet("i"), Double("value")], True
+        ),  # noqa: E501
+        ShiftedIndexAssignmentOperator(
+            "set_item_index_data", [Sizet("i"), Obj("Data", "value")], True
+        ),  # noqa: E501
+        OverloadSet(
+            "set_item",
+            [
+                "set_item_key_logical",
+                "set_item_key_character",
+                "set_item_key_int1",
+                "set_item_key_int2",
+                "set_item_key_int4",
+                "set_item_key_int8",
+                "set_item_key_real4",
+                "set_item_key_real8",
+                "set_item_key_data",
+                "set_item_index_logical",
+                "set_item_index_character",
+                "set_item_index_int1",
+                "set_item_index_int2",
+                "set_item_index_int4",
+                "set_item_index_int8",
+                "set_item_index_real4",
+                "set_item_index_real8",
+                "set_item_index_data",
+            ],
+            False,
+        ),
+        MemFun(
+            String(),
+            "key",
+            [Sizet("i")],
+            True,
+            fc_override=dedent("""\
             void $C_PREFIX$_Data_key_(
                     std::intptr_t self, std::size_t i,
                     char ** ret_val, std::size_t * ret_val_size,
@@ -768,10 +1025,14 @@ data_desc = Class('Data', dataconstref_desc, [
                 }
             }
 
-            """)),
-    MemFun(
-        Obj('Data'), 'value', [Sizet('i')], True,
-        fc_override=dedent("""\
+            """),
+        ),
+        MemFun(
+            Obj("Data"),
+            "value",
+            [Sizet("i")],
+            True,
+            fc_override=dedent("""\
             std::intptr_t $C_PREFIX$_Data_value_(
                     std::intptr_t self, std::size_t i,
                     int * err_code,
@@ -800,60 +1061,94 @@ data_desc = Class('Data', dataconstref_desc, [
                 return 0;
             }
 
-            """)),
-    ])
+            """),
+        ),
+    ],
+)
 
 
-message_desc = Class('Message', None, [
-    Constructor([Double('timestamp')], 'create_t'),
-    Constructor([Double('timestamp'), Obj('Data', 'data')], 'create_td'),
-    Constructor(
-        [Double('timestamp'), Double('next_timestamp'), Obj('Data', 'data')],
-        'create_tnd'),
-    Constructor(
-        [Double('timestamp'), Obj('Data', 'data'), Obj('Settings', 'settings')],
-        'create_tds'),
-    Constructor(
-        [Double('timestamp'), Double('next_timestamp'), Obj('Data', 'data'),
-            Obj('Settings', 'settings')],
-        'create_tnds'),
-    OverloadSet('create', [
-        'create_t', 'create_td', 'create_tnd', 'create_tds', 'create_tnds'], True),
-    Destructor(),
-    MemFun(Double(), 'timestamp'),
-    MemFun(Void(), 'set_timestamp', [Double('timestamp')]),
-    MemFun(Bool(), 'has_next_timestamp'),
-    MemFun(Double(), 'next_timestamp'),
-    MemFun(Void(), 'set_next_timestamp', [Double('next_timestamp')]),
-    MemFun(Void(), 'unset_next_timestamp'),
-    MemFun(
-        Obj('DataConstRef', 'data'), 'get_data',
-        cpp_chain_call=lambda **kwargs: 'self_p->data()'),
-    MemFun(
-        Void(), 'set_data_d', [Obj('Data', 'data')],
-        cpp_chain_call=lambda **kwargs: f'self_p->set_data({kwargs["cpp_args"]})'),
-    MemFun(
-        Void(), 'set_data_dcr', [Obj('DataConstRef', 'data')],
-        cpp_chain_call=lambda **kwargs: f'self_p->set_data({kwargs["cpp_args"]})'),
-    OverloadSet('set_data', ['set_data_d', 'set_data_dcr'], False),
-    MemFun(Bool(), 'has_settings'),
-    MemFun(
-        Obj('Settings'), 'get_settings',
-        cpp_chain_call=lambda **kwargs: 'self_p->settings()'),
-    MemFun(Void(), 'set_settings', [Obj('Settings', 'settings')]),
-    MemFun(Void(), 'unset_settings'),
-    ])
+message_desc = Class(
+    "Message",
+    None,
+    [
+        Constructor([Double("timestamp")], "create_t"),
+        Constructor([Double("timestamp"), Obj("Data", "data")], "create_td"),
+        Constructor(
+            [Double("timestamp"), Double("next_timestamp"), Obj("Data", "data")],
+            "create_tnd",
+        ),
+        Constructor(
+            [Double("timestamp"), Obj("Data", "data"), Obj("Settings", "settings")],
+            "create_tds",
+        ),
+        Constructor(
+            [
+                Double("timestamp"),
+                Double("next_timestamp"),
+                Obj("Data", "data"),
+                Obj("Settings", "settings"),
+            ],
+            "create_tnds",
+        ),
+        OverloadSet(
+            "create",
+            ["create_t", "create_td", "create_tnd", "create_tds", "create_tnds"],
+            True,
+        ),
+        Destructor(),
+        MemFun(Double(), "timestamp"),
+        MemFun(Void(), "set_timestamp", [Double("timestamp")]),
+        MemFun(Bool(), "has_next_timestamp"),
+        MemFun(Double(), "next_timestamp"),
+        MemFun(Void(), "set_next_timestamp", [Double("next_timestamp")]),
+        MemFun(Void(), "unset_next_timestamp"),
+        MemFun(
+            Obj("DataConstRef", "data"),
+            "get_data",
+            cpp_chain_call=lambda **kwargs: "self_p->data()",
+        ),
+        MemFun(
+            Void(),
+            "set_data_d",
+            [Obj("Data", "data")],
+            cpp_chain_call=lambda **kwargs: f"self_p->set_data({kwargs['cpp_args']})",
+        ),
+        MemFun(
+            Void(),
+            "set_data_dcr",
+            [Obj("DataConstRef", "data")],
+            cpp_chain_call=lambda **kwargs: f"self_p->set_data({kwargs['cpp_args']})",
+        ),
+        OverloadSet("set_data", ["set_data_d", "set_data_dcr"], False),
+        MemFun(Bool(), "has_settings"),
+        MemFun(
+            Obj("Settings"),
+            "get_settings",
+            cpp_chain_call=lambda **kwargs: "self_p->settings()",
+        ),
+        MemFun(Void(), "set_settings", [Obj("Settings", "settings")]),
+        MemFun(Void(), "unset_settings"),
+    ],
+)
 
 
-portsdescription_desc = Class('PortsDescription', None, [
-    Constructor(),
-    Destructor(),
-    MemFun(
-        Void(), 'add', [EnumVal('Operator', 'op'), String('port')],
-        cpp_chain_call=lambda **kwargs: '(*self_p)[op_e].push_back(port_s)'),
-    MemFun(
-        Sizet(), 'num_ports', [EnumVal('Operator', 'op')],
-        fc_override=dedent("""\
+portsdescription_desc = Class(
+    "PortsDescription",
+    None,
+    [
+        Constructor(),
+        Destructor(),
+        MemFun(
+            Void(),
+            "add",
+            [EnumVal("Operator", "op"), String("port")],
+            cpp_chain_call=lambda **kwargs: "(*self_p)[op_e].push_back(port_s)",
+        ),
+        MemFun(
+            Sizet(),
+            "num_ports",
+            [EnumVal("Operator", "op")],
+            fc_override=dedent("""\
             std::size_t $C_PREFIX$_PortsDescription_num_ports_(std::intptr_t self, int op) {
                 PortsDescription * self_p = reinterpret_cast<PortsDescription *>(self);
                 Operator op_e = static_cast<Operator>(op);
@@ -863,16 +1158,21 @@ portsdescription_desc = Class('PortsDescription', None, [
                 return result;
             }
 
-            """)),  # noqa: E501
-    MemFun(
-        String(), 'get', [EnumVal('Operator', 'op'), Sizet('i')], True,
-        cpp_chain_call=lambda **kwargs: '(*self_p)[op_e].at(i - 1)'),
-    ])
+            """),
+        ),  # noqa: E501
+        MemFun(
+            String(),
+            "get",
+            [EnumVal("Operator", "op"), Sizet("i")],
+            True,
+            cpp_chain_call=lambda **kwargs: "(*self_p)[op_e].at(i - 1)",
+        ),
+    ],
+)
 
 
 instance_constructor = Constructor(
-    [Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports'),
-        Int('flags')],
+    [Obj("CmdLineArgs", "cla"), Obj("PortsDescription", "ports"), Int("flags")],
     fc_override=dedent("""\
         std::intptr_t $C_PREFIX$_Instance_create_(
                 std::intptr_t cla,
@@ -922,12 +1222,17 @@ instance_constructor = Constructor(
             call $C_PREFIX$_IMPL_BINDINGS_CmdLineArgs_free_(cla)
         end function LIBMUSCLE_Instance_create
 
-        """))
+        """),
+)
 
 instance_mpi_constructor = Constructor(
     [
-        Obj('CmdLineArgs', 'cla'), Obj('PortsDescription', 'ports'),
-        Int('flags'), Int('communicator'), Int('root')],
+        Obj("CmdLineArgs", "cla"),
+        Obj("PortsDescription", "ports"),
+        Int("flags"),
+        Int("communicator"),
+        Int("root"),
+    ],
     fc_override=dedent("""\
         std::intptr_t $C_PREFIX$_Instance_create_(
                 std::intptr_t cla,
@@ -988,179 +1293,308 @@ instance_mpi_constructor = Constructor(
             call $C_PREFIX$_IMPL_BINDINGS_CmdLineArgs_free_(cla)
         end function LIBMUSCLE_Instance_create
 
-        """)  # noqa: E501
-    )
+        """),  # noqa: E501
+)
 
 
 instance_members = [
     Destructor(),
-    MemFun(Bool(), 'reuse_instance'),
-    MemFun(Void(), 'error_shutdown', [String('message')]),
+    MemFun(Bool(), "reuse_instance"),
+    MemFun(Void(), "error_shutdown", [String("message")]),
     MemFunTmpl(
-        [String(), Int64t(), Double(), Bool(), VecInt64t('value'), VecDbl('value'),
-         Vec2Dbl('value')],
-        Bool(), 'is_setting_a', [String('name')], True,
-        cpp_chain_call=lambda **kwargs:\
-            f'self_p->get_setting({kwargs["cpp_args"]}).is_a<{kwargs["tpl_type"]}>()'),
+        [
+            String(),
+            Int64t(),
+            Double(),
+            Bool(),
+            VecInt64t("value"),
+            VecDbl("value"),
+            Vec2Dbl("value"),
+        ],
+        Bool(),
+        "is_setting_a",
+        [String("name")],
+        True,
+        cpp_chain_call=lambda **kwargs: (
+            f"self_p->get_setting({kwargs['cpp_args']}).is_a<{kwargs['tpl_type']}>()"
+        ),
+    ),
     MemFunTmpl(
-        [String(), Int64t(), Double(), Bool(), VecInt64t('value'), VecDbl('value'),
-         Vec2Dbl('value')],
-        T(), 'get_setting_as1', [String('name')], True,
-        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs:\
-            f'self_p->get_setting_as<{tpl_type}>({cpp_args})'),
+        [
+            String(),
+            Int64t(),
+            Double(),
+            Bool(),
+            VecInt64t("value"),
+            VecDbl("value"),
+            Vec2Dbl("value"),
+        ],
+        T(),
+        "get_setting_as1",
+        [String("name")],
+        True,
+        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs: (
+            f"self_p->get_setting_as<{tpl_type}>({cpp_args})"
+        ),
+    ),
     MemFunTmpl(
-        [String(), Int64t(), Double(), Bool(), VecInt64t('value'),
-         VecDbl('value'), Vec2Dbl('value')],
-        T(), 'get_setting_as2',
-        [String('name'), T('default_value')], True,
-        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs:\
-            f'self_p->get_setting_as<{tpl_type}>({cpp_args})'),
+        [
+            String(),
+            Int64t(),
+            Double(),
+            Bool(),
+            VecInt64t("value"),
+            VecDbl("value"),
+            Vec2Dbl("value"),
+        ],
+        T(),
+        "get_setting_as2",
+        [String("name"), T("default_value")],
+        True,
+        cpp_chain_call=lambda cpp_args, tpl_type, **kwargs: (
+            f"self_p->get_setting_as<{tpl_type}>({cpp_args})"
+        ),
+    ),
     OverloadSetTmpl(
-        [String(), Int64t(), Double(), Bool(), VecInt64t('value'),
-         VecDbl('value'), Vec2Dbl('value')],
-        'get_setting_as', ['get_setting_as1', 'get_setting_as2'], False),
-    MemFun(VecString('value'), 'list_settings'),
-    MemFun(Obj('PortsDescription'), 'list_ports'),
-    MemFun(Bool(), 'is_connected', [String('port')]),
-    MemFun(Bool(), 'is_vector_port', [String('port')]),
-    MemFun(Bool(), 'is_resizable', [String('port')]),
-    MemFun(Int(), 'get_port_length', [String('port')]),
-    MemFun(Void(), 'set_port_length', [String('port'), Int('length')]),
-
-    MemFun(Void(), 'send_pm',
-           [String('port_name'), Obj('Message', 'message')],
-           cpp_chain_call=lambda **kwargs: f'self_p->send({kwargs["cpp_args"]})'),
-    MemFun(Void(), 'send_pms',
-           [String('port_name'), Obj('Message', 'message'), Int('slot')],
-           cpp_chain_call=lambda **kwargs: f'self_p->send({kwargs["cpp_args"]})'),
-    OverloadSet('send', ['send_pm', 'send_pms'], False),
-
-    MemFun(Obj('Message'), 'receive_p', [String('port_name')], True,
-           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
-    MemFun(Obj('Message'), 'receive_pd',
-           [String('port_name'), Obj('Message', 'default_msg')], True,
-           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
-    OverloadSet('receive', ['receive_p', 'receive_pd'], False),
-
-    MemFun(Obj('Message'), 'receive_ps', [String('port_name'), Int('slot')],
-           True,
-           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
-    MemFun(Obj('Message'), 'receive_psd',
-           [String('port_name'), Int('slot'), Obj('Message', 'default_message')],
-           True,
-           cpp_chain_call=lambda **kwargs: f'self_p->receive({kwargs["cpp_args"]})'),
-    OverloadSet('receive_on_slot', ['receive_ps', 'receive_psd'], False),
-
-    MemFun(Obj('Message'), 'receive_with_settings_p',
-           [String('port_name')], True,
-           cpp_chain_call=lambda **kwargs:
-                f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
-    MemFun(Obj('Message'), 'receive_with_settings_pd',
-           [String('port_name'), Obj('Message', 'default_msg')], True,
-           cpp_chain_call=lambda **kwargs:
-               f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
-    OverloadSet('receive_with_settings',
-               ['receive_with_settings_p', 'receive_with_settings_pd'], False),
-
-    MemFun(Obj('Message'), 'receive_with_settings_ps',
-           [String('port_name'), Int('slot')], True,
-           cpp_chain_call=lambda **kwargs:
-               f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
-    MemFun(Obj('Message'), 'receive_with_settings_psd',
-           [String('port_name'), Int('slot'), Obj('Message', 'default_msg')],
-           True,
-           cpp_chain_call=lambda **kwargs:
-               f'self_p->receive_with_settings({kwargs["cpp_args"]})'),
-    OverloadSet('receive_with_settings_on_slot',
-                ['receive_with_settings_ps', 'receive_with_settings_psd'], False),
-    MemFun(Bool(), 'resuming'),
-    MemFun(Bool(), 'should_init'),
-    MemFun(Obj('Message'), 'load_snapshot'),
-    MemFun(Bool(), 'should_save_snapshot', [Double('timestamp')]),
-    MemFun(Void(), 'save_snapshot', [Obj('Message', 'message')]),
-    MemFun(Bool(), 'should_save_final_snapshot'),
-    MemFun(Void(), 'save_final_snapshot', [Obj('Message', 'message')]),
-    ]
+        [
+            String(),
+            Int64t(),
+            Double(),
+            Bool(),
+            VecInt64t("value"),
+            VecDbl("value"),
+            Vec2Dbl("value"),
+        ],
+        "get_setting_as",
+        ["get_setting_as1", "get_setting_as2"],
+        False,
+    ),
+    MemFun(VecString("value"), "list_settings"),
+    MemFun(Obj("PortsDescription"), "list_ports"),
+    MemFun(Bool(), "is_connected", [String("port")]),
+    MemFun(Bool(), "is_vector_port", [String("port")]),
+    MemFun(Bool(), "is_resizable", [String("port")]),
+    MemFun(Int(), "get_port_length", [String("port")]),
+    MemFun(Void(), "set_port_length", [String("port"), Int("length")]),
+    MemFun(
+        Void(),
+        "send_pm",
+        [String("port_name"), Obj("Message", "message")],
+        cpp_chain_call=lambda **kwargs: f"self_p->send({kwargs['cpp_args']})",
+    ),
+    MemFun(
+        Void(),
+        "send_pms",
+        [String("port_name"), Obj("Message", "message"), Int("slot")],
+        cpp_chain_call=lambda **kwargs: f"self_p->send({kwargs['cpp_args']})",
+    ),
+    OverloadSet("send", ["send_pm", "send_pms"], False),
+    MemFun(
+        Obj("Message"),
+        "receive_p",
+        [String("port_name")],
+        True,
+        cpp_chain_call=lambda **kwargs: f"self_p->receive({kwargs['cpp_args']})",
+    ),
+    MemFun(
+        Obj("Message"),
+        "receive_pd",
+        [String("port_name"), Obj("Message", "default_msg")],
+        True,
+        cpp_chain_call=lambda **kwargs: f"self_p->receive({kwargs['cpp_args']})",
+    ),
+    OverloadSet("receive", ["receive_p", "receive_pd"], False),
+    MemFun(
+        Obj("Message"),
+        "receive_ps",
+        [String("port_name"), Int("slot")],
+        True,
+        cpp_chain_call=lambda **kwargs: f"self_p->receive({kwargs['cpp_args']})",
+    ),
+    MemFun(
+        Obj("Message"),
+        "receive_psd",
+        [String("port_name"), Int("slot"), Obj("Message", "default_message")],
+        True,
+        cpp_chain_call=lambda **kwargs: f"self_p->receive({kwargs['cpp_args']})",
+    ),
+    OverloadSet("receive_on_slot", ["receive_ps", "receive_psd"], False),
+    MemFun(
+        Obj("Message"),
+        "receive_with_settings_p",
+        [String("port_name")],
+        True,
+        cpp_chain_call=lambda **kwargs: (
+            f"self_p->receive_with_settings({kwargs['cpp_args']})"
+        ),
+    ),
+    MemFun(
+        Obj("Message"),
+        "receive_with_settings_pd",
+        [String("port_name"), Obj("Message", "default_msg")],
+        True,
+        cpp_chain_call=lambda **kwargs: (
+            f"self_p->receive_with_settings({kwargs['cpp_args']})"
+        ),
+    ),
+    OverloadSet(
+        "receive_with_settings",
+        ["receive_with_settings_p", "receive_with_settings_pd"],
+        False,
+    ),
+    MemFun(
+        Obj("Message"),
+        "receive_with_settings_ps",
+        [String("port_name"), Int("slot")],
+        True,
+        cpp_chain_call=lambda **kwargs: (
+            f"self_p->receive_with_settings({kwargs['cpp_args']})"
+        ),
+    ),
+    MemFun(
+        Obj("Message"),
+        "receive_with_settings_psd",
+        [String("port_name"), Int("slot"), Obj("Message", "default_msg")],
+        True,
+        cpp_chain_call=lambda **kwargs: (
+            f"self_p->receive_with_settings({kwargs['cpp_args']})"
+        ),
+    ),
+    OverloadSet(
+        "receive_with_settings_on_slot",
+        ["receive_with_settings_ps", "receive_with_settings_psd"],
+        False,
+    ),
+    MemFun(Bool(), "resuming"),
+    MemFun(Bool(), "should_init"),
+    MemFun(Obj("Message"), "load_snapshot"),
+    MemFun(Bool(), "should_save_snapshot", [Double("timestamp")]),
+    MemFun(Void(), "save_snapshot", [Obj("Message", "message")]),
+    MemFun(Bool(), "should_save_final_snapshot"),
+    MemFun(Void(), "save_final_snapshot", [Obj("Message", "message")]),
+]
 
 
 # These need to kept in sync with the values in the C++ implementation
-instanceflags_desc = Flags('InstanceFlags', [
-            "DONT_APPLY_OVERLAY",
-            "USES_CHECKPOINT_API",
-            "KEEPS_NO_STATE_FOR_NEXT_USE",
-            "STATE_NOT_REQUIRED_FOR_NEXT_USE"])
+instanceflags_desc = Flags(
+    "InstanceFlags",
+    [
+        "DONT_APPLY_OVERLAY",
+        "USES_CHECKPOINT_API",
+        "KEEPS_NO_STATE_FOR_NEXT_USE",
+        "STATE_NOT_REQUIRED_FOR_NEXT_USE",
+    ],
+)
 
 
 instance_desc = Class(
-        'Instance', None, [cast(Member, instance_constructor)] + [
-            copy(mem) for mem in instance_members])
+    "Instance",
+    None,
+    [cast(Member, instance_constructor)] + [copy(mem) for mem in instance_members],
+)
 
 
 instance_mpi_desc = Class(
-        'Instance', None, [cast(Member, instance_mpi_constructor)] + [
-            copy(mem) for mem in instance_members])
+    "Instance",
+    None,
+    [cast(Member, instance_mpi_constructor)] + [copy(mem) for mem in instance_members],
+)
 
 
-cmdlineargs_desc = Class('CmdLineArgs', None, [
-        Constructor([Int('count')]),
+cmdlineargs_desc = Class(
+    "CmdLineArgs",
+    None,
+    [
+        Constructor([Int("count")]),
         Destructor(),
-        MemFun(Void(), 'set_arg', [Int('i'), String('arg')]),
-        ])
+        MemFun(Void(), "set_arg", [Int("i"), String("arg")]),
+    ],
+)
 
 
-ymmsl_forward_members = [Enum('Operator', []), Class('Settings', None, [])]
+ymmsl_forward_members = [Enum("Operator", []), Class("Settings", None, [])]
 
 
 libmuscle_api_description = API(
-        'libmuscle',
-        [
-            'libmuscle/libmuscle.hpp',
-            'libmuscle/bindings/cmdlineargs.hpp',
-            'ymmsl/ymmsl.hpp',
-            'stdexcept',
-            'typeinfo'],
-        [
-            'ymmsl'],
-        [
-            Namespace('libmuscle', True, 'LIBMUSCLE', 'LIBMUSCLE', [
-                dataconstref_desc, data_desc, portsdescription_desc,
-                message_desc, instance_desc, instanceflags_desc]),
-            Namespace('libmuscle::impl::bindings', False, 'LIBMUSCLE_IMPL_BINDINGS',
-                      'LIBMUSCLE_IMPL_BINDINGS', [cmdlineargs_desc]),
-            Namespace('ymmsl', None, 'YMMSL', 'YMMSL',
-                      ymmsl_forward_members)
-        ])
+    "libmuscle",
+    [
+        "libmuscle/libmuscle.hpp",
+        "libmuscle/bindings/cmdlineargs.hpp",
+        "ymmsl/ymmsl.hpp",
+        "stdexcept",
+        "typeinfo",
+    ],
+    ["ymmsl"],
+    [
+        Namespace(
+            "libmuscle",
+            True,
+            "LIBMUSCLE",
+            "LIBMUSCLE",
+            [
+                dataconstref_desc,
+                data_desc,
+                portsdescription_desc,
+                message_desc,
+                instance_desc,
+                instanceflags_desc,
+            ],
+        ),
+        Namespace(
+            "libmuscle::impl::bindings",
+            False,
+            "LIBMUSCLE_IMPL_BINDINGS",
+            "LIBMUSCLE_IMPL_BINDINGS",
+            [cmdlineargs_desc],
+        ),
+        Namespace("ymmsl", None, "YMMSL", "YMMSL", ymmsl_forward_members),
+    ],
+)
 
 
 libmuscle_mpi_api_description = API(
-        'libmuscle_mpi',
-        [
-            'libmuscle/libmuscle.hpp',
-            'libmuscle/bindings/cmdlineargs.hpp',
-            'ymmsl/ymmsl.hpp',
-            'stdexcept',
-            'typeinfo'],
-        [
-            'mpi', 'ymmsl'],
-        [
-            Namespace('libmuscle', True, 'LIBMUSCLE_MPI', 'LIBMUSCLE', [
-                deepcopy(dataconstref_desc), deepcopy(data_desc),
-                deepcopy(portsdescription_desc), deepcopy(message_desc),
-                deepcopy(instance_mpi_desc), deepcopy(instanceflags_desc)]),
-            Namespace('libmuscle::mpi_impl::bindings', False,
-                      'LIBMUSCLE_MPI_IMPL_BINDINGS', 'LIBMUSCLE_IMPL_BINDINGS',
-                      [deepcopy(cmdlineargs_desc)]),
-            Namespace('ymmsl', None, 'YMMSL', 'YMMSL',
-                      ymmsl_forward_members)
-        ])
+    "libmuscle_mpi",
+    [
+        "libmuscle/libmuscle.hpp",
+        "libmuscle/bindings/cmdlineargs.hpp",
+        "ymmsl/ymmsl.hpp",
+        "stdexcept",
+        "typeinfo",
+    ],
+    ["mpi", "ymmsl"],
+    [
+        Namespace(
+            "libmuscle",
+            True,
+            "LIBMUSCLE_MPI",
+            "LIBMUSCLE",
+            [
+                deepcopy(dataconstref_desc),
+                deepcopy(data_desc),
+                deepcopy(portsdescription_desc),
+                deepcopy(message_desc),
+                deepcopy(instance_mpi_desc),
+                deepcopy(instanceflags_desc),
+            ],
+        ),
+        Namespace(
+            "libmuscle::mpi_impl::bindings",
+            False,
+            "LIBMUSCLE_MPI_IMPL_BINDINGS",
+            "LIBMUSCLE_IMPL_BINDINGS",
+            [deepcopy(cmdlineargs_desc)],
+        ),
+        Namespace("ymmsl", None, "YMMSL", "YMMSL", ymmsl_forward_members),
+    ],
+)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='MUSCLE API Generator')
-    parser.add_argument('--fortran-c-wrappers', action='store_true')
-    parser.add_argument('--fortran-module', action='store_true')
-    parser.add_argument('--fortran-mpi-c-wrappers', action='store_true')
-    parser.add_argument('--fortran-mpi-module', action='store_true')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MUSCLE API Generator")
+    parser.add_argument("--fortran-c-wrappers", action="store_true")
+    parser.add_argument("--fortran-module", action="store_true")
+    parser.add_argument("--fortran-mpi-c-wrappers", action="store_true")
+    parser.add_argument("--fortran-mpi-module", action="store_true")
 
     args = parser.parse_args()
     if args.fortran_c_wrappers:

--- a/scripts/make_ymmsl_api.py
+++ b/scripts/make_ymmsl_api.py
@@ -30,51 +30,89 @@ from api_generator import (
 )
 
 # These need to kept in sync with the values in the C++ implementation
-operator_desc = Enum('Operator', [
-        ('NONE', 0),
-        ('F_INIT', 1),
-        ('O_I', 2),
-        ('S', 3),
-        ('B', 4),
-        ('O_F', 5)
-        ])
+operator_desc = Enum(
+    "Operator", [("NONE", 0), ("F_INIT", 1), ("O_I", 2), ("S", 3), ("B", 4), ("O_F", 5)]
+)
 
 
-settings_desc = Class('Settings', None, [
-    Constructor(),
-    Destructor(),
-    EqualsOperator(Obj('Settings', 'other')),
-    MemFun(Sizet('size'), 'size'),
-    MemFun(Bool('empty'), 'empty'),
-    MemFunTmpl(
-        [String(), Int32t(), Int64t(), Double(), Bool(), VecInt64t(), VecDbl(),
-         Vec2Dbl()],
-        Bool(), 'is_a', [String('key')], True,
-        cpp_chain_call=lambda **kwargs: 'self_p->at({}).is_a<{}>()'.format(
-            kwargs['cpp_args'], kwargs['tpl_type'])),
-    IndexAssignmentOperator('set_character', [String('key'), String('value')]),
-    IndexAssignmentOperator('set_int4', [String('key'), Int32t('value')]),
-    IndexAssignmentOperator('set_int8', [String('key'), Int64t('value')]),
-    IndexAssignmentOperator('set_real8', [String('key'), Double('value')]),
-    IndexAssignmentOperator('set_logical', [String('key'), Bool('value')]),
-    IndexAssignmentOperator('set_int8array', [String('key'), VecInt64t('value')]),
-    IndexAssignmentOperator('set_real8array', [String('key'), VecDbl('value')]),
-    IndexAssignmentOperator('set_real8array2', [String('key'), Vec2Dbl('value')]),
-    OverloadSet('set', [
-        'set_character', 'set_int4', 'set_int8', 'set_real8', 'set_logical',
-        'set_int8array', 'set_real8array', 'set_real8array2'], False),
-    MemFunTmpl(
-        [String(), Int32t(), Int64t(), Double(), Bool(), VecInt64t('value'),
-         VecDbl('value'), Vec2Dbl('value')],
-        T(), 'get_as', [String('key')], True,
-        cpp_chain_call=lambda **kwargs: 'self_p->at({}).as<{}>()'.format(
-            kwargs['cpp_args'], kwargs['tpl_type'])),
-    MemFun(Bool(), 'contains', [String('key')]),
-    MemFun(Sizet('removed'), 'erase', [String('key')]),
-    MemFun(Void(), 'clear'),
-    MemFun(
-        String(), 'key', [Sizet('i')], True,
-        fc_override=dedent("""\
+settings_desc = Class(
+    "Settings",
+    None,
+    [
+        Constructor(),
+        Destructor(),
+        EqualsOperator(Obj("Settings", "other")),
+        MemFun(Sizet("size"), "size"),
+        MemFun(Bool("empty"), "empty"),
+        MemFunTmpl(
+            [
+                String(),
+                Int32t(),
+                Int64t(),
+                Double(),
+                Bool(),
+                VecInt64t(),
+                VecDbl(),
+                Vec2Dbl(),
+            ],
+            Bool(),
+            "is_a",
+            [String("key")],
+            True,
+            cpp_chain_call=lambda **kwargs: "self_p->at({}).is_a<{}>()".format(
+                kwargs["cpp_args"], kwargs["tpl_type"]
+            ),
+        ),
+        IndexAssignmentOperator("set_character", [String("key"), String("value")]),
+        IndexAssignmentOperator("set_int4", [String("key"), Int32t("value")]),
+        IndexAssignmentOperator("set_int8", [String("key"), Int64t("value")]),
+        IndexAssignmentOperator("set_real8", [String("key"), Double("value")]),
+        IndexAssignmentOperator("set_logical", [String("key"), Bool("value")]),
+        IndexAssignmentOperator("set_int8array", [String("key"), VecInt64t("value")]),
+        IndexAssignmentOperator("set_real8array", [String("key"), VecDbl("value")]),
+        IndexAssignmentOperator("set_real8array2", [String("key"), Vec2Dbl("value")]),
+        OverloadSet(
+            "set",
+            [
+                "set_character",
+                "set_int4",
+                "set_int8",
+                "set_real8",
+                "set_logical",
+                "set_int8array",
+                "set_real8array",
+                "set_real8array2",
+            ],
+            False,
+        ),
+        MemFunTmpl(
+            [
+                String(),
+                Int32t(),
+                Int64t(),
+                Double(),
+                Bool(),
+                VecInt64t("value"),
+                VecDbl("value"),
+                Vec2Dbl("value"),
+            ],
+            T(),
+            "get_as",
+            [String("key")],
+            True,
+            cpp_chain_call=lambda **kwargs: "self_p->at({}).as<{}>()".format(
+                kwargs["cpp_args"], kwargs["tpl_type"]
+            ),
+        ),
+        MemFun(Bool(), "contains", [String("key")]),
+        MemFun(Sizet("removed"), "erase", [String("key")]),
+        MemFun(Void(), "clear"),
+        MemFun(
+            String(),
+            "key",
+            [Sizet("i")],
+            True,
+            fc_override=dedent("""\
             void YMMSL_Settings_key_(
                     std::intptr_t self, std::size_t i,
                     char ** ret_val, std::size_t * ret_val_size,
@@ -96,29 +134,26 @@ settings_desc = Class('Settings', None, [
                 return;
             }
 
-            """)),
-    ])
+            """),
+        ),
+    ],
+)
 
 
 ymmsl_api_description = API(
-        'ymmsl',
-        [
-            'ymmsl/ymmsl.hpp',
-            'cstring',
-            'stdexcept',
-            'typeinfo'],
-        [],
-        [
-            Namespace(
-                'ymmsl', True, 'YMMSL', 'YMMSL',
-                [operator_desc, settings_desc]),
-        ])
+    "ymmsl",
+    ["ymmsl/ymmsl.hpp", "cstring", "stdexcept", "typeinfo"],
+    [],
+    [
+        Namespace("ymmsl", True, "YMMSL", "YMMSL", [operator_desc, settings_desc]),
+    ],
+)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='MUSCLE API Generator')
-    parser.add_argument('--fortran-c-wrappers', action='store_true')
-    parser.add_argument('--fortran-module', action='store_true')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MUSCLE API Generator")
+    parser.add_argument("--fortran-c-wrappers", action="store_true")
+    parser.add_argument("--fortran-module", action="store_true")
 
     args = parser.parse_args()
     if args.fortran_c_wrappers:

--- a/scripts/tests/make_echolib_api.py
+++ b/scripts/tests/make_echolib_api.py
@@ -26,90 +26,103 @@ from api_generator import (
     Void,
 )
 
-color_desc = Enum('Color', [('RED', 1), ('GREEN', 2), ('BLUE', 3)])
+color_desc = Enum("Color", [("RED", 1), ("GREEN", 2), ("BLUE", 3)])
 
 
-cmdlineargs_desc = Class('CmdLineArgs', None, [
-        Constructor([Int('count')]),
+cmdlineargs_desc = Class(
+    "CmdLineArgs",
+    None,
+    [
+        Constructor([Int("count")]),
         Destructor(),
-        MemFun(Void(), 'set_arg', [Int('i'), String('arg')]),
-        ])
+        MemFun(Void(), "set_arg", [Int("i"), String("arg")]),
+    ],
+)
 
 
-echo_desc = Class('Echo', None, [
-        Constructor([Obj('CmdLineArgs', 'cla')], fc_override=(
-            'std::intptr_t ECHO_Echo_create_(std::intptr_t cla) {\n'
-            '    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(\n'
-            '            cla);\n'
-            '    Echo * result = new Echo(cla_p->argc(), cla_p->argv());\n'
-            '    return reinterpret_cast<std::intptr_t>(result);\n'
-            '}\n\n'),
+echo_desc = Class(
+    "Echo",
+    None,
+    [
+        Constructor(
+            [Obj("CmdLineArgs", "cla")],
+            fc_override=(
+                "std::intptr_t ECHO_Echo_create_(std::intptr_t cla) {\n"
+                "    CmdLineArgs * cla_p = reinterpret_cast<CmdLineArgs *>(\n"
+                "            cla);\n"
+                "    Echo * result = new Echo(cla_p->argc(), cla_p->argv());\n"
+                "    return reinterpret_cast<std::intptr_t>(result);\n"
+                "}\n\n"
+            ),
             f_override=(
-                'type(ECHO_Echo) function ECHO_Echo_create()\n'
-                '    implicit none\n'
-                '\n'
-                '    integer :: num_args, i, arg_len\n'
-                '    integer (c_intptr_t) :: cla\n'
-                '    character (kind=c_char, len=:), allocatable :: cur_arg\n'
-                '\n'
-                '    num_args = command_argument_count()\n'
-                '    cla = ECHO_impl_CmdLineArgs_create_(num_args + 1)\n'
-                '    do i = 0, num_args\n'
-                '        call get_command_argument(i, length=arg_len)\n'
-                '        allocate (character(arg_len+1) :: cur_arg)\n'
-                '        call get_command_argument(i, value=cur_arg)\n'
-                '        cur_arg(arg_len+1:arg_len+1) = c_null_char\n'
-                '        call ECHO_impl_CmdLineArgs_set_arg_('
-                        'cla, i, cur_arg, int(len(cur_arg), c_size_t))\n'  # noqa: E131
-                '        deallocate(cur_arg)\n'
-                '    end do\n'
-                '    ECHO_Echo_create%ptr = ECHO_Echo_create_(cla)\n'
-                '    call ECHO_impl_CmdLineArgs_free_(cla)\n'
-                'end function ECHO_Echo_create\n'
-                '\n'
-                )),
+                "type(ECHO_Echo) function ECHO_Echo_create()\n"
+                "    implicit none\n"
+                "\n"
+                "    integer :: num_args, i, arg_len\n"
+                "    integer (c_intptr_t) :: cla\n"
+                "    character (kind=c_char, len=:), allocatable :: cur_arg\n"
+                "\n"
+                "    num_args = command_argument_count()\n"
+                "    cla = ECHO_impl_CmdLineArgs_create_(num_args + 1)\n"
+                "    do i = 0, num_args\n"
+                "        call get_command_argument(i, length=arg_len)\n"
+                "        allocate (character(arg_len+1) :: cur_arg)\n"
+                "        call get_command_argument(i, value=cur_arg)\n"
+                "        cur_arg(arg_len+1:arg_len+1) = c_null_char\n"
+                "        call ECHO_impl_CmdLineArgs_set_arg_("
+                "cla, i, cur_arg, int(len(cur_arg), c_size_t))\n"  # noqa: E131
+                "        deallocate(cur_arg)\n"
+                "    end do\n"
+                "    ECHO_Echo_create%ptr = ECHO_Echo_create_(cla)\n"
+                "    call ECHO_impl_CmdLineArgs_free_(cla)\n"
+                "end function ECHO_Echo_create\n"
+                "\n"
+            ),
+        ),
         Destructor(),
-        MemFun(Void(), 'echo_nothing'),
-        MemFun(Int(), 'echo_int', [Int('value')]),
-        MemFun(Int64t(), 'echo_int64_t', [Int64t('value')]),
-        MemFun(Double(), 'echo_double', [Double('value')]),
-        MemFun(Bool(), 'echo_bool', [Bool('value')]),
-        MemFun(EnumVal('Color'), 'echo_enum', [EnumVal('Color', 'value')]),
-        MemFun(String(), 'echo_string', [String('value')]),
-        MemFun(VecDbl('echo'), 'echo_double_vec', [VecDbl('value')]),
-        MemFun(Vec2Dbl('echo'), 'echo_double_vec2', [Vec2Dbl('value')]),
-        MemFun(Obj('Echo'), 'echo_object', [Obj('Echo', 'value')]),
-        MemFun(Bytes('echo'), 'echo_bytes', [Bytes('value')]),
-        MemFun(String(), 'echo_error', [Double('value')], True),
+        MemFun(Void(), "echo_nothing"),
+        MemFun(Int(), "echo_int", [Int("value")]),
+        MemFun(Int64t(), "echo_int64_t", [Int64t("value")]),
+        MemFun(Double(), "echo_double", [Double("value")]),
+        MemFun(Bool(), "echo_bool", [Bool("value")]),
+        MemFun(EnumVal("Color"), "echo_enum", [EnumVal("Color", "value")]),
+        MemFun(String(), "echo_string", [String("value")]),
+        MemFun(VecDbl("echo"), "echo_double_vec", [VecDbl("value")]),
+        MemFun(Vec2Dbl("echo"), "echo_double_vec2", [Vec2Dbl("value")]),
+        MemFun(Obj("Echo"), "echo_object", [Obj("Echo", "value")]),
+        MemFun(Bytes("echo"), "echo_bytes", [Bytes("value")]),
+        MemFun(String(), "echo_error", [Double("value")], True),
         MemFunTmpl(
-                [Int(), Double(), String()],
-                T(), 'echo_template', [T('value')], True),
-        OverloadSet('echo', ['echo_int', 'echo_bool', 'echo_double'], False),
-        ])
+            [Int(), Double(), String()], T(), "echo_template", [T("value")], True
+        ),
+        OverloadSet("echo", ["echo_int", "echo_bool", "echo_double"], False),
+    ],
+)
 
 
 test_api_description = API(
-        'echolib',
-        [
-            'echolib.hpp',
-            'cmdlineargs.hpp',
-            'cstdint',
-            'stdexcept',
-            'string',
-            'typeinfo',
-            'vector'],
-        [],
-        [
-            Namespace('echolib', True, 'ECHO', 'ECHO', [color_desc, echo_desc]),
-            Namespace('echolib::impl', False, 'ECHO_impl', 'ECHO_impl',
-                      [cmdlineargs_desc])
-            ])
+    "echolib",
+    [
+        "echolib.hpp",
+        "cmdlineargs.hpp",
+        "cstdint",
+        "stdexcept",
+        "string",
+        "typeinfo",
+        "vector",
+    ],
+    [],
+    [
+        Namespace("echolib", True, "ECHO", "ECHO", [color_desc, echo_desc]),
+        Namespace("echolib::impl", False, "ECHO_impl", "ECHO_impl", [cmdlineargs_desc]),
+    ],
+)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Test API Generator')
-    parser.add_argument('--fortran-c-wrappers', action='store_true')
-    parser.add_argument('--fortran-module', action='store_true')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test API Generator")
+    parser.add_argument("--fortran-c-wrappers", action="store_true")
+    parser.add_argument("--fortran-module", action="store_true")
 
     args = parser.parse_args()
     if args.fortran_c_wrappers:

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands =
     mypy
     pytest {posargs}
     ruff check
+    ruff format --check
 
 [testenv:cluster]
 deps =


### PR DESCRIPTION
This PR:
1. Applies `ruff format` to the repository
2. Adds a `.git-blame-ignore-revs` to allow to ignore that commit when doing a git blame
3. Adds a step to the tox config to run `ruff format --check` to keep the code formatted according to ruff's rules