### PR TITLE
docs: link yMMSL configuration reference

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Cham.  `<https://doi.org/10.1007/978-3-030-50433-5_33>`_
    :maxdepth: 4
    :caption: API documentation
 
+   yMMSL configuration and Python API <https://ymmsl-python.readthedocs.io/en/stable/>
    python_api
    cpp_api
    fortran_api

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ Cham.  `<https://doi.org/10.1007/978-3-030-50433-5_33>`_
    distributed_execution
    nested_models
    models_as_software
+   yMMSL documentation <https://ymmsl-python.readthedocs.io/en/stable/>
    profiling
 
    coupling
@@ -93,7 +94,6 @@ Cham.  `<https://doi.org/10.1007/978-3-030-50433-5_33>`_
    :maxdepth: 4
    :caption: API documentation
 
-   yMMSL configuration and Python API <https://ymmsl-python.readthedocs.io/en/stable/>
    python_api
    cpp_api
    fortran_api


### PR DESCRIPTION
Closes #190.

Add the live stable yMMSL documentation as a labeled external entry in MUSCLE3’s API documentation navigation, making its configuration examples and Python API reference directly discoverable.

Validation:
- live target returns HTTP 200 and matches the existing yMMSL intersphinx base
- external Title <URL> toctree syntax passes an isolated Sphinx 8 build with warnings as errors
- git diff --check

The full repository docs build reaches the existing Doxygen prerequisite and stops because doxygen/json-glib are not installed locally; the changed navigation entry was validated independently.