### PR TITLE
Fix `make test_examples` and make it run on pull requests

### DIFF
--- a/.github/workflows/ci_ubuntu24.04.yaml
+++ b/.github/workflows/ci_ubuntu24.04.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'release-*'
       - fix_native_compatibility_ci
+      - main
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docs/source/examples/cpp/diffusion.cpp
+++ b/docs/source/examples/cpp/diffusion.cpp
@@ -40,6 +40,11 @@ void diffusion(int argc, char * argv[]) {
             {Operator::O_F, {"final_state_out"}}});
 
     while (instance.reuse_instance()) {
+        if (instance.get_setting_as<bool>("skip", false)) {
+            // The load balancer has no work for us this iteration
+            instance.send("final_state_out", Message(-1));
+            continue;
+        }
         // F_INIT
         double t_max = instance.get_setting_as<double>("t_max");
         double dt = instance.get_setting_as<double>("dt");

--- a/docs/source/examples/cpp/load_balancer.cpp
+++ b/docs/source/examples/cpp/load_balancer.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <cinttypes>
+#include <limits>
 #include <random>
 
 #include <libmuscle/libmuscle.hpp>
@@ -45,7 +46,8 @@ void load_balancer(int argc, char * argv[]) {
             for (int i = 0; i < num_workers; ++i) {
                 auto msg = (started < num_calls) ? 
                     instance.receive_with_settings("front_in", started)
-                    : Message(-INFINITY);
+                    // Send a message indicating nothing left to do:
+                    : Message(-std::numeric_limits<double>::infinity(), Settings({{"skip", true}}));
                 instance.send("back_out", msg, i);
                 ++started;
             }

--- a/docs/source/examples/cpp/load_balancer.cpp
+++ b/docs/source/examples/cpp/load_balancer.cpp
@@ -34,22 +34,28 @@ void load_balancer(int argc, char * argv[]) {
     while (instance.reuse_instance()) {
         // F_INIT
         int started = 0;
-        int done = 0;
+        std::vector<Message> result;
 
         int num_calls = instance.get_port_length("front_in");
         int num_workers = instance.get_port_length("back_out");
 
         instance.set_port_length("front_out", num_calls);
 
-        while (done < num_calls) {
-            while ((started - done < num_workers) && (started < num_calls)) {
-                auto msg = instance.receive_with_settings("front_in", started);
-                instance.send("back_out", msg, started % num_workers);
+        while (result.size() < num_calls) {
+            for (int i = 0; i < num_workers; ++i) {
+                auto msg = (started < num_calls) ? 
+                    instance.receive_with_settings("front_in", started)
+                    : Message(-INFINITY);
+                instance.send("back_out", msg, i);
                 ++started;
             }
-            auto msg = instance.receive_with_settings("back_in", done % num_workers);
-            instance.send("front_out", msg, done);
-            ++done;
+            for (int i = 0; i < num_workers; ++i) {
+                result.push_back(instance.receive_with_settings("back_in", i));
+            }
+        }
+
+        for (int i = 0; i < num_calls; ++i) {
+            instance.send("front_out", result[i], i);
         }
     }
 }

--- a/docs/source/examples/fortran/diffusion.f90
+++ b/docs/source/examples/fortran/diffusion.f90
@@ -13,7 +13,7 @@ program diffusion
     type(LIBMUSCLE_Instance) :: instance
 
     type(LIBMUSCLE_Message) :: rmsg
-    type(LIBMUSCLE_DataConstRef) :: rdata, item
+    type(LIBMUSCLE_DataConstRef) :: rdata
 
 
     type(LIBMUSCLE_Message) :: smsg
@@ -33,6 +33,14 @@ program diffusion
     call LIBMUSCLE_PortsDescription_free(ports)
 
     do while (instance%reuse_instance())
+        if (instance%get_setting_as_logical('skip', .false.)) then
+            ! The load balancer has no work for us this iteration
+            smsg = LIBMUSCLE_Message(-1.0d0)
+            call instance%send('final_state_out', smsg)
+            call LIBMUSCLE_Message_free(smsg)
+            cycle
+        end if
+
         ! F_INIT
         t_max = instance%get_setting_as_real8('t_max')
         dt = instance%get_setting_as_real8('dt')

--- a/docs/source/examples/fortran/load_balancer.f90
+++ b/docs/source/examples/fortran/load_balancer.f90
@@ -17,7 +17,8 @@ program load_balancer
 
     type(LIBMUSCLE_Message) :: rmsg
     type(LIBMUSCLE_Message), allocatable :: result(:)
-    type(LIBMUSCLE_DataConstRef) :: rdata
+    type(LIBMUSCLE_Data) :: rdata
+    type(YMMSL_Settings) :: settings
 
     integer :: started, done, num_calls, num_workers, i
 
@@ -46,16 +47,25 @@ program load_balancer
                 if (started < num_calls) then
                     rmsg = instance%receive_with_settings_on_slot('front_in', started)
                 else
-                    rmsg = LIBMUSCLE_Message(-1d40)
+                    ! Send a message indicating nothing left to do:
+                    settings = YMMSL_Settings()
+                    call settings%set('skip', .true.)
+                    rdata = LIBMUSCLE_Data(settings)
+                    rmsg = LIBMUSCLE_Message(-1d40, rdata)
+                    call LIBMUSCLE_Data_free(rdata)
+                    call YMMSL_Settings_free(settings)
                 end if
                 call instance%send('back_out', rmsg, i)
                 call LIBMUSCLE_Message_free(rmsg)
                 started = started + 1
             end do
             do i = 0, num_workers-1
+                rmsg = instance%receive_with_settings_on_slot('back_in', i)
                 if (done < num_calls) then
                     done = done + 1
-                    result(done) = instance%receive_with_settings_on_slot('back_in', mod(done, num_workers))
+                    result(done) = rmsg
+                else
+                    call LIBMUSCLE_Message_free(rmsg)
                 end if
             end do
         end do

--- a/docs/source/examples/fortran/load_balancer.f90
+++ b/docs/source/examples/fortran/load_balancer.f90
@@ -16,9 +16,10 @@ program load_balancer
     type(LIBMUSCLE_Instance) :: instance
 
     type(LIBMUSCLE_Message) :: rmsg
+    type(LIBMUSCLE_Message), allocatable :: result(:)
     type(LIBMUSCLE_DataConstRef) :: rdata
 
-    integer :: started, done, num_calls, num_workers
+    integer :: started, done, num_calls, num_workers, i
 
 
     ports = LIBMUSCLE_PortsDescription()
@@ -36,22 +37,34 @@ program load_balancer
 
         num_calls = instance%get_port_length('front_in')
         num_workers = instance%get_port_length('back_out')
+        allocate(result(num_calls))
 
         call instance%set_port_length('front_out', num_calls)
 
         do while (done < num_calls)
-            do while ((started - done < num_workers) .and. (started < num_calls))
-                rmsg = instance%receive_with_settings_on_slot('front_in', started)
-                call instance%send('back_out', rmsg, mod(started, num_workers))
+            do i = 0, num_workers-1
+                if (started < num_calls) then
+                    rmsg = instance%receive_with_settings_on_slot('front_in', started)
+                else
+                    rmsg = LIBMUSCLE_Message(-1d40)
+                end if
+                call instance%send('back_out', rmsg, i)
                 call LIBMUSCLE_Message_free(rmsg)
                 started = started + 1
             end do
-
-            rmsg = instance%receive_with_settings_on_slot('back_in', mod(done, num_workers))
-            call instance%send('front_out', rmsg, done)
-            call LIBMUSCLE_Message_free(rmsg)
-            done = done + 1
+            do i = 0, num_workers-1
+                if (done < num_calls) then
+                    done = done + 1
+                    result(done) = instance%receive_with_settings_on_slot('back_in', mod(done, num_workers))
+                end if
+            end do
         end do
+
+        do i = 1, num_calls
+            call instance%send('front_out', result(i), i-1)
+            call LIBMUSCLE_Message_free(result(i))
+        end do
+        deallocate(result)
     end do
 
     call LIBMUSCLE_Instance_free(instance)

--- a/docs/source/examples/python/interact_coupling.py
+++ b/docs/source/examples/python/interact_coupling.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Tuple, Dict
 
 from libmuscle import Instance, InstanceFlags, Message
 from libmuscle.runner import run_simulation
-from ymmsl.v0_2 import (
-        Component, Conduit, Configuration, Model, Operator, Ports, Settings)
+from ymmsl.v0_2 import Configuration, Operator
+from ymmsl import load_as
 
 
 def submodel() -> None:
@@ -317,38 +317,47 @@ if __name__ == '__main__':
     logging.basicConfig()
     logging.getLogger().setLevel(logging.INFO)
 
-    components = [
-            Component(
-                'left', Ports(o_i=['boundary_out'], s=['boundary_in']),
-                'One of the interacting components', 'model'),
-            Component(
-                'right', Ports(o_i=['boundary_out'], s=['boundary_in']),
-                'The other interacting component', 'model'),
-            Component(
-                'coupler', Ports(o_i=['a_out', 'b_out'], s=['a_in', 'b_in']),
-                'This connects the two and interpolates', 'temporal_coupler')]
+    config = """
+ymmsl_version: v0.2
 
-    conduits = [
-            Conduit('left.boundary_out', 'coupler.a_in'),
-            Conduit('right.boundary_out', 'coupler.b_in'),
-            Conduit('coupler.a_out', 'left.boundary_in'),
-            Conduit('coupler.b_out', 'right.boundary_in')]
+models:
+  interact_coupling:
+    description: |
+      A model demonstrating a time scale overlapping coupling, using a time bridge.
+    components:
+      left:
+        description: One of the interacting components
+        ports:
+          o_i: boundary_out
+          s: boundary_in
+        implementation: model
+      right:
+        description: The other interacting component
+        ports:
+          o_i: boundary_out
+          s: boundary_in
+        implementation: model
+      coupler:
+        description: This connects the two and interpolates
+        ports:
+          timeline left:
+            o_i: a_out
+            s: a_in
+          timeline right:
+            o_i: b_out
+            s: b_in
+        implementation: temporal_coupler
+    conduits:
+      left.boundary_out: coupler.a_in
+      right.boundary_out: coupler.b_in
+      coupler.a_out: left.boundary_in
+      coupler.b_out: right.boundary_in
+settings:
+  t_max: 100.0
+  left.dt: 5.0
+  right.dt: 13.0
+"""
 
-    model = Model(
-            'interact_coupling', description='A model demonstrating a time scale'
-            ' overlapping coupling, using a time bridge.', components=components,
-            conduits=conduits)
-
-    settings = Settings({
-        't_max': 100.0,
-        'left.dt': 5.0,
-        'right.dt': 13.0,
-        })
-
-    configuration = Configuration(
-            'This demonstrates two models running with different timesteps while'
-            ' communicating with each other via a time bridge', models=[model],
-            settings=settings)
-
+    configuration = load_as(Configuration, config)
     implementations = {'model': submodel, 'temporal_coupler': temporal_coupler}
     run_simulation(configuration, implementations)

--- a/docs/source/examples/python/reaction_diffusion_qmc.py
+++ b/docs/source/examples/python/reaction_diffusion_qmc.py
@@ -134,22 +134,26 @@ def load_balancer() -> None:
             DONT_APPLY_OVERLAY)
 
     while instance.reuse_instance():
-        # F_INIT
-        started = 0     # number started and index of next to start
-        done = 0        # number done and index of next to return
+        started = 0  # number started and index of next to start
+        result: list[Message] = []
 
-        num_calls = instance.get_port_length('front_in')
-        num_workers = instance.get_port_length('back_out')
+        num_calls = instance.get_port_length("front_in")
+        num_workers = instance.get_port_length("back_out")
 
-        instance.set_port_length('front_out', num_calls)
-        while done < num_calls:
-            while started - done < num_workers and started < num_calls:
-                msg = instance.receive_with_settings('front_in', started)
-                instance.send('back_out', msg, started % num_workers)
+        instance.set_port_length("front_out", num_calls)
+        while len(result) < num_calls:
+            for i in range(num_workers):
+                if started < num_calls:
+                    msg = instance.receive_with_settings("front_in", started)
+                else:
+                    msg = Message(float("-inf"))  # data=None indicates nothing to do
+                instance.send("back_out", msg, i)
                 started += 1
-            msg = instance.receive_with_settings('back_in', done % num_workers)
-            instance.send('front_out', msg, done)
-            done += 1
+            for i in range(num_workers):
+                result.append(instance.receive_with_settings("back_in", i))
+
+        for i in range(num_calls):
+            instance.send("front_out", result[i], i)
 
 
 def qmc_driver() -> None:

--- a/docs/source/examples/python/reaction_diffusion_qmc.py
+++ b/docs/source/examples/python/reaction_diffusion_qmc.py
@@ -67,6 +67,11 @@ def diffusion() -> None:
             Operator.O_F: ['final_state_out']})
 
     while instance.reuse_instance():
+        if instance.get_setting('skip', 'bool', default=False):
+            # The load balancer has no work for us this iteration
+            instance.send('final_state_out', Message(-1))
+            continue
+
         # F_INIT
         t_max = instance.get_setting('t_max', 'float')
         dt = instance.get_setting('dt', 'float')
@@ -146,7 +151,8 @@ def load_balancer() -> None:
                 if started < num_calls:
                     msg = instance.receive_with_settings("front_in", started)
                 else:
-                    msg = Message(float("-inf"))  # data=None indicates nothing to do
+                    # Send a message indicating nothing left to do:
+                    msg = Message(float("-inf"), data=Settings(dict(skip=True)))
                 instance.send("back_out", msg, i)
                 started += 1
             for i in range(num_workers):
@@ -299,7 +305,7 @@ if __name__ == '__main__':
         'k_max': -3.645e4,
         'd_min': 0.03645,
         'd_max': 0.04455,
-        'n_samples': 100
+        'n_samples': 105
         })
 
     configuration = Configuration(

--- a/docs/source/examples/rdmc_settings.ymmsl
+++ b/docs/source/examples/rdmc_settings.ymmsl
@@ -14,4 +14,4 @@ settings:
   k_max: -3.645e4
   d_min: 0.03645
   d_max: 0.04455
-  n_samples: 10
+  n_samples: 15

--- a/src/cpp/libmuscle/port_manager.cpp
+++ b/src/cpp/libmuscle/port_manager.cpp
@@ -49,9 +49,9 @@ bool PortManager::has_f_init_connections() const {
     return false;
 }
 
-std::vector<Port> PortManager::get_connected_ports(
+PortManager::PortReferences PortManager::get_connected_ports(
         Operator oper, Optional<Timeline> const & timeline) const {
-    std::vector<Port> result;
+    PortManager::PortReferences result;
     for (auto const & port : ports_) {
         if (port.second.oper != oper)
             continue;

--- a/src/cpp/libmuscle/port_manager.hpp
+++ b/src/cpp/libmuscle/port_manager.hpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
@@ -24,6 +25,8 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 class PortManager {
     public:
         using PortMessageCounts = std::unordered_map<std::string, std::vector<int>>;
+        /* Memory safety: PortReferences is only valid while PortManager is alive! */
+        using PortReferences = std::vector<std::reference_wrapper<const Port>>;
 
         /** Create a PortManager.
          *
@@ -70,7 +73,7 @@ class PortManager {
          * @param oper The operator to select ports for.
          * @param timeline If set, only return ports on this timeline.
          */
-        std::vector<Port> get_connected_ports(
+        PortReferences get_connected_ports(
                 ::ymmsl::Operator oper,
                 Optional<::ymmsl::Timeline> const & timeline = {}) const;
 

--- a/src/cpp/libmuscle/tests/mocks/mock_port_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_port_manager.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
@@ -22,6 +23,7 @@ using PortsDescription = std::unordered_map<ymmsl::Operator, std::vector<std::st
 class MockPortManager : public MockClass<MockPortManager> {
     public:
         using PortMessageCounts = std::unordered_map<std::string, std::vector<int>>;
+        using PortReferences = std::vector<std::reference_wrapper<const Port>>;
 
         MockPortManager(ReturnValue) {
             NAME_MOCK_MEM_FUN(MockPortManager, constructor);
@@ -42,7 +44,7 @@ class MockPortManager : public MockClass<MockPortManager> {
             // which queries these at construction time.
             settings_in_connected.return_value = false;
             has_f_init_connections.return_value = false;
-            get_connected_ports.return_value = std::vector<Port>();
+            get_connected_ports.return_value = PortReferences();
             list_subtimelines.return_value = std::vector<::ymmsl::Timeline>();
         }
 
@@ -68,7 +70,7 @@ class MockPortManager : public MockClass<MockPortManager> {
         MockFun<Val<bool>> has_f_init_connections;
 
         MockFun<
-            Val<std::vector<Port>>, Val<::ymmsl::Operator>,
+            Val<PortReferences>, Val<::ymmsl::Operator>,
             Val<Optional<::ymmsl::Timeline> const &>> get_connected_ports;
 
         MockFun<Val<std::vector<::ymmsl::Timeline>>> list_subtimelines;

--- a/src/cpp/libmuscle/tests/test_port_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_port_manager.cpp
@@ -302,15 +302,20 @@ TEST_F(libmuscle_port_manager, test_list_subtimelines_and_get_connected_ports) {
     auto oi_ports = port_manager.get_connected_ports(Operator::O_I);
     ASSERT_EQ(oi_ports.size(), 2u);
     std::unordered_map<std::string, Timeline> oi_timeline_by_name;
-    for (auto const & port : oi_ports)
+    for (Port const & port : oi_ports)
         oi_timeline_by_name.emplace(port.name, port.timeline);
     ASSERT_EQ(oi_timeline_by_name.at("oi_a"), Timeline(":a"));
     ASSERT_EQ(oi_timeline_by_name.at("oi_b"), Timeline(":b"));
 
     auto oi_a_ports = port_manager.get_connected_ports(Operator::O_I, Timeline(":a"));
     ASSERT_EQ(oi_a_ports.size(), 1u);
-    ASSERT_EQ(oi_a_ports[0].name, "oi_a");
-    ASSERT_EQ(oi_a_ports[0].timeline, Timeline(":a"));
+    ASSERT_EQ(oi_a_ports[0].get().name, "oi_a");
+    ASSERT_EQ(oi_a_ports[0].get().timeline, Timeline(":a"));
+
+    // Check that PortReferences are indeed referring to the original port
+    ASSERT_TRUE(oi_a_ports[0].get().is_open());
+    port_manager.get_port("oi_a").set_closed();
+    ASSERT_FALSE(oi_a_ports[0].get().is_open());
 }
 
 TEST_F(libmuscle_port_manager, test_port_message_counts) {

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include "timeline_manager.hpp"
 
 
 using ymmsl::Operator;
@@ -201,14 +202,10 @@ MessageOutOfSync::MessageOutOfSync(Port const & port, Optional<int> slot)
 {}
 
 
-TimelinePorts::TimelinePorts(std::vector<Port> const & ports_in)
+TimelinePorts::TimelinePorts(PortManager::PortReferences ports_in)
     : ports(ports_in)
-    , num_slots(0)
     , participated()
-{
-    for (auto const & port : ports)
-        num_slots += port.is_vector() ? static_cast<std::size_t>(port.get_length()) : 1;
-}
+{}
 
 void TimelinePorts::participate(std::string const & port_name, Optional<int> slot) {
     if (!has_participated(port_name, slot))
@@ -221,12 +218,15 @@ bool TimelinePorts::has_participated(std::string const & port_name, Optional<int
 }
 
 bool TimelinePorts::all_participated() const {
+    std::size_t num_slots = 0;
+    for (Port const & port : ports) // ports is a copy, not a reference!!!!!!!!!!!
+        num_slots += port.is_vector() ? static_cast<std::size_t>(port.get_length()) : 1;
     return participated.size() == num_slots;
 }
 
 std::vector<std::pair<Port, std::vector<int>>> TimelinePorts::missing_ports() const {
     std::vector<std::pair<Port, std::vector<int>>> result;
-    for (auto const & port : ports) {
+    for (Port const & port : ports) {
         std::string name = std::string(port.name);
         if (port.is_vector()) {
             std::vector<int> slots;
@@ -246,8 +246,8 @@ std::vector<std::pair<Port, std::vector<int>>> TimelinePorts::all_ports() const 
     std::vector<std::pair<Port, std::vector<int>>> result;
     for (auto const & port : ports) {
         std::vector<int> slots;
-        if (port.is_vector())
-            for (int slot = 0; slot < port.get_length(); ++slot)
+        if (port.get().is_vector())
+            for (int slot = 0; slot < port.get().get_length(); ++slot)
                 slots.push_back(slot);
         result.emplace_back(port, slots);
     }
@@ -389,7 +389,7 @@ void SubTimelineManager::missing_actions(ExpectedActions & result) const {
 
 TimelineManager::TimelineManager(PortManager const & port_manager)
     : port_manager_(port_manager)
-    , receive_(std::vector<Port>())
+    , receive_({})
     , send_(port_manager.get_connected_ports(Operator::O_F, Optional<Timeline>()))
     , submanagers_()
     , iteration_()

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -138,7 +138,7 @@ class MessageOutOfSync : public TimelineError {
  */
 class TimelinePorts {
     public:
-        explicit TimelinePorts(std::vector<Port> const & ports);
+        explicit TimelinePorts(PortManager::PortReferences ports);
 
         /** Record that the given port/slot has participated. */
         void participate(std::string const & port_name, Optional<int> slot);
@@ -161,8 +161,7 @@ class TimelinePorts {
         /** Clear participation, keeping the tracked ports. */
         void reset();
 
-        std::vector<Port> ports;
-        std::size_t num_slots;
+        PortManager::PortReferences ports;
         std::vector<PortAndSlot> participated;
 };
 

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -134,9 +134,6 @@ class TimelinePorts:
 
     def __init__(self, ports: list[Port]) -> None:
         self.ports = ports
-        self.num_slots = sum(
-            port.get_length() if port.is_vector() else 1 for port in ports
-        )
         self.participated: set[PortAndSlot] = set()
 
     def participate(self, port_name: str, slot: Optional[int]) -> None:
@@ -149,7 +146,8 @@ class TimelinePorts:
 
     def all_participated(self) -> bool:
         """Return whether every port/slot combination has participated."""
-        return len(self.participated) == self.num_slots
+        num = sum(port.get_length() if port.is_vector() else 1 for port in self.ports)
+        return len(self.participated) == num
 
     def missing_ports(self) -> list[tuple[Port, list[int]]]:
         """Return each connected port that still has slots which haven't


### PR DESCRIPTION
Fixes made for the examples:

- Handle resizable ports in the TimelineManager
  - Also ensured that the C++ (Sub)TimelineManager was looking at references of the ports stored by the PortsManager instead of a copy.
- Update "load balancer" examples to conform to the Timeline restrictions:    
    1. F_INIT is first (this is covered by the pre_receive of Instance)
    2. All slots of the O_I port (back_out) must send once
    3. All slots of the S port (back_in) must receive once
    4. Repeat 2&3 until done
    5. Send all results on O_F

This PR also enables the `ci_ubuntu24.04` workflow for every pull request, and pushes to the `develop` and `main` branches

Fixes #391 