### PR TITLE
Feature/msgpack

### DIFF
--- a/libmuscle/cpp/build/Makefile
+++ b/libmuscle/cpp/build/Makefile
@@ -31,6 +31,7 @@ dep_name := msgpack
 dep_version_constraint := >= 7.0.0
 dep_version := 7.0.0
 dep_pkgconfig_name := msgpack-cxx
+dep_header := include/msgpack.hpp
 dep_install := 1
 include $(TOOLDIR)/make_available.make
 

--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -148,7 +148,7 @@ ifeq "$(filter $(MAKECMDGOALS),$(cleantargets))" ""
 
 # Dependencies
 $(info pcextra: $(PKG_CONFIG_EXTRA_DIRS))
-MSGPACK_INCLUDE_DIR = $(CURDIR)/../msgpack/msgpack/include
+MSGPACK_INCLUDE_DIR = $(msgpack_ROOT)/include
 export MSGPACK_INCLUDE_DIR
 CXXFLAGS += -I$(MSGPACK_INCLUDE_DIR)
 

--- a/libmuscle/cpp/build/libmuscle/Makefile
+++ b/libmuscle/cpp/build/libmuscle/Makefile
@@ -75,7 +75,7 @@ endif
 
 installed_pkg_config_files := $(pkg_config_files:%=$(PREFIX)/lib/pkgconfig/%)
 
-CXXFLAGS += -Wall -pedantic -std=c++14 -pthread -O3 -DMSGPACK_NO_BOOST
+CXXFLAGS += -Wall -pedantic -std=c++17 -pthread -O3 -DMSGPACK_NO_BOOST
 export CXXFLAGS
 
 MPIFLAGS := -DMUSCLE_ENABLE_MPI

--- a/libmuscle/cpp/build/ymmsl/Makefile
+++ b/libmuscle/cpp/build/ymmsl/Makefile
@@ -28,7 +28,7 @@ endif
 pkg_config_files := ymmsl.pc
 installed_pkg_config_files := $(pkg_config_files:%=$(PREFIX)/lib/pkgconfig/%)
 
-CXXFLAGS += -Wall -pedantic -std=c++14 -O3 -I$(hdrdir)
+CXXFLAGS += -Wall -pedantic -std=c++17 -O3 -I$(hdrdir)
 export CXXFLAGS
 DEBUGFLAGS += -g -O0
 export DEBUGFLAGS

--- a/scripts/gmake/dep_detect.make
+++ b/scripts/gmake/dep_detect.make
@@ -6,6 +6,9 @@
 # $(dep_name)_AVAILABLE to 1, $(dep_name)_ROOT to the prefix and
 # $(dep_name)_VERSION to the version if the dependency is found on the system
 
+# Optionally define $(dep_header) to detect a header-only dependency that does
+# not ship a pkg-config file by looking for $($(dep_name)_ROOT)/$(dep_header).
+
 ifneq ($(MAKECMDGOALS),clean)
 
 $(info )
@@ -16,8 +19,13 @@ _pkg_config := export PKG_CONFIG_PATH=$($(dep_name)_ROOT)/lib/pkgconfig:$(PKG_CO
 _pkg = '$(dep_pkgconfig_name) $(dep_version_constraint)'
 
 _exists_new_enough := $(shell $(_pkg_config) --exists $(_pkg) || echo NOTFOUND)
+_header_found := $(if $(dep_header),$(wildcard $($(dep_name)_ROOT)/$(dep_header)))
 
-ifneq ($(_exists_new_enough), NOTFOUND)
+ifneq ($(_header_found),)
+    $(info - $(dep_name) found at $($(dep_name)_ROOT) via $(dep_header))
+    export $(dep_name)_AVAILABLE := 1
+    export $(dep_name)_VERSION := $(dep_version)
+else ifneq ($(_exists_new_enough), NOTFOUND)
     _modversion = $(shell $(_pkg_config) --modversion $(dep_pkgconfig_name))
     _prefix = $(shell $(_pkg_config) --variable=prefix $(_pkg))
     $(info - $(dep_name) $(_modversion) found at $(_prefix))
@@ -33,6 +41,9 @@ else
         $(info - $(dep_name) not found on the system.)
     endif
 endif
+
+# clear, so that it does not leak into the detection of the next dependency
+dep_header :=
 
 endif
 


### PR DESCRIPTION
This patch prevents `msgpack` being downloaded if it's supplied.  (Note, `msgpack` does not come with a `.pc` file).  Also switched to use `c++17` standard to fix `googletest` >= 1.16.