### PR TITLE
Add ConduitFilters to the muscle manager protocol

### DIFF
--- a/src/cpp/libmuscle/mmp_client.cpp
+++ b/src/cpp/libmuscle/mmp_client.cpp
@@ -275,7 +275,9 @@ auto MMPClient::request_peers() -> PeerInfo
     std::vector<Conduit> conduits;
     for (std::size_t i = 0u; i < recv_conduits.size(); ++i)
         conduits.emplace_back(
-                recv_conduits[i][0].as<std::string>(), recv_conduits[i][1].as<std::string>());
+                recv_conduits[i][0].as<std::string>(),
+                recv_conduits[i][1].as<std::string>(),
+                recv_conduits[i][2].as<std::string>());
 
 
     auto const & recv_dims = response[2];

--- a/src/cpp/libmuscle/peer_info.cpp
+++ b/src/cpp/libmuscle/peer_info.cpp
@@ -21,9 +21,8 @@ PeerInfo::PeerInfo(
         )
     : kernel_(kernel)
     , index_(index)
-    , incoming_ports_()
-    , outgoing_ports_()
     , peers_()                          // peer port ids, indexed by local kernel.port
+    , filters_per_receiver_()           // conduit filters per receiving kernel.port
     , peer_dims_(peer_dims)             // indexed by peer kernel id
     , peer_locations_(peer_locations)   // indexed by peer instance id
     , ymmsl_ports_(ymmsl_ports)
