### PR TITLE
Refactor send / receive

### DIFF
--- a/integration_test/test_cpp_mpp_client.py
+++ b/integration_test/test_cpp_mpp_client.py
@@ -27,7 +27,6 @@ def tcp_server_process(control_pipe):
         2.0,
         settings,
         0,
-        1.0,
         data,
     ).encoded()
 

--- a/src/cpp/libmuscle/checkpoint_triggers.cpp
+++ b/src/cpp/libmuscle/checkpoint_triggers.cpp
@@ -174,19 +174,6 @@ double TriggerManager::elapsed_walltime() {
     return std::chrono::duration<double>(duration).count();
 }
 
-double TriggerManager::checkpoints_considered_until() {
-    return cpts_considered_until_;
-}
-
-void TriggerManager::harmonise_wall_time(double at_least) {
-    double cur = elapsed_walltime();
-    if (cur < at_least) {
-        auto duration = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-            std::chrono::duration<double>(at_least - cur));
-        simulation_epoch_ -= duration;
-    }
-}
-
 bool TriggerManager::should_save_snapshot(double timestamp) {
     if (!has_checkpoints_) return false;
 

--- a/src/cpp/libmuscle/checkpoint_triggers.hpp
+++ b/src/cpp/libmuscle/checkpoint_triggers.hpp
@@ -123,17 +123,9 @@ class TriggerManager {
          */
         double elapsed_walltime();
 
-        /** Return elapsed time of last should_save*
-         */
-        double checkpoints_considered_until();
-
         /** Returns whether checkpoints are defined
          */
         bool has_checkpoints() const { return has_checkpoints_; }
-
-        /** Ensure our elapsed time is at least the given value
-         */
-        void harmonise_wall_time(double at_least);
 
         /** Handles instance.should_save_snapshot
          */

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -78,40 +78,33 @@ void Communicator::send_message(
         Message const & message,
         Optional<int> slot)
 {
-    std::vector<int> slot_list;
-    if (slot.is_set())
-        slot_list.push_back(slot.get());
-    log_debug("Sending message on ", port_desc(port_name, slot));
-
-    Endpoint snd_endpoint = get_endpoint_(port_name, slot_list);
-    if (!port_manager_.get_port(snd_endpoint.port).is_connected())
-        // log sending on disconnected port
-        return;
-
     Port & port = port_manager_.get_port(port_name);
-
-    ProfileEvent profile_event(
-            ProfileEventType::send, ProfileTimestamp(), {}, port, {}, slot,
-            port.get_num_messages(), {}, message.timestamp());
-
-    auto recv_endpoints = peer_info_.get().get_peer_endpoints(
-            snd_endpoint.port, slot_list);
-
-    Data settings_overlay(message.settings());
-
-    Optional<int> port_length;
-    if (port.is_resizable())
-        port_length = port.get_length();
+    if (!port.is_connected()) {
+        log_debug("Sending message on unconnected port ", port_desc(port_name, slot));
+        return;
+    }
+    log_debug("Sending message on ", port_desc(port_name, slot));
 
     Optional<IterationCount> iteration;
     if (!is_close_port(message.data()))
         iteration = timeline_manager_->check_send_message(port_name, slot);
 
+    ProfileEvent profile_event(
+            ProfileEventType::send, ProfileTimestamp(), {}, port, {}, slot,
+            port.get_num_messages(), {}, message.timestamp());
+
+    Optional<int> port_length;
+    if (port.is_resizable())
+        port_length = port.get_length();
+
+    auto endpoints = get_endpoints_(port, slot);
+    auto& snd_endpoint = std::get<0>(endpoints);
+    auto& recv_endpoints = std::get<1>(endpoints);
     for (auto recv_endpoint : recv_endpoints) {
         MPPMessage mpp_message(
                 snd_endpoint.ref(), recv_endpoint.ref(),
                 port_length, message.timestamp(), Optional<double>(),
-                settings_overlay, port.get_num_messages(slot),
+                Data(message.settings()), port.get_num_messages(slot),
                 message.data(), iteration);
 
         if (message.has_next_timestamp())
@@ -166,26 +159,21 @@ Message Communicator::receive_message(
         Optional<int> slot,
         Optional<Message> const & default_msg)
 {
-    Port & port = port_manager_.get_port(port_name);
-
     timeline_manager_->check_receive(port_name, slot);
+
+    Port & port = port_manager_.get_port(port_name);
     std::string port_and_slot = port_desc(port_name, slot);
     log_debug("Waiting for message on ", port_and_slot);
-
-    std::vector<int> slot_list;
-    if (slot.is_set())
-        slot_list.emplace_back(slot.get());
-
-    Endpoint recv_endpoint(get_endpoint_(port_name, slot_list));
 
     ProfileEvent receive_event(
             ProfileEventType::receive, ProfileTimestamp(), {}, port, {}, slot,
             port.get_num_messages());
 
+    auto endpoints = get_endpoints_(port, slot);
+    auto& recv_endpoint = std::get<0>(endpoints);
     // peer_info already checks that there is at most one snd_endpoint
     // connected to the port we receive on
-    Endpoint snd_endpoint = peer_info_.get().get_peer_endpoints(
-            recv_endpoint.port, slot_list).at(0);
+    auto& snd_endpoint = std::get<1>(endpoints)[0];
     MPPClient & client = get_client_(snd_endpoint.instance());
     ReceiveTimeoutHandler handler(
             manager_, snd_endpoint.instance(), port_name, slot, receive_timeout_);
@@ -317,17 +305,12 @@ MPPClient & Communicator::get_client_(Reference const & instance) {
     return *clients_.at(instance);
 }
 
-Endpoint Communicator::get_endpoint_(
-        std::string const & port_name, std::vector<int> const & slot) const {
-    try {
-        Identifier port(port_name);
-        return Endpoint(kernel_, index_, port, slot);
-    }
-    catch (std::invalid_argument const & e) {
-        std::ostringstream oss;
-        oss << "'" << port_name << "' is not a valid port name: " << e.what();
-        throw std::invalid_argument(oss.str());
-    }
+std::tuple<Endpoint, std::vector<Endpoint>> Communicator::get_endpoints_(
+        Port const & port, Optional<int> const & slot) const {
+    return {
+        Endpoint(kernel_, index_, port.name, slot),
+        peer_info_.get().get_peer_endpoints(port.name, slot)
+    };
 }
 
 std::tuple<std::vector<char>, mcp::ProfileData> Communicator::try_receive_(

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -76,8 +76,7 @@ void Communicator::restore_state(TimelineState const & state) {
 void Communicator::send_message(
         std::string const & port_name,
         Message const & message,
-        Optional<int> slot,
-        double checkpoints_considered_until)
+        Optional<int> slot)
 {
     std::vector<int> slot_list;
     if (slot.is_set())
@@ -113,7 +112,6 @@ void Communicator::send_message(
                 snd_endpoint.ref(), recv_endpoint.ref(),
                 port_length, message.timestamp(), Optional<double>(),
                 settings_overlay, port.get_num_messages(slot),
-                checkpoints_considered_until,
                 message.data(), iteration);
 
         if (message.has_next_timestamp())
@@ -133,24 +131,18 @@ void Communicator::send_message(
         profiler_.record_event(std::move(profile_event));
 }
 
-std::tuple<Communicator::FInitCacheType, double> Communicator::pre_receive_f_init() {
+Communicator::FInitCacheType Communicator::pre_receive_f_init() {
     FInitCacheType cache;
-    double max_saved_until = -std::numeric_limits<double>::infinity();
 
     auto pre_receive = [&](std::string & port_name, Optional<int> slot) {
         Reference port_ref(port_name);
         if (slot.is_set())
             port_ref += slot.get();
         
-        auto msg_saved_until = receive_message(port_name, slot);
-        auto & msg = std::get<0>(msg_saved_until);
+        auto msg = receive_message(port_name, slot);
         if (is_close_port(msg.data()))
             throw PortClosed();
         cache.emplace(port_ref, msg);
-
-        auto & saved_until = std::get<1>(msg_saved_until);
-        if (saved_until > max_saved_until)
-            max_saved_until = saved_until;
     };
 
     for (Port const & port : port_manager_.get_connected_ports(Operator::F_INIT, {})) {
@@ -166,10 +158,10 @@ std::tuple<Communicator::FInitCacheType, double> Communicator::pre_receive_f_ini
         }
     }
 
-    return {cache, max_saved_until};
+    return cache;
 }
 
-std::tuple<Message, double> Communicator::receive_message(
+Message Communicator::receive_message(
         std::string const & port_name,
         Optional<int> slot,
         Optional<Message> const & default_msg)
@@ -285,7 +277,7 @@ std::tuple<Message, double> Communicator::receive_message(
         timeline_manager_->record_received_message(
                 port_name, slot, mpp_message.iteration.get());
     }
-    return std::make_tuple(message, mpp_message.saved_until);
+    return message;
 }
 
 void Communicator::shutdown() {

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -133,6 +133,42 @@ void Communicator::send_message(
         profiler_.record_event(std::move(profile_event));
 }
 
+std::tuple<Communicator::FInitCacheType, double> Communicator::pre_receive_f_init() {
+    FInitCacheType cache;
+    double max_saved_until = -std::numeric_limits<double>::infinity();
+
+    auto pre_receive = [&](std::string & port_name, Optional<int> slot) {
+        Reference port_ref(port_name);
+        if (slot.is_set())
+            port_ref += slot.get();
+        
+        auto msg_saved_until = receive_message(port_name, slot);
+        auto & msg = std::get<0>(msg_saved_until);
+        if (is_close_port(msg.data()))
+            throw PortClosed();
+        cache.emplace(port_ref, msg);
+
+        auto & saved_until = std::get<1>(msg_saved_until);
+        if (saved_until > max_saved_until)
+            max_saved_until = saved_until;
+    };
+
+    for (Port const & port : port_manager_.get_connected_ports(Operator::F_INIT, {})) {
+        std::string port_name(port.name);
+        log_debug("Pre-receiving on port ", port_name);
+        if (!port.is_vector())
+            pre_receive(port_name, {});
+        else {
+            pre_receive(port_name, 0);
+            // The above receives the length, if needed, so now we can get the rest.
+            for (int slot = 1; slot < port.get_length(); ++slot)
+                pre_receive(port_name, slot);
+        }
+    }
+
+    return {cache, max_saved_until};
+}
+
 std::tuple<Message, double> Communicator::receive_message(
         std::string const & port_name,
         Optional<int> slot,

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -170,10 +170,10 @@ class Communicator {
         ymmsl::Reference instance_id_() const;
         MPPClient & get_client_(ymmsl::Reference const & instance);
 
-        Endpoint get_endpoint_(
-                std::string const & port_name,
-                std::vector<int> const & slot
-                ) const;
+        /** Return our endpoint and the peer endpoints for the given port and slot.
+         */
+        std::tuple<Endpoint, std::vector<Endpoint>> get_endpoints_(
+                Port const & name, Optional<int> const & slot) const;
 
         std::tuple<std::vector<char>, mcp::ProfileData> try_receive_(
                 MPPClient & client, ymmsl::Reference const & receiver,

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -93,21 +93,17 @@ class Communicator {
          * @param port_name The port on which this message is to be sent.
          * @param message The message to send.
          * @param slot The slot to send the message on.
-         * @param checkpoints_considered_until When we last checked if we
-         *      should save a snapshot (wallclock time).
          */
         void send_message(
                 std::string const & port_name,
                 Message const & message,
-                Optional<int> slot = {},
-                double checkpoints_considered_until = -std::numeric_limits<double>::infinity());
+                Optional<int> slot = {});
 
         /** Receive on all connected F_INIT port (including muscle_settings_in).
          * 
-         * @return The received messages, as well as the maximum value of all
-         *      saved_until metadata from the received messages.
+         * @return The received messages.
          */
-        std::tuple<FInitCacheType, double> pre_receive_f_init();
+        FInitCacheType pre_receive_f_init();
 
         /** Receive a message and attached settings overlay.
          *
@@ -128,12 +124,11 @@ class Communicator {
          *
          * @return The received message, with message.settings holding the
          *      settings overlay. The setings attribute is guaranteed to be set.
-         *      Second, the saved_until metadata field from the received message.
          *
          * @throws std::runtime_error if no default was given and the port is
          *      not connected.
          */
-        std::tuple<Message, double> receive_message(
+        Message receive_message(
                 std::string const & port_name,
                 Optional<int> slot = {},
                 Optional<Message> const & default_msg = {}

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -29,6 +29,11 @@
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 
+class PortClosed : public std::runtime_error {
+    public:
+        PortClosed() : std::runtime_error("Port closed") {};
+};
+
 /** Communication engine for MUSCLE3.
  *
  * This class is the mailroom for an instance that uses MUSCLE3. It manages
@@ -38,6 +43,7 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 class Communicator {
     public:
         using PortMessageCounts = std::unordered_map<std::string, std::vector<int>>;
+        using FInitCacheType = std::unordered_map<::ymmsl::Reference, Message>;
 
         /** Create a Communicator.
          *
@@ -95,6 +101,13 @@ class Communicator {
                 Message const & message,
                 Optional<int> slot = {},
                 double checkpoints_considered_until = -std::numeric_limits<double>::infinity());
+
+        /** Receive on all connected F_INIT port (including muscle_settings_in).
+         * 
+         * @return The received messages, as well as the maximum value of all
+         *      saved_until metadata from the received messages.
+         */
+        std::tuple<FInitCacheType, double> pre_receive_f_init();
 
         /** Receive a message and attached settings overlay.
          *

--- a/src/cpp/libmuscle/endpoint.cpp
+++ b/src/cpp/libmuscle/endpoint.cpp
@@ -11,7 +11,7 @@ Endpoint::Endpoint(
         Reference const & kernel,
         std::vector<int> const & index,
         Identifier const & port,
-        std::vector<int> const & slot)
+        Optional<int> const & slot)
     : kernel(kernel)
     , index(index)
     , port(port)
@@ -23,8 +23,8 @@ Reference Endpoint::ref() const {
     if (!index.empty())
         ret += index;
     ret += port;
-    if (!slot.empty())
-        ret += slot;
+    if (slot.is_set())
+        ret += slot.get();
     return ret;
 }
 

--- a/src/cpp/libmuscle/endpoint.hpp
+++ b/src/cpp/libmuscle/endpoint.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <libmuscle/namespace.hpp>
+#include <libmuscle/util.hpp>
 
 #include <string>
 #include <vector>
@@ -60,7 +61,7 @@ class Endpoint {
                 ymmsl::Reference const & kernel,
                 std::vector<int> const & index,
                 ymmsl::Identifier const & port,
-                std::vector<int> const & slot);
+                Optional<int> const & slot);
 
         /** Express as Reference.
          *
@@ -94,7 +95,7 @@ class Endpoint {
         ymmsl::Identifier port;
 
         /// Slot on which to send or receive.
-        std::vector<int> slot;
+        Optional<int> slot;
 };
 
 } }

--- a/src/cpp/libmuscle/instance.cpp
+++ b/src/cpp/libmuscle/instance.cpp
@@ -674,21 +674,16 @@ Message Instance::Impl::receive_message(
             }
         }
         else {
-            double saved_until;
-            std::tie(result, saved_until) = communicator_->receive_message(
-                    port_name, slot);
+            result = communicator_->receive_message(port_name, slot);
             if (!port.is_open(slot)) {
                 std::ostringstream oss;
                 oss << "Port \"" << port_ref << "\" is closed, but we're trying";
                 oss << " to receive on it. Did the peer crash?";
                 error = Error(std::runtime_error(oss.str()));
             }
-            else {
-                if (!with_settings) {
-                    check_compatibility_(port_name, result.settings());
-                    result.unset_settings();
-                }
-                trigger_manager_->harmonise_wall_time(saved_until);
+            else if (!with_settings) {
+                check_compatibility_(port_name, result.settings());
+                result.unset_settings();
             }
         }
     }
@@ -941,9 +936,7 @@ bool Instance::Impl::pre_receive_() {
     ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
 
     try {
-        auto cache_saved_until = communicator_->pre_receive_f_init();
-        f_init_cache_ = std::get<0>(cache_saved_until);
-        trigger_manager_->harmonise_wall_time(std::get<1>(cache_saved_until));
+        f_init_cache_ = communicator_->pre_receive_f_init();
     } catch (PortClosed &err) {
         profiler_->record_event(std::move(sw_event));
         return false;

--- a/src/cpp/libmuscle/instance.cpp
+++ b/src/cpp/libmuscle/instance.cpp
@@ -156,10 +156,8 @@ class Instance::Impl {
                 std::string const & port_name, Optional<int> slot,
                 bool is_send, bool allow_slot_out_of_range = false);
 
-        bool receive_settings_();
+        void handle_receive_settings_();
         bool pre_receive_();
-        void pre_receive_(std::string const & port_name, Optional<int> slot);
-        void pre_receive_f_init_();
         Optional<double> f_init_max_timestamp_();
         bool decide_reuse_instance_();
         void save_snapshot_(
@@ -911,16 +909,11 @@ void Instance::Impl::check_port_(
     }
 }
 
-/* Receives settings on muscle_settings_in.
- *
- * @return false iff the port is connected and ClosePort was received.
- */
-bool Instance::Impl::receive_settings_() {
-    auto msg_saved_until = communicator_->receive_message("muscle_settings_in");
-    auto & msg = std::get<0>(msg_saved_until);
-
-    if (is_close_port(msg.data()))
-        return false;
+/* Handle received settings on pre-received muscle_settings_in. */
+void Instance::Impl::handle_receive_settings_() {
+    Reference port_ref("muscle_settings_in");
+    auto msg = f_init_cache_.at(port_ref);
+    f_init_cache_.erase(port_ref);
 
     if (!msg.data().is_a<Settings>()) {
         std::ostringstream oss;
@@ -936,8 +929,6 @@ bool Instance::Impl::receive_settings_() {
     for (auto const & key_val : msg.data().as<Settings>())
         settings[key_val.first] = key_val.second;
     settings_manager_.overlay = settings;
-
-    return true;
 }
 
 /** Pre-receives on all ports.
@@ -949,74 +940,34 @@ bool Instance::Impl::receive_settings_() {
 bool Instance::Impl::pre_receive_() {
     ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
 
-    bool all_ports_open = true;
-    if (!port_manager_->settings_in_connected())
-        settings_manager_.overlay = Settings();
-    else
-        all_ports_open = receive_settings_();
-
-    pre_receive_f_init_();
-    for (auto const & ref_msg : f_init_cache_)
-        if (is_close_port(ref_msg.second.data()))
-                all_ports_open = false;
-
-    if (!all_ports_open)
+    try {
+        auto cache_saved_until = communicator_->pre_receive_f_init();
+        f_init_cache_ = std::get<0>(cache_saved_until);
+        trigger_manager_->harmonise_wall_time(std::get<1>(cache_saved_until));
+    } catch (PortClosed &err) {
         profiler_->record_event(std::move(sw_event));
+        return false;
+    } catch (std::runtime_error &err) {
+        shutdown_(err.what());
+        throw;
+    }
 
-    return all_ports_open;
-}
-
-/* Pre-receive on the given port and slot, if any.
- *
- * Helper for pre_receive_f_init() below.
- */
-void Instance::Impl::pre_receive_(
-        std::string const & port_name, Optional<int> slot) {
-    Reference port_ref(port_name);
-    if (slot.is_set())
-        port_ref += slot.get();
-
-    auto msg_saved_until = communicator_->receive_message(port_name, slot);
-
-    auto & msg = std::get<0>(msg_saved_until);
+    // Handle received settings
+    if (port_manager_->settings_in_connected())
+        handle_receive_settings_();
+    else
+        settings_manager_.overlay = Settings();
+    // Overlay settings from received messages
     bool apply_overlay = !(flags_ & InstanceFlags::DONT_APPLY_OVERLAY);
     if (apply_overlay) {
-        apply_overlay_(msg);
-        if (msg.has_settings())
-            check_compatibility_(port_name, msg.settings());
-        msg.unset_settings();
-    }
-    f_init_cache_.emplace(port_ref, msg);
-
-    auto & saved_until = std::get<1>(msg_saved_until);
-    trigger_manager_->harmonise_wall_time(saved_until);
-}
-
-/* Receives on all ports connected to F_INIT.
- *
- * This receives all incoming messages on F_INIT and stores them in
- * f_init_cache_.
- */
-void Instance::Impl::pre_receive_f_init_() {
-    f_init_cache_.clear();
-    auto ports = port_manager_->list_ports();
-    if (ports.count(Operator::F_INIT) == 1) {
-        for (auto const & port_name : ports.at(Operator::F_INIT)) {
-            log_debug("Pre-receiving on port ", port_name);
-            auto const & port = port_manager_->get_port(port_name);
-            if (!port.is_connected())
-                continue;
-            if (!port.is_vector())
-                pre_receive_(port_name, {});
-            else {
-                pre_receive_(port_name, 0);
-                // The above receives the length, if needed, so now we can get
-                // the rest.
-                for (int slot = 1; slot < port.get_length(); ++slot)
-                    pre_receive_(port_name, slot);
-            }
+        for (auto &item : f_init_cache_) {
+            apply_overlay_(item.second);
+            if (item.second.has_settings())
+                check_compatibility_(std::string(item.first), item.second.settings());
+            item.second.unset_settings();
         }
     }
+    return true;
 }
 
 /** Return max timestamp of pre-received F_INIT messages

--- a/src/cpp/libmuscle/mpp_message.cpp
+++ b/src/cpp/libmuscle/mpp_message.cpp
@@ -17,7 +17,7 @@ MPPMessage::MPPMessage(
             Optional<int> port_length,
             double timestamp, Optional<double> next_timestamp,
             DataConstRef const & settings_overlay,
-            int message_number, double saved_until,
+            int message_number,
             DataConstRef const & data,
             Optional<IterationCount> const & iteration
             )
@@ -28,7 +28,6 @@ MPPMessage::MPPMessage(
         , next_timestamp(next_timestamp)
         , settings_overlay(settings_overlay)
         , message_number(message_number)
-        , saved_until(saved_until)
         , data(data)
         , iteration(iteration)
     {}
@@ -84,7 +83,6 @@ MPPMessage MPPMessage::from_dict_(DataConstRef const & dict) {
             next_timestamp,
             dict["settings_overlay"],
             dict["message_number"].as<int>(),
-            dict["saved_until"].as<double>(),
             dict["data"],
             decode_iteration(dict["iteration"]));
 }
@@ -106,7 +104,6 @@ DataConstRef MPPMessage::as_dict_() const {
             "next_timestamp", next_timestamp_data,
             "settings_overlay", settings_overlay,
             "message_number", message_number,
-            "saved_until", saved_until,
             "data", data,
             "iteration", encode_iteration(iteration)
             );

--- a/src/cpp/libmuscle/mpp_message.hpp
+++ b/src/cpp/libmuscle/mpp_message.hpp
@@ -38,7 +38,7 @@ class MPPMessage {
                 Optional<int> port_length,
                 double timestamp, Optional<double> next_timestamp,
                 DataConstRef const & settings_overlay, int message_number,
-                double saved_until, DataConstRef const & data,
+                DataConstRef const & data,
                 Optional<IterationCount> const & iteration = {});
 
         /** Create an MCP Message from an encoded buffer.
@@ -68,7 +68,6 @@ class MPPMessage {
         Optional<double> next_timestamp;
         DataConstRef settings_overlay;
         int message_number;
-        double saved_until;
         DataConstRef data;
         Optional<IterationCount> iteration;
 

--- a/src/cpp/libmuscle/peer_info.cpp
+++ b/src/cpp/libmuscle/peer_info.cpp
@@ -102,24 +102,27 @@ std::vector<std::string> PeerInfo::get_peer_locations(
 
 std::vector<Endpoint> PeerInfo::get_peer_endpoints(
         Identifier const & port,
-        std::vector<int> const & slot
+        Optional<int> const & slot
         ) const
 {
     auto peers = peers_.at(kernel_ + port);
     std::vector<Endpoint> endpoints;
+    
+    std::vector<int> total_index = index_;
+    if (slot.is_set())
+        total_index.push_back(slot.get());
 
     for (auto peer : peers) {
         Reference peer_kernel(peer.cbegin(), std::prev(peer.cend()));
         Identifier peer_port = std::prev(peer.cend())->identifier();
 
-        std::vector<int> total_index = index_;
-        total_index.insert(total_index.end(), slot.cbegin(), slot.cend());
-
         // rebalance the indices
         int peer_dim = peer_dims_.at(peer_kernel).size();
         auto peer_dim_it = std::next(total_index.cbegin(), peer_dim);
         std::vector<int> peer_index(total_index.cbegin(), peer_dim_it);
-        std::vector<int> peer_slot(peer_dim_it, total_index.cend());
+        Optional<int> peer_slot;
+        if (peer_dim_it != total_index.cend())
+            peer_slot = *peer_dim_it;
         endpoints.emplace_back(peer_kernel, peer_index, peer_port, peer_slot);
     }
 

--- a/src/cpp/libmuscle/peer_info.hpp
+++ b/src/cpp/libmuscle/peer_info.hpp
@@ -112,7 +112,7 @@ class PeerInfo {
          */
         std::vector<Endpoint> get_peer_endpoints(
                 ymmsl::Identifier const & port,
-                std::vector<int> const & slot) const;
+                Optional<int> const & slot) const;
 
         /** Checks peer dimensions are as expected.
          * 

--- a/src/cpp/libmuscle/port_manager.cpp
+++ b/src/cpp/libmuscle/port_manager.cpp
@@ -61,6 +61,8 @@ PortManager::PortReferences PortManager::get_connected_ports(
             continue;
         result.push_back(port.second);
     }
+    if (oper == Operator::F_INIT && settings_in_connected())
+        result.push_back(muscle_settings_in());
     return result;
 }
 

--- a/src/cpp/libmuscle/port_manager.hpp
+++ b/src/cpp/libmuscle/port_manager.hpp
@@ -68,7 +68,8 @@ class PortManager {
          */
         bool has_f_init_connections() const;
 
-        /** Returns the connected ports for the given operator.
+        /** Returns the connected ports for the given operator. This includes
+         * muscle_settings_in for F_INIT.
          *
          * @param oper The operator to select ports for.
          * @param timeline If set, only return ports on this timeline.

--- a/src/cpp/libmuscle/snapshot.cpp
+++ b/src/cpp/libmuscle/snapshot.cpp
@@ -101,7 +101,6 @@ std::vector<char> Snapshot::to_bytes() const {
                 msg.has_next_timestamp() ? msg.next_timestamp() : Optional<double>(),
                 msg.has_settings() ? msg.settings() : Data(),
                 0,
-                -1.0,
                 msg.data());
 
         DataConstRef dict = DataConstRef::dict(

--- a/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
@@ -91,10 +91,15 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 
 using PortsDescription = std::unordered_map<ymmsl::Operator, std::vector<std::string>>;
 
+class PortClosed : public std::runtime_error {
+    public:
+        PortClosed() : std::runtime_error("Port closed") {};
+};
 
 class MockCommunicator : public MockClass<MockCommunicator> {
     public:
         using PortMessageCounts = std::unordered_map<std::string, std::vector<int>>;
+        using FInitCacheType = std::unordered_map<::ymmsl::Reference, Message>;
 
         MockCommunicator(ReturnValue) {
             NAME_MOCK_MEM_FUN(MockCommunicator, constructor);
@@ -139,6 +144,10 @@ class MockCommunicator : public MockClass<MockCommunicator> {
             Val<PeerLocations const &>> connect;
 
         ::mock_communicator::CommunicatorSendMessageMock send_message;
+
+        MockFun<Val<
+            std::tuple<std::unordered_map<::ymmsl::Reference, Message>, double>
+            >> pre_receive_f_init;
 
         ::mock_communicator::CommunicatorReceiveMessageMock receive_message;
 

--- a/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
@@ -41,12 +41,12 @@ struct CommunicatorSendMessageMock : CommunicatorSendMessageBase {
 
 
 using CommunicatorReceiveMessageBase = MockFun<
-    Val<std::tuple<Message, double>>, Val<std::string const &>,
+    Val<Message>, Val<std::string const &>,
     Val<Optional<int>>,
     Val<Optional<Message>>>;
 
 struct CommunicatorReceiveMessageMock : CommunicatorReceiveMessageBase {
-    std::tuple<Message, double> operator()(
+    Message operator()(
             std::string const & port_name,
             Optional<int> slot = {},
             Optional<Message> const & default_msg = {})
@@ -145,9 +145,7 @@ class MockCommunicator : public MockClass<MockCommunicator> {
 
         ::mock_communicator::CommunicatorSendMessageMock send_message;
 
-        MockFun<Val<
-            std::tuple<std::unordered_map<::ymmsl::Reference, Message>, double>
-            >> pre_receive_f_init;
+        MockFun<Val<FInitCacheType>> pre_receive_f_init;
 
         ::mock_communicator::CommunicatorReceiveMessageMock receive_message;
 

--- a/src/cpp/libmuscle/tests/tcp_transport_server_test.cpp
+++ b/src/cpp/libmuscle/tests/tcp_transport_server_test.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
             "test_sender.port", receiver, 10,
             0.0, 1.0,
             overlay_settings,
-            0, 6.0,
+            0,
             data_dict);
     post_office.deposit(receiver, std::move(msg.encoded()));
 

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -142,7 +142,7 @@ TEST_F(libmuscle_communicator2, send_message) {
         IterationCount({2, 0});
     Message msg(0.0, 1.0, "test", Settings({{"s0", 0}, {"s1", "1"}}));
 
-    connected_communicator_.send_message("out_v", msg, 7, -1.0);
+    connected_communicator_.send_message("out_v", msg, 7);
 
     auto & server = communicator_.server_;
     ASSERT_EQ(server.deposit.call_arg<0>(), "peer2[7].in");
@@ -156,7 +156,6 @@ TEST_F(libmuscle_communicator2, send_message) {
     auto overlay = encoded_msg.settings_overlay.as<Settings>();
     ASSERT_EQ(overlay["s0"].as<int64_t>(), 0);
     ASSERT_EQ(overlay["s1"].as<std::string>(), "1");
-    ASSERT_EQ(encoded_msg.saved_until, -1.0);
     ASSERT_EQ(encoded_msg.data.as<std::string>(), "test");
     ASSERT_TRUE(encoded_msg.iteration.is_set());
     ASSERT_EQ(encoded_msg.iteration.get(), IterationCount({2, 0}));
@@ -173,15 +172,13 @@ TEST_F(libmuscle_communicator2, send_message_disconnected) {
 TEST_F(libmuscle_communicator2, receive_message) {
     MPPMessage msg(
             "peer.out", "component.in", {}, 2.0, 3.0,
-            Settings({{"s0", "0"}, {"s1", true}}), 0, 1.0, "Testing",
+            Settings({{"s0", "0"}, {"s1", true}}), 0, "Testing",
             IterationCount({0}));
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
             msg.encoded(), ProfileData());
 
-    auto recv_msg_saved_until = connected_communicator_.receive_message("in");
-    auto const & recv_msg = std::get<0>(recv_msg_saved_until);
-    double saved_until = std::get<1>(recv_msg_saved_until);
+    auto recv_msg = connected_communicator_.receive_message("in");
 
     auto & mpp_client = connected_communicator_.clients_.at("peer");
     ASSERT_TRUE(mpp_client->receive.called_with("component.in", nullptr));
@@ -191,21 +188,18 @@ TEST_F(libmuscle_communicator2, receive_message) {
     ASSERT_EQ(recv_msg.data().as<std::string>(), "Testing");
     ASSERT_EQ(recv_msg.settings().at("s0"), "0");
     ASSERT_TRUE(recv_msg.settings().at("s1").as<bool>());
-    ASSERT_EQ(saved_until, 1.0);
 }
 
 TEST_F(libmuscle_communicator2, receive_message_vector) {
     MPPMessage msg(
             "peer2.out_v", "component.in_v", 5, 4.0, 6.0,
-            Settings({{"s0", {0.0}}, {"s1", 1.0}}), 0, 3.5, "Testing2",
+            Settings({{"s0", {0.0}}, {"s1", 1.0}}), 0, "Testing2",
             IterationCount({0}));
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
             msg.encoded(), ProfileData());
 
-    auto recv_msg_saved_until = connected_communicator_.receive_message("in_v", 5);
-    auto const & recv_msg = std::get<0>(recv_msg_saved_until);
-    double saved_until = std::get<1>(recv_msg_saved_until);
+    auto recv_msg = connected_communicator_.receive_message("in_v", 5);
 
     auto mpp_client = connected_communicator_.clients_.at("peer2[5]").get();
     ASSERT_TRUE(mpp_client->receive.called_with("component.in_v[5]", nullptr));
@@ -215,13 +209,12 @@ TEST_F(libmuscle_communicator2, receive_message_vector) {
     ASSERT_EQ(recv_msg.data().as<std::string>(), "Testing2");
     ASSERT_EQ(recv_msg.settings().at("s0"), std::vector<double>{0.0});
     ASSERT_EQ(recv_msg.settings().at("s1"), 1.0);
-    ASSERT_EQ(saved_until, 3.5);
 }
 
 TEST_F(libmuscle_communicator2, receive_close_port) {
     MPPMessage msg(
             "peer.out", "component.in", {}, std::numeric_limits<double>::infinity(), {},
-            Settings(), 0, 0.1, ClosePort());
+            Settings(), 0, ClosePort());
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
             msg.encoded(), ProfileData());
@@ -238,7 +231,7 @@ TEST_F(libmuscle_communicator2, receive_close_port) {
 TEST_F(libmuscle_communicator2, receive_close_port_vector) {
     MPPMessage msg(
             "peer2.out_v", "component.in_v", 5, std::numeric_limits<double>::infinity(),
-            {}, Settings(), 0, 3.5, ClosePort());
+            {}, Settings(), 0, ClosePort());
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
             msg.encoded(), ProfileData());
@@ -251,7 +244,7 @@ TEST_F(libmuscle_communicator2, receive_close_port_vector) {
 TEST_F(libmuscle_communicator2, port_count_validation) {
     MPPMessage msg(
             "peer.out", "component.in",
-            {}, 0.0, {}, Settings({{"test1", 12}}), 0, 7.6, "test",
+            {}, 0.0, {}, Settings({{"test1", 12}}), 0, "test",
             IterationCount({0}));
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
@@ -270,7 +263,7 @@ TEST_F(libmuscle_communicator2, port_count_validation) {
 TEST_F(libmuscle_communicator2, port_discard_error_on_resume) {
     MPPMessage msg(
             "other.out[13]", "kernel[13].in",
-            {}, 0.0, {}, Settings({{"test1", 12}}), 1, 2.3, "test",
+            {}, 0.0, {}, Settings({{"test1", 12}}), 1, "test",
             IterationCount({0}));
 
     MockMPPClient::return_value.receive.return_value = std::make_tuple(
@@ -308,7 +301,7 @@ TEST_F(libmuscle_communicator2, port_discard_success_on_resume) {
     for (int message_number : {1, 2}) {
         side_effect.push_back(MPPMessage(
                 "other.out[13]", "kernel[13].in",
-                {}, 0.0, {}, Settings({{"test1", 12}}), message_number, 1.0,
+                {}, 0.0, {}, Settings({{"test1", 12}}), message_number,
                 Data::dict("this is message", message_number),
                 IterationCount({0})));
     }
@@ -330,8 +323,7 @@ TEST_F(libmuscle_communicator2, port_discard_success_on_resume) {
         ASSERT_TRUE(connected_port_manager_.get_port(port).is_resuming());
     }
 
-    auto recv_msg_saved_until = connected_communicator_.receive_message("in");
-    auto const & recv_msg = std::get<0>(recv_msg_saved_until);
+    auto recv_msg = connected_communicator_.receive_message("in");
 
     bool message_logged = false;
     for (auto const & log_args : MockLogger::instance().caplog.call_args_list) {
@@ -356,7 +348,7 @@ TEST_F(libmuscle_communicator2, test_shutdown) {
     messages["component.in"] = std::make_unique<MPPMessage>(
             "peer.out", "component.in", Optional<int>(),
             std::numeric_limits<double>::infinity(), Optional<double>(), Settings(),
-            0, 0.0, ClosePort());
+            0, ClosePort());
 
     std::vector<std::tuple<std::string, std::string, std::string>> port_sender({
             {"in_v", "peer2[", "].out_v"},
@@ -373,7 +365,7 @@ TEST_F(libmuscle_communicator2, test_shutdown) {
             Reference receiver("component." + port_name + "[" + std::to_string(slot) + "]");
             messages[receiver] = std::make_unique<MPPMessage>(
                     sender, receiver, slot, std::numeric_limits<double>::infinity(),
-                    Optional<double>(), Settings(), 0, 3.5,
+                    Optional<double>(), Settings(), 0,
                     ClosePort());
         }
     }

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -231,6 +231,10 @@ TEST_F(libmuscle_communicator2, receive_close_port) {
     ASSERT_FALSE(mock_ports_.at("in")->is_open());
 }
 
+// Testing pre_receive_f_init is too difficult to set up correctly without the ability
+// to mock Communicator::receive_message (like the Python tests can)
+// TODO: review after implementing conduit filters.
+
 TEST_F(libmuscle_communicator2, receive_close_port_vector) {
     MPPMessage msg(
             "peer2.out_v", "component.in_v", 5, std::numeric_limits<double>::infinity(),

--- a/src/cpp/libmuscle/tests/test_instance.cpp
+++ b/src/cpp/libmuscle/tests/test_instance.cpp
@@ -413,7 +413,7 @@ TEST_F(libmuscle_instance, reuse_set_overlay) {
     Message mock_msg(
             0.0, {}, Settings({{"s1", 1}, {"s2", 2}}), Settings({{"s0", 0}}));
     MockCommunicator::FInitCacheType cache = {{"muscle_settings_in", mock_msg}};
-    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
+    communicator_.pre_receive_f_init.return_value = cache;
 
     instance_.reuse_instance();
 
@@ -424,7 +424,7 @@ TEST_F(libmuscle_instance, reuse_set_overlay) {
 
 TEST_F(libmuscle_instance, reuse_closed_port) {
     communicator_.pre_receive_f_init.side_effect = [](
-        ) -> std::tuple<MockCommunicator::FInitCacheType, double> {
+        ) -> MockCommunicator::FInitCacheType {
             throw PortClosed();
         };
     ASSERT_FALSE(instance_.reuse_instance());
@@ -489,7 +489,7 @@ TEST_F(libmuscle_instance, receive_on_sending_port) {
 TEST_F(libmuscle_instance, receive_f_init) {
     Message mock_msg(0.0, Settings());
     MockCommunicator::FInitCacheType cache = {{"in", mock_msg}};
-    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
+    communicator_.pre_receive_f_init.return_value = cache;
 
     instance_.reuse_instance();
 
@@ -523,7 +523,7 @@ TEST_F(libmuscle_instance, receive_inconsistent_settings) {
     MockCommunicator::FInitCacheType cache = {
         {"muscle_settings_in", Message(0.0, Settings({{"s1", 1}}), Settings())},
         {"in", Message(0.0, DataConstRef(), Settings({{"s0", 0}}))}};
-    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
+    communicator_.pre_receive_f_init.return_value = cache;
     port_manager_.settings_in_connected.return_value = true;
 
     ASSERT_THROW(instance_.reuse_instance(), std::logic_error);
@@ -533,7 +533,7 @@ TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings) {
     Message mock_msg(0.0);
     mock_msg.settings_ = Settings({{"s0", 0}, {"s1", 1}});
     MockCommunicator::FInitCacheType cache = {{"in", mock_msg}};
-    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
+    communicator_.pre_receive_f_init.return_value = cache;
 
     instance_dont_apply_overlay_.reuse_instance();
     auto msg = instance_dont_apply_overlay_.receive("in");
@@ -546,7 +546,7 @@ TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings) {
 
 TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings_default) {
     port_manager_.get_port("in").is_connected_ = false;
-    communicator_.pre_receive_f_init.return_value = std::make_tuple(MockCommunicator::FInitCacheType(), 0.0);
+    communicator_.pre_receive_f_init.return_value = MockCommunicator::FInitCacheType();
 
     instance_dont_apply_overlay_.reuse_instance();
 

--- a/src/cpp/libmuscle/tests/test_instance.cpp
+++ b/src/cpp/libmuscle/tests/test_instance.cpp
@@ -62,6 +62,7 @@ using libmuscle::_MUSCLE_IMPL_NS::MockTriggerManager;
 using libmuscle::_MUSCLE_IMPL_NS::Optional;
 using libmuscle::_MUSCLE_IMPL_NS::PeerInfo;
 using libmuscle::_MUSCLE_IMPL_NS::Port;
+using libmuscle::_MUSCLE_IMPL_NS::PortClosed;
 using libmuscle::_MUSCLE_IMPL_NS::PortsDescription;
 
 using ymmsl::Operator;
@@ -411,49 +412,25 @@ TEST_F(libmuscle_instance, reuse_set_overlay) {
 
     Message mock_msg(
             0.0, {}, Settings({{"s1", 1}, {"s2", 2}}), Settings({{"s0", 0}}));
-    communicator_.receive_message.return_value = std::make_tuple(mock_msg, 0.0);
+    MockCommunicator::FInitCacheType cache = {{"muscle_settings_in", mock_msg}};
+    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
 
     instance_.reuse_instance();
 
-    ASSERT_TRUE(communicator_.receive_message.called_with("muscle_settings_in"));
     ASSERT_EQ(settings_manager_.overlay["s0"], 0);
     ASSERT_EQ(settings_manager_.overlay["s1"], 1);
     ASSERT_EQ(settings_manager_.overlay["s2"], 2);
 }
 
 TEST_F(libmuscle_instance, reuse_closed_port) {
-    for (auto const & closed_port : {"muscle_settings_in", "in"}) {
-        port_manager_.settings_in_connected.return_value = true;
-        communicator_.receive_message.side_effect = [&closed_port](
-                std::string const & port_name, Optional<int> slot = {},
-                Optional<Message> const & default_msg = {}) -> std::tuple<Message, double>
-            {
-                if (port_name == closed_port)
-                    return std::make_tuple(Message(0.0, ClosePort(), Settings()), 0.0);
-                else
-                    return std::make_tuple(Message(0.0, Settings(), Settings()), 0.0);
-            };
-
-        ASSERT_FALSE(instance_.reuse_instance());
-    }
-}
-
-TEST_F(libmuscle_instance, reuse_f_init_vector_port) {
-    port_manager_.get_port("in").length_ = 10;
-
-    communicator_.receive_message.side_effect = [](
-            std::string const & port_name, Optional<int> slot = {},
-            Optional<Message> const & default_msg = {}) -> std::tuple<Message, double>
-        {
-            Message mock_msg(0.0, Settings());
-            return std::make_tuple(mock_msg, 0.0);
+    communicator_.pre_receive_f_init.side_effect = [](
+        ) -> std::tuple<MockCommunicator::FInitCacheType, double> {
+            throw PortClosed();
         };
-
-    ASSERT_TRUE(instance_.reuse_instance());
+    ASSERT_FALSE(instance_.reuse_instance());
 }
 
 TEST_F(libmuscle_instance, reuse_no_f_init_ports) {
-    port_manager_.list_ports.return_value = PortsDescription();
     port_manager_.has_f_init_connections.return_value = false;
 
     ASSERT_TRUE(instance_.reuse_instance());
@@ -511,7 +488,8 @@ TEST_F(libmuscle_instance, receive_on_sending_port) {
 
 TEST_F(libmuscle_instance, receive_f_init) {
     Message mock_msg(0.0, Settings());
-    communicator_.receive_message.return_value = std::make_tuple(mock_msg, 0.0);
+    MockCommunicator::FInitCacheType cache = {{"in", mock_msg}};
+    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
 
     instance_.reuse_instance();
 
@@ -542,19 +520,10 @@ TEST_F(libmuscle_instance, receive_no_default) {
 }
 
 TEST_F(libmuscle_instance, receive_inconsistent_settings) {
-    communicator_.receive_message.side_effect = [](
-            std::string const & port_name, Optional<int> const & slot,
-            Optional<Message> const & default_msg)
-        {
-            if (port_name == "muscle_settings_in")
-                return std::make_tuple(
-                        Message(0.0, Settings({{"s1", 1}}), Settings()),
-                        0.0);
-            return std::make_tuple(
-                    Message(0.0, DataConstRef(), Settings({{"s0", 0}})),
-                    0.0);
-        };
-
+    MockCommunicator::FInitCacheType cache = {
+        {"muscle_settings_in", Message(0.0, Settings({{"s1", 1}}), Settings())},
+        {"in", Message(0.0, DataConstRef(), Settings({{"s0", 0}}))}};
+    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
     port_manager_.settings_in_connected.return_value = true;
 
     ASSERT_THROW(instance_.reuse_instance(), std::logic_error);
@@ -563,7 +532,8 @@ TEST_F(libmuscle_instance, receive_inconsistent_settings) {
 TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings) {
     Message mock_msg(0.0);
     mock_msg.settings_ = Settings({{"s0", 0}, {"s1", 1}});
-    communicator_.receive_message.return_value = std::make_tuple(mock_msg, 0.0);
+    MockCommunicator::FInitCacheType cache = {{"in", mock_msg}};
+    communicator_.pre_receive_f_init.return_value = std::make_tuple(cache, 0.0);
 
     instance_dont_apply_overlay_.reuse_instance();
     auto msg = instance_dont_apply_overlay_.receive("in");
@@ -576,6 +546,7 @@ TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings) {
 
 TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings_default) {
     port_manager_.get_port("in").is_connected_ = false;
+    communicator_.pre_receive_f_init.return_value = std::make_tuple(MockCommunicator::FInitCacheType(), 0.0);
 
     instance_dont_apply_overlay_.reuse_instance();
 

--- a/src/cpp/libmuscle/tests/test_mpp_message.cpp
+++ b/src/cpp/libmuscle/tests/test_mpp_message.cpp
@@ -31,7 +31,7 @@ TEST(test_mcp_message, create_mcp_message) {
             Reference("sender.port"), Reference("receiver.port"),
             10,
             100.1, 101.0,
-            test, 0, 1.0, abc
+            test, 0, abc
             );
 
     ASSERT_EQ(m.sender, "sender.port");
@@ -41,7 +41,6 @@ TEST(test_mcp_message, create_mcp_message) {
     ASSERT_EQ(m.next_timestamp, 101.0);
     ASSERT_EQ(m.settings_overlay.as<std::string>(), "test");
     ASSERT_EQ(m.message_number, 0);
-    ASSERT_EQ(m.saved_until, 1.0);
     ASSERT_EQ(m.data.as<std::string>(), "abc");
 }
 
@@ -52,7 +51,7 @@ TEST(test_mcp_message, create_mcp_message_minimal) {
             Reference("sender.port"), Reference("receiver.port"),
             {},
             100.1, {},
-            test, 0, 2.0, abc
+            test, 0, abc
             );
 
     ASSERT_EQ(m.sender, "sender.port");
@@ -62,7 +61,6 @@ TEST(test_mcp_message, create_mcp_message_minimal) {
     ASSERT_FALSE(m.next_timestamp.is_set());
     ASSERT_TRUE(m.settings_overlay.is_nil());
     ASSERT_EQ(m.message_number, 0);
-    ASSERT_EQ(m.saved_until, 2.0);
     ASSERT_TRUE(m.data.is_nil());
 }
 
@@ -75,7 +73,6 @@ TEST(test_mcp_message, from_bytes) {
             "next_timestamp", Data(),
             "settings_overlay", Data(),
             "message_number", 0,
-            "saved_until", 3.0,
             "data", Data(),
             "iteration", Data()
             );
@@ -94,7 +91,6 @@ TEST(test_mcp_message, from_bytes) {
     ASSERT_FALSE(m.next_timestamp.is_set());
     ASSERT_TRUE(m.settings_overlay.is_nil());
     ASSERT_EQ(m.message_number, 0);
-    ASSERT_EQ(m.saved_until, 3.0);
     ASSERT_TRUE(m.data.is_nil());
 }
 
@@ -105,7 +101,7 @@ TEST(test_mcp_message, iteration_roundtrip) {
             Reference("sender.port"), Reference("receiver.port"),
             {},
             0.0, {},
-            settings, 0, 0.0, data,
+            settings, 0, data,
             IterationCount({0, 2})
             );
 

--- a/src/cpp/libmuscle/tests/test_outbox.cpp
+++ b/src/cpp/libmuscle/tests/test_outbox.cpp
@@ -37,7 +37,7 @@ TEST(libmuscle_outbox, test_deposit_retrieve_message) {
             Optional<int>(),
             0.0, 1.0,
             DataConstRef(),
-            0, 1.0,
+            0,
             DataConstRef("testing"));
 
     auto message_data = message.encoded();

--- a/src/cpp/libmuscle/tests/test_peer_info.cpp
+++ b/src/cpp/libmuscle/tests/test_peer_info.cpp
@@ -137,12 +137,12 @@ TEST(libmuscle_peer_info, get_peer_endpoint) {
     ASSERT_EQ(std::string(pi.get_peer_endpoints("in", {})[0]), "other.out[13]");
 
     auto pi2 = peer_info2();
-    ASSERT_EQ(std::string(pi2.get_peer_endpoints("out", {11})[0]), "kernel[11].in");
-    ASSERT_EQ(std::string(pi2.get_peer_endpoints("in", {11})[0]), "kernel[11].out");
+    ASSERT_EQ(std::string(pi2.get_peer_endpoints("out", 11)[0]), "kernel[11].in");
+    ASSERT_EQ(std::string(pi2.get_peer_endpoints("in", 11)[0]), "kernel[11].out");
 
     auto pi3 = peer_info3();
-    ASSERT_EQ(std::string(pi3.get_peer_endpoints("out", {42})[0]), "other.in[42]");
-    ASSERT_EQ(std::string(pi3.get_peer_endpoints("in", {42})[0]), "other.out[42]");
+    ASSERT_EQ(std::string(pi3.get_peer_endpoints("out", 42)[0]), "other.in[42]");
+    ASSERT_EQ(std::string(pi3.get_peer_endpoints("in", 42)[0]), "other.out[42]");
 }
 
 

--- a/src/cpp/libmuscle/tests/test_post_office.cpp
+++ b/src/cpp/libmuscle/tests/test_post_office.cpp
@@ -34,7 +34,7 @@ std::vector<char> make_message() {
             "test_sender.port", "test_receiver.port",
             Optional<int>(),
             0.0, 1.0,
-            DataConstRef(), 0, 5.0, DataConstRef());
+            DataConstRef(), 0, DataConstRef());
     return msg.encoded();
 }
 

--- a/src/cpp/libmuscle/tests/test_tcp_communication.cpp
+++ b/src/cpp/libmuscle/tests/test_tcp_communication.cpp
@@ -40,7 +40,7 @@ TEST(test_tcp_communication, send_receive) {
     MPPMessage msg(
             "test_sender.port", receiver, 10,
             0.0, 1.0,
-            Data::dict("par1", 13), 1, 4.0,
+            Data::dict("par1", 13), 1,
             Data::dict("var1", 1, "var2", 2.0, "var3", "3"));
     post_office.deposit(receiver, msg.encoded());
 
@@ -57,7 +57,6 @@ TEST(test_tcp_communication, send_receive) {
     ASSERT_EQ(m.next_timestamp, 1.0);
     ASSERT_EQ(m.settings_overlay["par1"].as<int>(), 13);
     ASSERT_EQ(m.message_number, 1);
-    ASSERT_EQ(m.saved_until, 4.0);
     ASSERT_EQ(m.data["var1"].as<int>(), 1);
     ASSERT_EQ(m.data["var2"].as<double>(), 2.0);
     ASSERT_EQ(m.data["var3"].as<std::string>(), "3");

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -389,16 +389,11 @@ void SubTimelineManager::missing_actions(ExpectedActions & result) const {
 
 TimelineManager::TimelineManager(PortManager const & port_manager)
     : port_manager_(port_manager)
-    , receive_({})
+    , receive_(port_manager.get_connected_ports(Operator::F_INIT, Optional<Timeline>()))
     , send_(port_manager.get_connected_ports(Operator::O_F, Optional<Timeline>()))
     , submanagers_()
     , iteration_()
 {
-    auto receive_ports = port_manager_.get_connected_ports(Operator::F_INIT, Optional<Timeline>());
-    if (port_manager_.settings_in_connected())
-        receive_ports.push_back(port_manager_.get_port("muscle_settings_in"));
-    receive_ = TimelinePorts(receive_ports);
-
     for (auto const & tl : port_manager_.list_subtimelines())
         submanagers_.emplace(tl, SubTimelineManager(tl, port_manager_));
 

--- a/src/python/libmuscle/checkpoint_triggers.py
+++ b/src/python/libmuscle/checkpoint_triggers.py
@@ -190,19 +190,6 @@ class TriggerManager:
         """Returns elapsed wallclock_time in seconds."""
         return time.monotonic() + self._mono_to_elapsed
 
-    def checkpoints_considered_until(self) -> float:
-        """Return elapsed time of last should_save*"""
-        return self._cpts_considered_until
-
-    def harmonise_wall_time(self, at_least: float) -> None:
-        """Ensure our elapsed time is at least the given value"""
-        cur = self.elapsed_walltime()
-        if cur < at_least:
-            _logger.debug(
-                "Harmonise wall time: advancing clock by %f seconds", at_least - cur
-            )
-            self._mono_to_elapsed += at_least - cur
-
     def should_save_snapshot(self, timestamp: float) -> bool:
         """Handles instance.should_save_snapshot"""
         if not self._has_checkpoints:

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -249,7 +249,13 @@ class Communicator:
             self._profiler.record_event(profile_event)
 
     def pre_receive_f_init(self) -> tuple[FInitCacheType, float]:
-        """Receive on all connected F_INIT port (including muscle_settings_in)."""
+        """Receive on all connected F_INIT port (including muscle_settings_in).
+
+        Returns:
+            f_init_cache: The received messages.
+            max_saved_until: Maximum value of all saved_until metadata from the received
+                messages.
+        """
         cache: FInitCacheType = {}
         saved_until_list: list[float] = []
 
@@ -267,8 +273,7 @@ class Communicator:
                 pre_receive(port_name, None)
             else:
                 pre_receive(port_name, 0)
-                # The above receives the length, if needed, so now we can
-                # get the rest.
+                # The above receives the length, if needed, so now we can get the rest.
                 for slot in range(1, port.get_length()):
                     pre_receive(port_name, slot)
 

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -173,7 +173,6 @@ class Communicator:
         port_name: str,
         message: Message,
         slot: Optional[int] = None,
-        checkpoints_considered_until: float = float("-inf"),
     ) -> None:
         """Send a message and settings to the outside world.
 
@@ -184,8 +183,6 @@ class Communicator:
             port_name: The port on which this message is to be sent.
             message: The message to be sent.
             slot: The slot to send the message on, if any.
-            checkpoints_considered_until: When we last checked if we
-                should save a snapshot (wallclock time).
         """
         _logger.debug(f"Sending message on {port_desc(port_name, slot)}")
         slot_list: list[int] = [] if slot is None else [slot]
@@ -232,7 +229,6 @@ class Communicator:
                 message.next_timestamp,
                 cast(Settings, message.settings),
                 port.get_num_messages(slot),
-                checkpoints_considered_until,
                 message.data,
                 iteration,
             )
@@ -248,23 +244,19 @@ class Communicator:
         if not isinstance(message.data, ClosePort):
             self._profiler.record_event(profile_event)
 
-    def pre_receive_f_init(self) -> tuple[FInitCacheType, float]:
+    def pre_receive_f_init(self) -> FInitCacheType:
         """Receive on all connected F_INIT port (including muscle_settings_in).
 
         Returns:
             f_init_cache: The received messages.
-            max_saved_until: Maximum value of all saved_until metadata from the received
-                messages.
         """
         cache: FInitCacheType = {}
-        saved_until_list: list[float] = []
 
         def pre_receive(port_name: str, slot: Optional[int]) -> None:
-            msg, saved_until = self.receive_message(port_name, slot)
+            msg = self.receive_message(port_name, slot)
             if isinstance(msg.data, ClosePort):
                 raise PortClosed()
             cache[(port_name, slot)] = msg
-            saved_until_list.append(saved_until)
 
         for port in self._port_manager.get_connected_ports(Operator.F_INIT):
             port_name = str(port.name)
@@ -277,11 +269,9 @@ class Communicator:
                 for slot in range(1, port.get_length()):
                     pre_receive(port_name, slot)
 
-        return cache, max(saved_until_list)
+        return cache
 
-    def receive_message(
-        self, port_name: str, slot: Optional[int] = None
-    ) -> tuple[Message, float]:
+    def receive_message(self, port_name: str, slot: Optional[int] = None) -> Message:
         """Receive a message and attached settings overlay.
 
         Receiving is a blocking operation. This function will contact
@@ -300,8 +290,7 @@ class Communicator:
         Returns:
             The received message, with message.settings holding
             the settings overlay. The settings attribute is
-            guaranteed to not be None. Secondly, the saved_until
-            metadata field from the received message.
+            guaranteed to not be None.
 
         Raises:
             RuntimeError: If the network connection had an error, or the
@@ -456,7 +445,7 @@ class Communicator:
                 port_name, slot, mpp_message.iteration
             )
 
-        return message, mpp_message.saved_until
+        return message
 
     def shutdown(self) -> None:
         """Shuts down the Communicator, closing connections."""

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional, cast
 
-from ymmsl.v0_2 import Identifier, Operator, Reference, Settings
+from ymmsl.v0_2 import Operator, Reference, Settings
 
 from libmuscle.endpoint import Endpoint
 from libmuscle.mcp.tcp_util import SocketClosed
@@ -10,6 +10,7 @@ from libmuscle.mpp_client import MPPClient
 from libmuscle.mpp_message import ClosePort, MPPMessage
 from libmuscle.mpp_server import MPPServer
 from libmuscle.peer_info import PeerInfo
+from libmuscle.port import Port
 from libmuscle.port_manager import PortManager
 from libmuscle.profiler import Profiler
 from libmuscle.profiling import ProfileEvent, ProfileEventType, ProfileTimestamp
@@ -184,13 +185,13 @@ class Communicator:
             message: The message to be sent.
             slot: The slot to send the message on, if any.
         """
-        _logger.debug(f"Sending message on {port_desc(port_name, slot)}")
-        slot_list: list[int] = [] if slot is None else [slot]
-
-        snd_endpoint = self.__get_endpoint(port_name, slot_list)
-        if not self._port_manager.get_port(str(snd_endpoint.port)).is_connected():
-            # log sending on disconnected port
+        port = self._port_manager.get_port(port_name)
+        if not port.is_connected():
+            _logger.debug(
+                "Sending message on unconnected port %s", port_desc(port_name, slot)
+            )
             return
+        _logger.debug("Sending message on %s", port_desc(port_name, slot))
 
         # TODO: ClosePort will be replaced with milestones, and then we do need an
         # iteration count.
@@ -199,7 +200,6 @@ class Communicator:
         else:
             iteration = self._timeline_manager.check_send_message(port_name, slot)
 
-        port = self._port_manager.get_port(port_name)
         profile_event = ProfileEvent(
             ProfileEventType.SEND,
             ProfileTimestamp(),
@@ -212,14 +212,11 @@ class Communicator:
             message.timestamp,
         )
 
-        recv_endpoints = self._peer_info.get_peer_endpoints(
-            snd_endpoint.port, slot_list
-        )
-
         port_length = None
         if port.is_resizable():
             port_length = port.get_length()
 
+        snd_endpoint, recv_endpoints = self._get_endpoints(port, slot)
         for recv_endpoint in recv_endpoints:
             mpp_message = MPPMessage(
                 snd_endpoint.ref(),
@@ -233,6 +230,7 @@ class Communicator:
                 iteration,
             )
             encoded_message = mpp_message.encoded()
+            profile_event.message_size = len(memoryview(encoded_message))
             self._server.deposit(recv_endpoint.ref(), encoded_message)
 
         port.increment_num_messages(slot)
@@ -240,7 +238,6 @@ class Communicator:
         profile_event.stop()
         if port.is_vector():
             profile_event.port_length = port.get_length()
-        profile_event.message_size = len(memoryview(encoded_message))
         if not isinstance(message.data, ClosePort):
             self._profiler.record_event(profile_event)
 
@@ -296,14 +293,11 @@ class Communicator:
             RuntimeError: If the network connection had an error, or the
                     message number was incorrect.
         """
-        port = self._port_manager.get_port(port_name)
         self._timeline_manager.check_receive(port_name, slot)
 
+        port = self._port_manager.get_port(port_name)
         port_and_slot = port_desc(port_name, slot)
-        slot_list: list[int] = [] if slot is None else [slot]
-        _logger.debug(f"Waiting for message on {port_and_slot}")
-
-        recv_endpoint = self.__get_endpoint(port_name, slot_list)
+        _logger.debug("Waiting for message on %s", port_and_slot)
 
         receive_event = ProfileEvent(
             ProfileEventType.RECEIVE,
@@ -317,10 +311,8 @@ class Communicator:
 
         # peer_info already checks that there is at most one snd_endpoint
         # connected to the port we receive on
-        snd_endpoint = self._peer_info.get_peer_endpoints(
-            recv_endpoint.port, slot_list
-        )[0]
-        client = self.__get_client(snd_endpoint.instance())
+        recv_endpoint, (snd_endpoint,) = self._get_endpoints(port, slot)
+        client = self._get_client(snd_endpoint.instance())
         timeout_handler = None
         if self._receive_timeout >= 0:
             timeout_handler = ReceiveTimeoutHandler(
@@ -462,11 +454,7 @@ class Communicator:
         self._server.shutdown()
         self._profiler.record_event(shutdown_event)
 
-    def __instance_id(self) -> Reference:
-        """Returns our complete instance id."""
-        return self._kernel + self._index
-
-    def __get_client(self, instance: Reference) -> MPPClient:
+    def _get_client(self, instance: Reference) -> MPPClient:
         """Get or create a client to connect to the given instance.
 
         Args:
@@ -482,19 +470,14 @@ class Communicator:
 
         return self._clients[instance]
 
-    def __get_endpoint(self, port_name: str, slot: list[int]) -> Endpoint:
-        """Determines the endpoint on our side.
-
-        Args:
-            port_name: Name of the port to send or receive on.
-            slot: Slot to send or receive on.
-        """
-        try:
-            port = Identifier(port_name)
-        except ValueError as e:
-            raise ValueError(f'"{port_name}" is not a valid port name: {e}') from None
-
-        return Endpoint(self._kernel, self._index, port, slot)
+    def _get_endpoints(
+        self, port: Port, slot: Optional[int]
+    ) -> tuple[Endpoint, list[Endpoint]]:
+        """Return our endpoint and the peer endpoints for the given port and slot."""
+        return (
+            Endpoint(self._kernel, self._index, port.name, slot),
+            self._peer_info.get_peer_endpoints(port.name, slot),
+        )
 
     def _close_port(self, port_name: str, slot: Optional[int] = None) -> None:
         """Closes the given port.
@@ -573,10 +556,8 @@ class Communicator:
                         else:
                             self._drain_incoming_vector_port(port_name)
                     except RuntimeError:
-                        peer_endpoints = self._peer_info.get_peer_endpoints(
-                            Identifier(port_name), []
-                        )
-                        peer_name = str(peer_endpoints[0].kernel)
+                        peer_port = self._peer_info.get_peer_ports(port.name)[0]
+                        peer_name = str(peer_port[:-1])
                         _logger.warning(
                             "Connection with peer '%s' was lost at the end of the "
                             "simulation, probably because it crashed.",

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional, cast
 
-from ymmsl.v0_2 import Identifier, Reference, Settings
+from ymmsl.v0_2 import Identifier, Operator, Reference, Settings
 
 from libmuscle.endpoint import Endpoint
 from libmuscle.mcp.tcp_util import SocketClosed
@@ -21,6 +21,11 @@ _logger = logging.getLogger(__name__)
 
 
 MessageObject = Any
+FInitCacheType = dict[tuple[str, Optional[int]], "Message"]
+
+
+class PortClosed(Exception):
+    """Exception raised when a port was closed during the F_INIT prereceive"""
 
 
 class Message:
@@ -242,6 +247,32 @@ class Communicator:
         profile_event.message_size = len(memoryview(encoded_message))
         if not isinstance(message.data, ClosePort):
             self._profiler.record_event(profile_event)
+
+    def pre_receive_f_init(self) -> tuple[FInitCacheType, float]:
+        """Receive on all connected F_INIT port (including muscle_settings_in)."""
+        cache: FInitCacheType = {}
+        saved_until_list: list[float] = []
+
+        def pre_receive(port_name: str, slot: Optional[int]) -> None:
+            msg, saved_until = self.receive_message(port_name, slot)
+            if isinstance(msg.data, ClosePort):
+                raise PortClosed()
+            cache[(port_name, slot)] = msg
+            saved_until_list.append(saved_until)
+
+        for port in self._port_manager.get_connected_ports(Operator.F_INIT):
+            port_name = str(port.name)
+            _logger.debug("Pre-receiving on port %s", port_name)
+            if not port.is_vector():
+                pre_receive(port_name, None)
+            else:
+                pre_receive(port_name, 0)
+                # The above receives the length, if needed, so now we can
+                # get the rest.
+                for slot in range(1, port.get_length()):
+                    pre_receive(port_name, slot)
+
+        return cache, max(saved_until_list)
 
     def receive_message(
         self, port_name: str, slot: Optional[int] = None

--- a/src/python/libmuscle/endpoint.py
+++ b/src/python/libmuscle/endpoint.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ymmsl.v0_2 import Identifier, Reference
 
 
@@ -38,7 +40,7 @@ class Endpoint:
     """
 
     def __init__(
-        self, kernel: Reference, index: list[int], port: Identifier, slot: list[int]
+        self, kernel: Reference, index: list[int], port: Identifier, slot: Optional[int]
     ) -> None:
         """Create an Endpoint
 
@@ -70,7 +72,7 @@ class Endpoint:
         if self.index:
             ret += self.index
         ret += self.port
-        if self.slot:
+        if self.slot is not None:
             ret += self.slot
         return ret
 

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -480,12 +480,7 @@ class Instance:
             message = copy(message)
             message.settings = self._settings_manager.overlay
 
-        self._communicator.send_message(
-            port_name,
-            message,
-            slot,
-            self._trigger_manager.checkpoints_considered_until(),
-        )
+        self._communicator.send_message(port_name, message, slot)
 
     def receive(
         self,
@@ -1018,7 +1013,7 @@ class Instance:
                     return default
 
             else:
-                msg, saved_until = self._communicator.receive_message(port_name, slot)
+                msg = self._communicator.receive_message(port_name, slot)
                 if not port.is_open(slot):
                     err_msg = (
                         f"Port {port_name} was closed while trying to"
@@ -1029,7 +1024,6 @@ class Instance:
                 if not with_settings:
                     self.__check_compatibility(port_name, msg.settings)
                     msg.settings = None
-                self._trigger_manager.harmonise_wall_time(saved_until)
         return msg
 
     def __make_full_name(self) -> tuple[Reference, list[int]]:
@@ -1151,14 +1145,13 @@ class Instance:
         sw_event = ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, ProfileTimestamp())
 
         try:
-            self._f_init_cache, saved_until = self._communicator.pre_receive_f_init()
+            self._f_init_cache = self._communicator.pre_receive_f_init()
         except PortClosed:
             self._profiler.record_event(sw_event)
             return False
         except RuntimeError as exc:
             self.__shutdown(str(exc))
             raise
-        self._trigger_manager.harmonise_wall_time(saved_until)
 
         # Handle received settings
         if self._port_manager.settings_in_connected():

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -1166,7 +1166,8 @@ class Instance:
         else:
             self._settings_manager.overlay = Settings()
         # Overlay settings from received messages
-        if InstanceFlags.DONT_APPLY_OVERLAY not in self._flags:
+        apply_overlay = InstanceFlags.DONT_APPLY_OVERLAY not in self._flags
+        if apply_overlay:
             for (port_name, _), msg in self._f_init_cache.items():
                 self.__apply_overlay(msg)
                 self.__check_compatibility(port_name, msg.settings)
@@ -1174,7 +1175,7 @@ class Instance:
         return True
 
     def __handle_receive_settings(self) -> None:
-        """Handle received settings on muscle_settings_in."""
+        """Handle received settings on pre-received muscle_settings_in."""
         message = self._f_init_cache.pop(("muscle_settings_in", None))
         if not isinstance(message.data, Settings):
             err_msg = (

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -9,11 +9,10 @@ from ymmsl.v0_2 import Identifier, Operator, Port, Reference, Settings, SettingV
 
 from libmuscle.api_guard import APIGuard
 from libmuscle.checkpoint_triggers import TriggerManager
-from libmuscle.communicator import Communicator, Message
+from libmuscle.communicator import Communicator, FInitCacheType, Message, PortClosed
 from libmuscle.logging import LogLevel
 from libmuscle.logging_handler import MuscleManagerHandler
 from libmuscle.mmp_client import MMPClient
-from libmuscle.mpp_message import ClosePort
 from libmuscle.port_manager import PortManager
 from libmuscle.profiler import Profiler
 from libmuscle.profiling import ProfileEvent, ProfileEventType, ProfileTimestamp
@@ -22,9 +21,6 @@ from libmuscle.snapshot_manager import SnapshotManager
 from libmuscle.util import extract_log_file_location
 
 _logger = logging.getLogger(__name__)
-
-
-_FInitCacheType = dict[tuple[str, Optional[int]], Message]
 
 
 class InstanceFlags(Flag):
@@ -176,7 +172,7 @@ class Instance:
         self._do_init = False
         """Whether to do f_init on this iteration of the reuse loop"""
 
-        self._f_init_cache: _FInitCacheType = {}
+        self._f_init_cache: FInitCacheType = {}
         """Stores pre-received messages for f_init ports"""
 
         self._register()
@@ -1154,32 +1150,32 @@ class Instance:
         """
         sw_event = ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, ProfileTimestamp())
 
-        all_ports_open = True
-        if not self._port_manager.settings_in_connected():
-            self._settings_manager.overlay = Settings()
-        else:
-            all_ports_open = self.__receive_settings()
-
-        self.__pre_receive_f_init()
-        for message in self._f_init_cache.values():
-            if isinstance(message.data, ClosePort):
-                all_ports_open = False
-
-        if not all_ports_open:
+        try:
+            self._f_init_cache, saved_until = self._communicator.pre_receive_f_init()
+        except PortClosed:
             self._profiler.record_event(sw_event)
-
-        return all_ports_open
-
-    def __receive_settings(self) -> bool:
-        """Receives settings on muscle_settings_in.
-
-        Returns:
-            False iff the port is connnected and ClosePort was received.
-        """
-        message, saved_until = self._communicator.receive_message("muscle_settings_in")
-
-        if isinstance(message.data, ClosePort):
             return False
+        except RuntimeError as exc:
+            self.__shutdown(str(exc))
+            raise
+        self._trigger_manager.harmonise_wall_time(saved_until)
+
+        # Handle received settings
+        if self._port_manager.settings_in_connected():
+            self.__handle_receive_settings()
+        else:
+            self._settings_manager.overlay = Settings()
+        # Overlay settings from received messages
+        if InstanceFlags.DONT_APPLY_OVERLAY not in self._flags:
+            for (port_name, _), msg in self._f_init_cache.items():
+                self.__apply_overlay(msg)
+                self.__check_compatibility(port_name, msg.settings)
+                msg.settings = None
+        return True
+
+    def __handle_receive_settings(self) -> None:
+        """Handle received settings on muscle_settings_in."""
+        message = self._f_init_cache.pop(("muscle_settings_in", None))
         if not isinstance(message.data, Settings):
             err_msg = (
                 f'"{self._instance_id}" received a message on'
@@ -1193,42 +1189,6 @@ class Instance:
         for key, value in message.data.items():
             settings[key] = value
         self._settings_manager.overlay = settings
-
-        self._trigger_manager.harmonise_wall_time(saved_until)
-        return True
-
-    def __pre_receive_f_init(self) -> None:
-        """Receives on all ports connected to F_INIT.
-
-        This receives all incoming messages on F_INIT and stores them
-        in self._f_init_cache.
-        """
-        apply_overlay = InstanceFlags.DONT_APPLY_OVERLAY not in self._flags
-
-        def pre_receive(port_name: str, slot: Optional[int]) -> None:
-            msg, saved_until = self._communicator.receive_message(port_name, slot)
-            if apply_overlay:
-                self.__apply_overlay(msg)
-                self.__check_compatibility(port_name, msg.settings)
-                msg.settings = None
-            self._f_init_cache[(port_name, slot)] = msg
-            self._trigger_manager.harmonise_wall_time(saved_until)
-
-        self._f_init_cache = dict()
-        ports = self._port_manager.list_ports()
-        for port_name in ports.get(Operator.F_INIT, []):
-            _logger.debug(f"Pre-receiving on port {port_name}")
-            port = self._port_manager.get_port(port_name)
-            if not port.is_connected():
-                continue
-            if not port.is_vector():
-                pre_receive(port_name, None)
-            else:
-                pre_receive(port_name, 0)
-                # The above receives the length, if needed, so now we can
-                # get the rest.
-                for slot in range(1, port.get_length()):
-                    pre_receive(port_name, slot)
 
     def _set_remote_log_level(self) -> None:
         """Sets the remote log level.

--- a/src/python/libmuscle/mpp_message.py
+++ b/src/python/libmuscle/mpp_message.py
@@ -159,7 +159,6 @@ class MPPMessage:
         next_timestamp: Optional[float],
         settings_overlay: Settings,
         message_number: int,
-        saved_until: float,
         data: Any,
         iteration: Optional[IterationCount] = None,
     ) -> None:
@@ -180,8 +179,6 @@ class MPPMessage:
             port_length: Length of the slot, where applicable.
             settings_overlay: The serialised overlay settings.
             message_number: Sequence number on this conduit.
-            saved_until: Elapsed time until which the sender has
-                processed checkpoints.
             data: The serialised contents of the message.
             iteration: The iteration of the sending port, or None.
                 TODO: When replacing ClosePort with Milestones we shouldn't allow a None
@@ -199,7 +196,6 @@ class MPPMessage:
         self.next_timestamp = next_timestamp
         self.settings_overlay = settings_overlay
         self.message_number = message_number
-        self.saved_until = saved_until
         self.iteration = iteration
         if isinstance(data, np.ndarray):
             self.data = Grid(data)
@@ -221,7 +217,6 @@ class MPPMessage:
         next_timestamp = message_dict["next_timestamp"]
         settings_overlay = message_dict["settings_overlay"]
         message_number = message_dict["message_number"]
-        saved_until = message_dict["saved_until"]
 
         data = message_dict["data"]
         iteration = message_dict.get("iteration")
@@ -233,7 +228,6 @@ class MPPMessage:
             next_timestamp,
             settings_overlay,
             message_number,
-            saved_until,
             data,
             iteration,
         )
@@ -248,7 +242,6 @@ class MPPMessage:
             "next_timestamp": self.next_timestamp,
             "settings_overlay": self.settings_overlay,
             "message_number": self.message_number,
-            "saved_until": self.saved_until,
             "data": self.data,
             "iteration": self.iteration,
         }

--- a/src/python/libmuscle/peer_info.py
+++ b/src/python/libmuscle/peer_info.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from ymmsl.v0_2 import Conduit, Identifier, Port, Reference
 
@@ -132,7 +132,9 @@ class PeerInfo:
         """
         return self._peer_locations[peer_instance]
 
-    def get_peer_endpoints(self, port: Identifier, slot: list[int]) -> list[Endpoint]:
+    def get_peer_endpoints(
+        self, port: Identifier, slot: Optional[int]
+    ) -> list[Endpoint]:
         """Determine the peer endpoints for the given port and slot.
 
         Args:
@@ -145,16 +147,18 @@ class PeerInfo:
         peers = self._peers[self._kernel + port]
         endpoints = []
 
+        total_index = self._index.copy()
+        if slot is not None:
+            total_index.append(slot)
+
         for peer in peers:
             peer_kernel = peer[:-1]
             peer_port = cast(Identifier, peer[-1])
 
-            total_index = self._index + slot
-
             # rebalance the indices
             peer_dim = len(self._peer_dims[peer_kernel])
             peer_index = total_index[0:peer_dim]
-            peer_slot = total_index[peer_dim:]
+            peer_slot = total_index[peer_dim] if peer_dim < len(total_index) else None
             endpoints.append(Endpoint(peer_kernel, peer_index, peer_port, peer_slot))
 
         return endpoints

--- a/src/python/libmuscle/port_manager.py
+++ b/src/python/libmuscle/port_manager.py
@@ -85,7 +85,8 @@ class PortManager:
         operator: Operator,
         timeline: Optional[Timeline] = None,
     ) -> list[Port]:
-        """Returns the connected ports for the given operator.
+        """Returns the connected ports for the given operator. Includes
+        muscle_settings_in for F_INIT.
 
         Args:
             operator: The operator to select ports for.
@@ -94,13 +95,16 @@ class PortManager:
         Returns:
             The Port objects for this operator's connected ports.
         """
-        return [
+        result = [
             port
             for port in self._ports.values()
             if port.operator is operator
             and (timeline is None or port.timeline == timeline)
             and port.is_connected()
         ]
+        if operator is Operator.F_INIT and self.settings_in_connected():
+            result.append(self._muscle_settings_in)
+        return result
 
     def list_subtimelines(self) -> set[Timeline]:
         """Returns the timelines of this instance's connected O_I/S ports.

--- a/src/python/libmuscle/snapshot.py
+++ b/src/python/libmuscle/snapshot.py
@@ -111,7 +111,6 @@ class MsgPackSnapshot(Snapshot):
             message.next_timestamp,
             settings,
             0,
-            -1.0,
             message.data,
         ).encoded()
 

--- a/src/python/libmuscle/test/conftest.py
+++ b/src/python/libmuscle/test/conftest.py
@@ -11,6 +11,7 @@ from libmuscle.mcp.transport_client import ProfileData
 from libmuscle.mmp_client import MMPClient
 from libmuscle.planner.resources import Core, CoreSet, OnNodeResources, Resources
 from libmuscle.port import Port
+from libmuscle.port_manager import PortManager
 from libmuscle.profiler import Profiler
 from libmuscle.timeline_manager import TimelineState
 from libmuscle.timestamp import Timestamp
@@ -115,7 +116,16 @@ def connected_port_manager(port_manager, declared_ports, mock_ports):
     def port_exists(name):
         return name in mock_ports
 
+    def get_connected_ports(operator, timeline=None):
+        # Delegate to actual implementation
+        return PortManager.get_connected_ports(port_manager, operator, timeline)
+
+    port_manager._ports = mock_ports
+    port_manager._muscle_settings_in = Port(
+        "muscle_settings_in", Operator.F_INIT, None, False, True, 0, []
+    )
     port_manager.get_port = get_port
+    port_manager.get_connected_ports = get_connected_ports
     port_manager.list_ports.return_value = declared_ports
     port_manager.port_exists = port_exists
     port_manager.has_f_init_connections.return_value = True

--- a/src/python/libmuscle/test/test_communicator.py
+++ b/src/python/libmuscle/test/test_communicator.py
@@ -99,7 +99,7 @@ def test_send_message(connected_communicator, mpp_server, timeline_manager):
     timeline_manager.return_value.check_send_message.return_value = [2, 0]
     msg = Message(0.0, 1.0, "Testing", Settings({"s0": 0, "s1": "1"}))
 
-    connected_communicator.send_message("out_v", msg, 7, -1.0)
+    connected_communicator.send_message("out_v", msg, 7)
 
     mpp_server.deposit.assert_called_once()
     args = mpp_server.deposit.call_args[0]
@@ -115,7 +115,6 @@ def test_send_message(connected_communicator, mpp_server, timeline_manager):
     assert encoded_msg.settings_overlay["s0"] == 0
     assert encoded_msg.settings_overlay["s1"] == "1"
     assert encoded_msg.message_number == 0
-    assert encoded_msg.saved_until == -1.0
     assert encoded_msg.data == "Testing"
     assert encoded_msg.iteration == [2, 0]
     timeline_manager.return_value.check_send_message.assert_called_with("out_v", 7)
@@ -138,7 +137,6 @@ def test_receive_message(connected_communicator, mpp_client):
         3.0,
         Settings({"s0": "0", "s1": True}),
         0,
-        1.0,
         "Testing",
         [0],
     )
@@ -146,7 +144,7 @@ def test_receive_message(connected_communicator, mpp_client):
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
     connected_communicator.set_receive_timeout(-1)
-    recv_msg, saved_until = connected_communicator.receive_message("in")
+    recv_msg = connected_communicator.receive_message("in")
 
     mpp_client.receive.assert_called_with(Ref("component.in"), None)
 
@@ -156,7 +154,6 @@ def test_receive_message(connected_communicator, mpp_client):
     assert len(recv_msg.settings) == 2
     assert recv_msg.settings["s0"] == "0"
     assert recv_msg.settings["s1"] is True
-    assert saved_until == 1.0
 
 
 def test_receive_message_vector(connected_communicator, mpp_client):
@@ -168,7 +165,6 @@ def test_receive_message_vector(connected_communicator, mpp_client):
         6.0,
         Settings({"s0": [0.0], "s1": 1.0}),
         0,
-        3.5,
         "Testing2",
         [0],
     )
@@ -176,7 +172,7 @@ def test_receive_message_vector(connected_communicator, mpp_client):
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
     connected_communicator.set_receive_timeout(-1)
-    recv_msg, saved_until = connected_communicator.receive_message("in_v", 5)
+    recv_msg = connected_communicator.receive_message("in_v", 5)
 
     mpp_client.receive.assert_called_with(Ref("component.in_v[5]"), None)
 
@@ -186,7 +182,6 @@ def test_receive_message_vector(connected_communicator, mpp_client):
     assert len(recv_msg.settings) == 2
     assert recv_msg.settings["s0"] == [0.0]
     assert recv_msg.settings["s1"] == 1.0
-    assert saved_until == 3.5
 
 
 def test_receive_close_port(connected_communicator, mpp_client, port_manager):
@@ -198,14 +193,13 @@ def test_receive_close_port(connected_communicator, mpp_client, port_manager):
         None,
         Settings(),
         0,
-        0.1,
         ClosePort(),
     )
     assert msg.iteration is None
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
-    recv_msg, saved_until = connected_communicator.receive_message("in")
+    connected_communicator.receive_message("in")
 
     assert port_manager.get_port("in").is_open() is False
 
@@ -219,24 +213,22 @@ def test_receive_close_port_vector(connected_communicator, mpp_client, port_mana
         None,
         Settings(),
         0,
-        3.5,
         ClosePort(),
     )
     assert msg.iteration is None
 
     mpp_client.receive.return_value = msg.encoded(), MagicMock()
 
-    recv_msg, saved_until = connected_communicator.receive_message("in_v", 5)
+    connected_communicator.receive_message("in_v", 5)
 
     assert port_manager.get_port("in_v").is_open(5) is False
 
 
 def test_pre_receive_f_init(connected_communicator):
     msg = MagicMock()
-    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+    connected_communicator.receive_message = MagicMock(return_value=msg)
 
-    cache, saved_until = connected_communicator.pre_receive_f_init()
-    assert saved_until == 0.0
+    cache = connected_communicator.pre_receive_f_init()
     assert cache == {("in", None): msg}
 
 
@@ -244,17 +236,16 @@ def test_pre_receive_f_init_with_settings(
     connected_communicator, connected_port_manager
 ):
     msg = MagicMock()
-    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+    connected_communicator.receive_message = MagicMock(return_value=msg)
     connected_port_manager.settings_in_connected.return_value = True
 
-    cache, saved_until = connected_communicator.pre_receive_f_init()
-    assert saved_until == 0.0
+    cache = connected_communicator.pre_receive_f_init()
     assert cache == {("in", None): msg, ("muscle_settings_in", None): msg}
 
 
 def test_pre_receive_close_port(connected_communicator):
     msg = MagicMock(data=ClosePort())
-    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+    connected_communicator.receive_message = MagicMock(return_value=msg)
 
     with pytest.raises(PortClosed):
         connected_communicator.pre_receive_f_init()
@@ -262,11 +253,10 @@ def test_pre_receive_close_port(connected_communicator):
 
 def test_pre_receive_vector(connected_communicator, mock_ports):
     msg = MagicMock()
-    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+    connected_communicator.receive_message = MagicMock(return_value=msg)
     mock_ports["in"]._length = 4
 
-    cache, saved_until = connected_communicator.pre_receive_f_init()
-    assert saved_until == 0.0
+    cache = connected_communicator.pre_receive_f_init()
     assert cache == {("in", slot): msg for slot in range(4)}
 
 
@@ -282,7 +272,6 @@ def test_port_count_validation(
         None,
         Settings({"test1": 12}),
         0,
-        7.6,
         b"test",
         [0],
     )
@@ -309,7 +298,6 @@ def test_port_discard_error_on_resume(
         None,
         Settings({"test1": 12}),
         1,
-        2.3,
         b"test",
     )
 
@@ -348,7 +336,6 @@ def test_port_discard_success_on_resume(
                 None,
                 Settings({"test1": 12}),
                 message_number,
-                1.0,
                 {"this is message": message_number},
                 [0],
             ).encoded(),
@@ -367,7 +354,7 @@ def test_port_discard_success_on_resume(
         assert connected_port_manager.get_port(port).is_resuming(None)
 
     with caplog.at_level(logging.DEBUG, "libmuscle.communicator"):
-        msg, _ = connected_communicator.receive_message("in")
+        msg = connected_communicator.receive_message("in")
         assert any(
             ["Discarding received message" in rec.message for rec in caplog.records]
         )
@@ -391,7 +378,6 @@ def test_shutdown(
         None,
         Settings(),
         0,
-        0.0,
         ClosePort(),
     )
 
@@ -413,7 +399,6 @@ def test_shutdown(
                 None,
                 Settings(),
                 0,
-                3.5,
                 ClosePort(),
             )
 

--- a/src/python/libmuscle/test/test_communicator.py
+++ b/src/python/libmuscle/test/test_communicator.py
@@ -5,7 +5,7 @@ import pytest
 from ymmsl.v0_2 import Conduit, Settings
 from ymmsl.v0_2 import Reference as Ref
 
-from libmuscle.communicator import Communicator, Message
+from libmuscle.communicator import Communicator, Message, PortClosed
 from libmuscle.mpp_message import ClosePort, MPPMessage
 from libmuscle.peer_info import PeerInfo
 
@@ -229,6 +229,45 @@ def test_receive_close_port_vector(connected_communicator, mpp_client, port_mana
     recv_msg, saved_until = connected_communicator.receive_message("in_v", 5)
 
     assert port_manager.get_port("in_v").is_open(5) is False
+
+
+def test_pre_receive_f_init(connected_communicator):
+    msg = MagicMock()
+    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+
+    cache, saved_until = connected_communicator.pre_receive_f_init()
+    assert saved_until == 0.0
+    assert cache == {("in", None): msg}
+
+
+def test_pre_receive_f_init_with_settings(
+    connected_communicator, connected_port_manager
+):
+    msg = MagicMock()
+    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+    connected_port_manager.settings_in_connected.return_value = True
+
+    cache, saved_until = connected_communicator.pre_receive_f_init()
+    assert saved_until == 0.0
+    assert cache == {("in", None): msg, ("muscle_settings_in", None): msg}
+
+
+def test_pre_receive_close_port(connected_communicator):
+    msg = MagicMock(data=ClosePort())
+    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+
+    with pytest.raises(PortClosed):
+        connected_communicator.pre_receive_f_init()
+
+
+def test_pre_receive_vector(connected_communicator, mock_ports):
+    msg = MagicMock()
+    connected_communicator.receive_message = MagicMock(return_value=(msg, 0.0))
+    mock_ports["in"]._length = 4
+
+    cache, saved_until = connected_communicator.pre_receive_f_init()
+    assert saved_until == 0.0
+    assert cache == {("in", slot): msg for slot in range(4)}
 
 
 def test_port_count_validation(

--- a/src/python/libmuscle/test/test_instance.py
+++ b/src/python/libmuscle/test/test_instance.py
@@ -63,7 +63,7 @@ def port_manager():
 def communicator():
     with patch("libmuscle.instance.Communicator") as Communicator:
         communicator = Communicator.return_value
-        communicator.pre_receive_f_init.return_value = {}, 0.0
+        communicator.pre_receive_f_init.return_value = {}
         yield communicator
 
 
@@ -431,10 +431,9 @@ def test_reuse_set_overlay(
     mock_msg = MagicMock()
     mock_msg.data = Settings({"s1": 1, "s2": 2})
     mock_msg.settings = Settings({"s0": 0})
-    communicator.pre_receive_f_init.return_value = (
-        {("muscle_settings_in", None): mock_msg},
-        0.0,
-    )
+    communicator.pre_receive_f_init.return_value = {
+        ("muscle_settings_in", None): mock_msg
+    }
 
     instance.reuse_instance()
     assert settings_manager.overlay["s0"] == 0
@@ -519,7 +518,7 @@ def test_receive_on_sending_port(instance):
 def test_receive_f_init(instance, port_manager, communicator):
     mock_msg = MagicMock()
     mock_msg.data = Settings()
-    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}, 0.0
+    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}
 
     instance.reuse_instance()
 
@@ -561,7 +560,7 @@ def test_receive_inconsistent_settings(
         ),
         ("in", None): MagicMock(settings=Settings({"s0": 0})),
     }
-    communicator.pre_receive_f_init.return_value = msgs, 0.0
+    communicator.pre_receive_f_init.return_value = msgs
     port_manager.settings_in_connected.return_value = True
 
     with pytest.raises(RuntimeError):
@@ -574,7 +573,7 @@ def test_receive_with_settings(
 
     mock_msg = MagicMock()
     mock_msg.settings = Settings({"s0": 0, "s1": 1})
-    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}, 0.0
+    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}
 
     instance_dont_apply_overlay.reuse_instance()
     msg = instance_dont_apply_overlay.receive("in")

--- a/src/python/libmuscle/test/test_instance.py
+++ b/src/python/libmuscle/test/test_instance.py
@@ -6,8 +6,8 @@ import pytest
 from ymmsl.v0_2 import Checkpoints, Operator, Settings
 from ymmsl.v0_2 import Reference as Ref
 
+from libmuscle.communicator import PortClosed
 from libmuscle.instance import Instance, InstanceFlags
-from libmuscle.mpp_message import ClosePort
 from libmuscle.peer_info import PeerInfo
 
 
@@ -62,7 +62,9 @@ def port_manager():
 @pytest.fixture
 def communicator():
     with patch("libmuscle.instance.Communicator") as Communicator:
-        yield Communicator.return_value
+        communicator = Communicator.return_value
+        communicator.pre_receive_f_init.return_value = {}, 0.0
+        yield communicator
 
 
 @pytest.fixture
@@ -429,48 +431,30 @@ def test_reuse_set_overlay(
     mock_msg = MagicMock()
     mock_msg.data = Settings({"s1": 1, "s2": 2})
     mock_msg.settings = Settings({"s0": 0})
-    communicator.receive_message.return_value = mock_msg, 0.0
+    communicator.pre_receive_f_init.return_value = (
+        {("muscle_settings_in", None): mock_msg},
+        0.0,
+    )
 
     instance.reuse_instance()
-
-    communicator.receive_message.assert_called_with("muscle_settings_in")
     assert settings_manager.overlay["s0"] == 0
     assert settings_manager.overlay["s1"] == 1
     assert settings_manager.overlay["s2"] == 2
 
 
-@pytest.mark.parametrize("closed_port", ["muscle_settings_in", "in"])
-def test_reuse_closed_port(instance, port_manager, communicator, closed_port):
-
-    def receive_message(port, slot=None, default=None):
-        mock_msg = MagicMock()
-        if port == closed_port:
-            mock_msg.data = ClosePort()
-        else:
-            mock_msg.data = Settings()
-        return mock_msg, 0.0
-
-    port_manager.settings_in_connected.return_value = True
-    communicator.receive_message = receive_message
-
+def test_reuse_closed_port(instance, communicator):
+    communicator.pre_receive_f_init.side_effect = PortClosed()
     assert instance.reuse_instance() is False
 
 
-def test_reuse_f_init_vector_port(instance, port_manager, communicator):
-    port_manager.get_port("in")._length = 10
-
-    def receive_message(port, slot=None, default=None):
-        mock_msg = MagicMock()
-        mock_msg.data = Settings()
-        return mock_msg, 0.0
-
-    communicator.receive_message = receive_message
-
-    assert instance.reuse_instance() is True
+def test_reuse_no_closed_port(instance, communicator):
+    for _ in range(20):
+        assert instance.reuse_instance() is True
+    communicator.pre_receive_f_init.side_effect = PortClosed()
+    assert instance.reuse_instance() is False
 
 
 def test_reuse_no_f_init_ports(instance, connected_port_manager, communicator):
-    connected_port_manager.list_ports.return_value = {}
     connected_port_manager.has_f_init_connections.return_value = False
 
     assert instance.reuse_instance() is True
@@ -535,7 +519,7 @@ def test_receive_on_sending_port(instance):
 def test_receive_f_init(instance, port_manager, communicator):
     mock_msg = MagicMock()
     mock_msg.data = Settings()
-    communicator.receive_message.return_value = mock_msg, 0.0
+    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}, 0.0
 
     instance.reuse_instance()
 
@@ -571,19 +555,13 @@ def test_receive_no_default(instance):
 def test_receive_inconsistent_settings(
     instance, settings_manager, port_manager, communicator
 ):
-
-    def receive_message(port, slot=None):
-        mock_msg = MagicMock()
-        if port == "muscle_settings_in":
-            mock_msg.data = Settings({"s1": 1})
-            mock_msg.settings = Settings()
-        else:
-            mock_msg.data = None
-            mock_msg.settings = Settings({"s0": 0})
-        return mock_msg, 0.0
-
-    communicator.receive_message.side_effect = receive_message
-
+    msgs = {
+        ("muscle_settings_in", None): MagicMock(
+            data=Settings({"s1": 1}), settings=Settings()
+        ),
+        ("in", None): MagicMock(settings=Settings({"s0": 0})),
+    }
+    communicator.pre_receive_f_init.return_value = msgs, 0.0
     port_manager.settings_in_connected.return_value = True
 
     with pytest.raises(RuntimeError):
@@ -596,7 +574,7 @@ def test_receive_with_settings(
 
     mock_msg = MagicMock()
     mock_msg.settings = Settings({"s0": 0, "s1": 1})
-    communicator.receive_message.return_value = mock_msg, 0.0
+    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}, 0.0
 
     instance_dont_apply_overlay.reuse_instance()
     msg = instance_dont_apply_overlay.receive("in")

--- a/src/python/libmuscle/test/test_mpp_message.py
+++ b/src/python/libmuscle/test/test_mpp_message.py
@@ -15,7 +15,6 @@ def test_create() -> None:
     next_timestamp = 11.0
     settings_overlay = (6789).to_bytes(2, "little", signed=True)
     message_number = 0
-    saved_until = 1.6
     data = (12345).to_bytes(2, "little", signed=True)
     msg = MPPMessage(
         sender,
@@ -25,7 +24,6 @@ def test_create() -> None:
         next_timestamp,
         settings_overlay,
         message_number,
-        saved_until,
         data,
     )
     assert msg.sender == sender
@@ -35,7 +33,6 @@ def test_create() -> None:
     assert msg.next_timestamp == 11.0
     assert msg.settings_overlay == settings_overlay
     assert msg.message_number == 0
-    assert msg.saved_until == 1.6
     assert msg.data == data
 
 
@@ -52,7 +49,7 @@ def test_grid_encode() -> None:
 
     grid = Grid(array, ["x", "y", "z"])
     msg = MPPMessage(
-        sender, receiver, None, timestamp, next_timestamp, Settings(), 0, 1.0, grid
+        sender, receiver, None, timestamp, next_timestamp, Settings(), 0, grid
     )
 
     wire_data = msg.encoded()
@@ -94,7 +91,6 @@ def test_grid_decode() -> None:
         "next_timestamp": None,
         "settings_overlay": msgpack.ExtType(1, settings_data),
         "message_number": 0,
-        "saved_until": 9.9,
         "data": msgpack.ExtType(2, grid_data),
     }
 
@@ -144,7 +140,7 @@ def test_grid_roundtrip() -> None:
 
         grid = Grid(array, ["x", "y", "z"])
         msg = MPPMessage(
-            sender, receiver, None, timestamp, next_timestamp, Settings(), 0, 1.0, grid
+            sender, receiver, None, timestamp, next_timestamp, Settings(), 0, grid
         )
 
         wire_data = msg.encoded()
@@ -166,7 +162,7 @@ def test_iteration_roundtrip() -> None:
     receiver = Reference("receiver.port")
 
     msg = MPPMessage(
-        sender, receiver, None, 0.0, None, Settings(), 0, 0.0, 42, iteration=[0, 2]
+        sender, receiver, None, 0.0, None, Settings(), 0, 42, iteration=[0, 2]
     )
     msg_out = MPPMessage.from_bytes(msg.encoded())
     assert msg_out.iteration == [0, 2]
@@ -197,7 +193,7 @@ def test_non_contiguous_grid_roundtrip() -> None:
 
     grid = Grid(array.real, ["a", "b", "c"])
     msg = MPPMessage(
-        sender, receiver, None, timestamp, next_timestamp, Settings(), 0, 7.7, grid
+        sender, receiver, None, timestamp, next_timestamp, Settings(), 0, grid
     )
 
     wire_data = msg.encoded()

--- a/src/python/libmuscle/test/test_outbox.py
+++ b/src/python/libmuscle/test/test_outbox.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 import pytest
-from ymmsl.v0_2 import Reference
+from ymmsl.v0_2 import Reference, Settings
 
 from libmuscle.mpp_message import MPPMessage
 from libmuscle.outbox import Outbox
@@ -16,7 +16,7 @@ def outbox():
 def message():
     Ref = Reference
     return MPPMessage(
-        Ref("sender.out"), Ref("receiver.in"), None, 0.0, 1.0, b"", 0, 1.0, b"testing"
+        Ref("sender.out"), Ref("receiver.in"), None, 0.0, 1.0, Settings(), 0, b"testing"
     )
 
 

--- a/src/python/libmuscle/test/test_peer_info.py
+++ b/src/python/libmuscle/test/test_peer_info.py
@@ -88,14 +88,14 @@ def test_get_peer_locations(peer_info, peer_info2, peer_info3) -> None:
 
 
 def test_get_peer_endpoint(peer_info, peer_info2, peer_info3) -> None:
-    assert str(peer_info.get_peer_endpoints(Id("out"), [])[0]) == "other.in[13]"
-    assert str(peer_info.get_peer_endpoints(Id("in"), [])[0]) == "other.out[13]"
+    assert str(peer_info.get_peer_endpoints(Id("out"), None)[0]) == "other.in[13]"
+    assert str(peer_info.get_peer_endpoints(Id("in"), None)[0]) == "other.out[13]"
 
-    assert str(peer_info2.get_peer_endpoints(Id("out"), [11])[0]) == "kernel[11].in"
-    assert str(peer_info2.get_peer_endpoints(Id("in"), [11])[0]) == "kernel[11].out"
+    assert str(peer_info2.get_peer_endpoints(Id("out"), 11)[0]) == "kernel[11].in"
+    assert str(peer_info2.get_peer_endpoints(Id("in"), 11)[0]) == "kernel[11].out"
 
-    assert str(peer_info3.get_peer_endpoints(Id("out"), [42])[0]) == "other.in[42]"
-    assert str(peer_info3.get_peer_endpoints(Id("in"), [42])[0]) == "other.out[42]"
+    assert str(peer_info3.get_peer_endpoints(Id("out"), 42)[0]) == "other.in[42]"
+    assert str(peer_info3.get_peer_endpoints(Id("in"), 42)[0]) == "other.out[42]"
 
 
 def test_get_ymmsl_ports(peer_info) -> None:

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -233,18 +233,10 @@ class TimelineManager:
         """
         self._port_manager = port_manager
 
-        receive_ports = self._port_manager.get_connected_ports(Operator.F_INIT)
-        # muscle_settings_in is F_INIT too, but it's not a declared port, so
-        # list_ports() doesn't return it; check_receive/record_received_message
-        # do treat it as F_INIT though, so it must be tracked here as well.
-        if self._port_manager.settings_in_connected():
-            receive_ports.append(self._port_manager.get_port("muscle_settings_in"))
-        self._receive = TimelinePorts(receive_ports)
+        self._receive = TimelinePorts(port_manager.get_connected_ports(Operator.F_INIT))
+        self._send = TimelinePorts(port_manager.get_connected_ports(Operator.O_F))
 
-        self._send = TimelinePorts(self._port_manager.get_connected_ports(Operator.O_F))
-
-        subtimelines = self._port_manager.list_subtimelines()
-
+        subtimelines = port_manager.list_subtimelines()
         self._submanagers = {
             tl: SubTimelineManager(tl, self._port_manager) for tl in subtimelines
         }


### PR DESCRIPTION
Some refactoring of send/receive logic in the communicator in preparation for the Milestones and Conduit Filter PRs:

1. Move "pre receive" of F_INIT messages to communicator, so the Instance won't need to care about conduit filters and the Communicator can handle it all.
2. Remove the "saved_until" metadata from MPPMessage and corresponding logic in the Instance/Communicator/TriggerManager. The checkpointing works just fine without it, and it simplifies the send/receive logic.
3. Slightly simplify constructing the endpoints: use `Optional[int]` for slots instead of a `list[int]` which may be `[]` or `[slot]`
4. Move some logic around so `send_message` and `receive_message` do things in the same order in the Python and C++ implementations.