@@ -31,11 +30,6 @@ PeerInfo::PeerInfo(
     for (auto const & conduit : conduits) {
         if (conduit.sending_component() == kernel_) {
             // we send on the port this conduit attaches to
-            auto it = std::find(
-                    outgoing_ports_.cbegin(), outgoing_ports_.cend(), conduit.sender);
-            if (it == outgoing_ports_.end())
-                outgoing_ports_.push_back(conduit.sender);
-
             auto search = peers_.find(conduit.sender);
             if (search == peers_.end())
                 search = peers_.emplace(
@@ -52,10 +46,11 @@ PeerInfo::PeerInfo(
                 ss << " is allowed.";
                 throw std::runtime_error(ss.str());
             }
-            incoming_ports_.push_back(conduit.receiver);
             std::vector<Reference> vec = {conduit.sender};
             peers_.emplace(conduit.receiver, vec);
         }
+
+        filters_per_receiver_.emplace(conduit.receiver, conduit.filters);
     }
 }
 
@@ -63,26 +58,13 @@ std::vector<::ymmsl::Port> const & PeerInfo::list_ymmsl_ports() const {
     return ymmsl_ports_;
 }
 
-IncomingPorts PeerInfo::list_incoming_ports() const {
-    IncomingPorts result;
-    for (auto const & port_ref: incoming_ports_) {
-        Identifier port_id = port_ref[port_ref.length() - 1].identifier();
-        result.emplace_back(port_id, peers_.at(port_ref)[0]);
-    }
-    return result;
-}
-
-OutgoingPorts PeerInfo::list_outgoing_ports() const {
-    OutgoingPorts result;
-    for (auto const & port_ref: outgoing_ports_) {
-        Identifier port_id = port_ref[port_ref.length() - 1].identifier();
-        result.emplace_back(port_id, peers_.at(port_ref));
-    }
-    return result;
-}
-
 bool PeerInfo::is_connected(Identifier const & port) const {
     return peers_.count(kernel_ + port);
+}
+
+std::vector<ymmsl::ConduitFilter> const & PeerInfo::get_filters_for_receiver(
+        Reference const & receiver) {
+    return filters_per_receiver_.at(receiver);
 }
 
  std::vector<ymmsl::Reference> const & PeerInfo::get_peer_ports(

--- a/src/cpp/libmuscle/peer_info.hpp
+++ b/src/cpp/libmuscle/peer_info.hpp
@@ -59,26 +59,17 @@ class PeerInfo {
          */
         std::vector<::ymmsl::Port> const & list_ymmsl_ports() const;
 
-        /** List incoming ports.
-         *
-         * @return A vector of tuples containing a port id and a reference to the
-         *      peer endpoint.
-         */
-        IncomingPorts list_incoming_ports() const;
-
-        /** List outgoing ports.
-         *
-         * @return A vector of tuples containing a port id and a vector of references
-         * to the peer endpoints.
-         */
-        OutgoingPorts list_outgoing_ports() const;
-
         /** Determine whether the given port is connected.
          *
          * @param port The port to check.
          * @return true iff the port is connected.
          */
         bool is_connected(ymmsl::Identifier const & port) const;
+
+        /** Get the conduit filters for a receiver (component + port name)
+         */
+        std::vector<ymmsl::ConduitFilter> const & get_filters_for_receiver(
+                ymmsl::Reference const & receiver);
 
         /** Get a reference for all the peer ports.
          *
@@ -125,9 +116,8 @@ class PeerInfo {
         ymmsl::Reference kernel_;
         std::vector<int> index_;
 
-        std::vector<ymmsl::Reference> incoming_ports_, outgoing_ports_;
-
         std::unordered_map<ymmsl::Reference, std::vector<ymmsl::Reference>> peers_;
+        std::unordered_map<ymmsl::Reference, std::vector<ymmsl::ConduitFilter>> filters_per_receiver_;
         PeerDims peer_dims_;
         PeerLocations peer_locations_;
         std::vector<::ymmsl::Port> ymmsl_ports_;

--- a/src/cpp/libmuscle/tests/mmp_client_test.cpp
+++ b/src/cpp/libmuscle/tests/mmp_client_test.cpp
@@ -50,14 +50,6 @@ void test_register_instance(MMPClient & client) {
 void test_request_peers(MMPClient & client) {
     auto peer_info = client.request_peers();
 
-    auto const & incoming_ports = peer_info.list_incoming_ports();
-    assert(incoming_ports.size() == 1);
-    assert(std::get<0>(incoming_ports[0]) == "micro.in");
-
-    auto const & outgoing_ports = peer_info.list_outgoing_ports();
-    assert(outgoing_ports.size() == 1);
-    assert(std::get<0>(outgoing_ports[0]) == "micro.out");
-
     auto const & in_peer_ports = peer_info.get_peer_ports("micro.in");
     assert(in_peer_ports.size() == 1);
     assert(in_peer_ports[0] == "macro.out");

--- a/src/cpp/libmuscle/tests/test_instance.cpp
+++ b/src/cpp/libmuscle/tests/test_instance.cpp
@@ -85,8 +85,7 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 bool operator==(PeerInfo const & lhs, PeerInfo const & rhs) {
     if (lhs.kernel_ != rhs.kernel_) return false;
     if (lhs.index_ != rhs.index_) return false;
-    if (lhs.incoming_ports_ != rhs.incoming_ports_) return false;
-    if (lhs.outgoing_ports_ != rhs.outgoing_ports_) return false;
+    if (lhs.filters_per_receiver_ != rhs.filters_per_receiver_) return false;
     if (lhs.peers_ != rhs.peers_) return false;
     if (lhs.peer_dims_ != rhs.peer_dims_) return false;
     if (lhs.peer_locations_ != rhs.peer_locations_) return false;

--- a/src/cpp/ymmsl/model.cpp
+++ b/src/cpp/ymmsl/model.cpp
@@ -6,10 +6,49 @@
 
 namespace ymmsl { namespace impl {
 
-Conduit::Conduit(std::string const & sender, std::string const & receiver)
+std::string conduit_filter_name(ConduitFilter filter) {
+    switch (filter) {
+        case ConduitFilter::LAST:
+            return "last";
+        case ConduitFilter::REPEAT:
+            return "repeat";
+        case ConduitFilter::PAD:
+            return "pad";
+    }
+    throw std::logic_error("Unreachable code reached");
+}
+
+ConduitFilter conduit_filter_for_name(std::string const & name) {
+    if (name == "last")
+        return ConduitFilter::LAST;
+    if (name == "repeat")
+        return ConduitFilter::REPEAT;
+    if (name == "pad")
+        return ConduitFilter::PAD;
+    throw std::invalid_argument("Unknown conduit filter name: " + name);
+}
+
+bool is_reducer(ConduitFilter filter) {
+    return filter == ConduitFilter::LAST;
+}
+
+bool is_repeater(ConduitFilter filter) {
+    return filter == ConduitFilter::REPEAT || filter == ConduitFilter::PAD;
+}
+
+
+Conduit::Conduit(
+        std::string const & sender, std::string const & receiver,
+        std::string const & filters)
     : sender(sender)
     , receiver(receiver)
+    , filters()
 {
+    std::istringstream stream(filters);
+    std::string f;
+    while (stream >> f)
+        this->filters.push_back(conduit_filter_for_name(f));
+
     check_reference_(sender);
     check_reference_(receiver);
 }

--- a/src/cpp/ymmsl/model.cpp
+++ b/src/cpp/ymmsl/model.cpp
@@ -56,12 +56,18 @@ Conduit::Conduit(
 Conduit::operator std::string() const {
     std::ostringstream oss;
 
-    oss << "Conduit(" << sender << " -> " << receiver << ")";
+    oss << "Conduit(" << sender;
+    if (!filters.empty()) {
+        oss << " ->";
+        for (auto & filter : filters)
+            oss << " " << conduit_filter_name(filter);
+    }
+    oss << " -> " << receiver << ")";
     return oss.str();
 }
 
 bool Conduit::operator==(Conduit const & rhs) const {
-    return sender == rhs.sender && receiver == rhs.receiver;
+    return sender == rhs.sender && receiver == rhs.receiver && filters == rhs.filters;
 }
 
 Reference Conduit::sending_component() const {

--- a/src/cpp/ymmsl/model.hpp
+++ b/src/cpp/ymmsl/model.hpp
@@ -7,6 +7,39 @@
 
 namespace ymmsl { namespace impl {
 
+/** Represents a filter to apply to messages passing through a conduit.
+ */
+enum ConduitFilter {
+    /** Pass only the last message and drop preceding ones. */
+    LAST,
+    /** Repeat a single message as often as needed. */
+    REPEAT,
+    /** Pass a single message and then generate nil-messages as needed. */
+    PAD
+};
+
+/** Return the name of the given conduit filter.
+ */
+std::string conduit_filter_name(ConduitFilter filter);
+
+/** Return the conduit filter from its name.
+ */
+ConduitFilter conduit_filter_for_name(std::string const & name);
+
+/** Return whether this filter is a reducer.
+ * 
+ * Reducers take one or more sent messages and filter them down to a single one for
+ * the recipient.
+ **/
+bool is_reducer(ConduitFilter filter);
+
+/** Return whether this filter is a repeater.
+ * 
+ * Repeaters take a single message and turn it into multiple to cover multiple
+ * receive attempts.
+ **/
+bool is_repeater(ConduitFilter filter);
+
 /** A conduit transports data between simulation components.
  *
  * A conduit has two endpoints, which are references to a Port on a Component.
@@ -21,6 +54,7 @@ namespace ymmsl { namespace impl {
 class Conduit {
     public:
         Reference sender, receiver;
+        std::vector<ConduitFilter> filters;
 
         /** Create a Conduit.
          *
@@ -28,8 +62,9 @@ class Conduit {
          *      including the component name and the port name.
          * @param receiver The receiving port that this conduit is connected
          *      to, including the component name and the port name.
+         * @param filters A string containing space-separated filter names.
          */
-        Conduit(std::string const & sender, std::string const & receiver);
+        Conduit(std::string const & sender, std::string const & receiver, std::string const & filters = {});
 
         /** Convert to string.
          */

--- a/src/cpp/ymmsl/model.hpp
+++ b/src/cpp/ymmsl/model.hpp
@@ -9,7 +9,7 @@ namespace ymmsl { namespace impl {
 
 /** Represents a filter to apply to messages passing through a conduit.
  */
-enum ConduitFilter {
+enum class ConduitFilter {
     /** Pass only the last message and drop preceding ones. */
     LAST,
     /** Repeat a single message as often as needed. */

--- a/src/cpp/ymmsl/tests/test_model.cpp
+++ b/src/cpp/ymmsl/tests/test_model.cpp
@@ -6,6 +6,7 @@
 
 
 using ymmsl::impl::Conduit;
+using ymmsl::impl::ConduitFilter;
 using ymmsl::impl::Identifier;
 using ymmsl::impl::ReferencePart;
 
@@ -46,5 +47,19 @@ TEST(ymmsl_model, conduit) {
     ASSERT_EQ(test_conduit3.receiving_component(), Identifier("a"));
     ASSERT_EQ(test_conduit3.receiving_port(), Identifier("b"));
     ASSERT_EQ(test_conduit3.receiving_slot(), std::vector<int>{3});
+
+    Conduit test_conduit4("a.b", "b.c", "last repeat pad");
+    ASSERT_EQ(test_conduit4.filters.size(), 3);
+    ASSERT_EQ(test_conduit4.filters[0], ConduitFilter::LAST);
+    ASSERT_EQ(test_conduit4.filters[1], ConduitFilter::REPEAT);
+    ASSERT_EQ(test_conduit4.filters[2], ConduitFilter::PAD);
+
+    ASSERT_TRUE(is_repeater(ConduitFilter::REPEAT));
+    ASSERT_TRUE(is_repeater(ConduitFilter::PAD));
+    ASSERT_FALSE(is_repeater(ConduitFilter::LAST));
+
+    ASSERT_FALSE(is_reducer(ConduitFilter::REPEAT));
+    ASSERT_FALSE(is_reducer(ConduitFilter::PAD));
+    ASSERT_TRUE(is_reducer(ConduitFilter::LAST));
 }
 

--- a/src/cpp/ymmsl/tests/test_model.cpp
+++ b/src/cpp/ymmsl/tests/test_model.cpp
@@ -53,6 +53,7 @@ TEST(ymmsl_model, conduit) {
     ASSERT_EQ(test_conduit4.filters[0], ConduitFilter::LAST);
     ASSERT_EQ(test_conduit4.filters[1], ConduitFilter::REPEAT);
     ASSERT_EQ(test_conduit4.filters[2], ConduitFilter::PAD);
+    ASSERT_EQ(std::string(test_conduit4), "Conduit(a.b -> last repeat pad -> b.c)");
 
     ASSERT_TRUE(is_repeater(ConduitFilter::REPEAT));
     ASSERT_TRUE(is_repeater(ConduitFilter::PAD));

--- a/src/cpp/ymmsl/ymmsl.hpp
+++ b/src/cpp/ymmsl/ymmsl.hpp
@@ -14,6 +14,7 @@ namespace ymmsl {
     using impl::operator_name;
     using impl::operator_for_name;
     using impl::Conduit;
+    using impl::ConduitFilter;
     using impl::Identifier;
     using impl::operator<<;
     using impl::Operator;

--- a/src/python/libmuscle/manager/mmp_server.py
+++ b/src/python/libmuscle/manager/mmp_server.py
@@ -50,7 +50,11 @@ def decode_port(data: list[str]) -> Port:
 
 def encode_conduit(conduit: Conduit) -> list[str]:
     """Convert a Conduit to a MsgPack-compatible value."""
-    return [str(conduit.sender), str(conduit.receiver)]
+    return [
+        str(conduit.sender),
+        str(conduit.receiver),
+        " ".join(f.value for f in conduit.filters),
+    ]
 
 
 def encode_ports(ports: Ports) -> list[list[str]]:

--- a/src/python/libmuscle/mmp_client.py
+++ b/src/python/libmuscle/mmp_client.py
@@ -302,7 +302,7 @@ class MMPClient:
         if response[0] == ResponseType.ERROR.value:
             raise RuntimeError(f"Error getting peers from manager: {response[1]}")
 
-        conduits = [Conduit(snd, recv) for snd, recv in response[1]]
+        conduits = [Conduit(snd, recv, filters) for snd, recv, filters in response[1]]
 
         peer_dimensions = {
             Reference(component): dims for component, dims in response[2].items()

--- a/src/python/libmuscle/peer_info.py
+++ b/src/python/libmuscle/peer_info.py
@@ -1,6 +1,6 @@
 from typing import Optional, cast
 
-from ymmsl.v0_2 import Conduit, Identifier, Port, Reference
+from ymmsl.v0_2 import Conduit, ConduitFilter, Identifier, Port, Reference
 
 from libmuscle.endpoint import Endpoint
 
@@ -41,28 +41,25 @@ class PeerInfo:
         self._index = index
         self._conduits = conduits
 
-        self._incoming_ports: list[Reference] = []
-        self._outgoing_ports: list[Reference] = []
-
         # peer port ids, indexed by local kernel.port id
         self._peers: dict[Reference, list[Reference]] = {}
+        self._filters_per_receiver: dict[Reference, list[ConduitFilter]] = {}
 
         for conduit in conduits:
-            if str(conduit.sending_component()) == str(kernel):
+            if conduit.sending_component() == kernel:
                 # we send on the port this conduit attaches to
-                if conduit.sender not in self._outgoing_ports:
-                    self._outgoing_ports.append(conduit.sender)
                 self._peers.setdefault(conduit.sender, []).append(conduit.receiver)
 
-            if str(conduit.receiving_component()) == str(kernel):
+            if conduit.receiving_component() == kernel:
                 # we receive on the port this conduit attaches to
                 if conduit.receiver in self._peers:
                     raise RuntimeError(
                         f'Receiving port "{conduit.receiving_port()}" is connected'
                         " by multiple conduits, but at most one is allowed."
                     )
-                self._incoming_ports.append(conduit.receiver)
                 self._peers[conduit.receiver] = [conduit.sender]
+
+            self._filters_per_receiver[conduit.receiver] = conduit.filters
 
         self._peer_dims = peer_dims  # indexed by kernel id
         self._peer_locations = peer_locations  # indexed by instance id
@@ -72,30 +69,6 @@ class PeerInfo:
         """list ports declared in the yMMSL configuration"""
         return self._ymmsl_ports
 
-    def list_incoming_ports(self) -> list[tuple[Identifier, Reference]]:
-        """list incoming ports.
-
-        Returns:
-            A list of tuples containing a port id and a reference to the
-            peer endpoint.
-        """
-        return [
-            (cast(Identifier, port_ref[-1]), self._peers[port_ref][0])
-            for port_ref in self._incoming_ports
-        ]
-
-    def list_outgoing_ports(self) -> list[tuple[Identifier, list[Reference]]]:
-        """list outgoing ports.
-
-        Returns:
-            A list of tuples containing a port id and a list of references
-            to the peer endpoint(s).
-        """
-        return [
-            (cast(Identifier, port_ref[-1]), self._peers[port_ref])
-            for port_ref in self._outgoing_ports
-        ]
-
     def is_connected(self, port: Identifier) -> bool:
         """Determine whether the given port is connected.
 
@@ -104,6 +77,10 @@ class PeerInfo:
         """
         recv_port_full = self._kernel + port
         return recv_port_full in self._peers
+
+    def get_filters_for_receiver(self, receiver: Reference) -> list[ConduitFilter]:
+        """Get the conduit filters for a receiver (component + port name)"""
+        return self._filters_per_receiver[receiver]
 
     def get_peer_ports(self, port: Identifier) -> list[Reference]:
         """Get a reference for the peer ports.

--- a/src/python/libmuscle/test/test_mmp_client.py
+++ b/src/python/libmuscle/test/test_mmp_client.py
@@ -130,10 +130,7 @@ def test_request_peers(mocked_mmp_client, profile_data) -> None:
     assert peer_info._conduits[0].sender == "component.out"
     assert peer_info._conduits[0].receiver == "other.in"
 
-    assert peer_info._incoming_ports == []
-    assert peer_info._outgoing_ports == [Reference("component.out")]
     assert peer_info._peers == {"component.out": ["other.in"]}
-
     assert peer_info._peer_dims == {"other": [20]}
     assert peer_info._peer_locations == {"other": ["direct:test", "tcp:test"]}
 

--- a/src/python/libmuscle/test/test_mmp_client.py
+++ b/src/python/libmuscle/test/test_mmp_client.py
@@ -105,7 +105,7 @@ def test_request_peers(mocked_mmp_client, profile_data) -> None:
 
     result_msg = [
         ResponseType.SUCCESS.value,
-        [["component.out", "other.in"]],
+        [["component.out", "other.in", ""]],
         {"other": [20]},
         {"other": ["direct:test", "tcp:test"]},
         [["out", "O_F", ""]],


### PR DESCRIPTION
- Add ConduitFilters to C++ ymmsl API
- Muscle Manager now sends the configured conduit filters for each Conduit to the instances.
- Instances store the conduit filters in PeerInfo