### PR TITLE
Implement repeater conduit filters

### DIFF
--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -50,7 +50,7 @@ def ls_snapshots(run_dir, instance=None):
     )
 
 
-def _python_wrapper(tmpdir, instance_name, muscle_manager, callable):
+def _python_wrapper(tmpdir, instance_name, muscle_manager, callable, *args):
     sys.argv.append(f"--muscle-instance={instance_name}")
     sys.argv.append(f"--muscle-manager={muscle_manager}")
 
@@ -70,7 +70,7 @@ def _python_wrapper(tmpdir, instance_name, muscle_manager, callable):
             root_logger.setLevel(logging.DEBUG)
 
             try:
-                callable()
+                callable(*args)
             except Exception as e:
                 root_logger.exception(e)
                 raise
@@ -88,8 +88,9 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
             Language can be ``"python"``, ``"cpp"``, ``"mpi_cpp"`` or ``"fortran"``.
             Details differ per language.
 
-            For python actors, details is a single callable which is executed
-            in a ``multiprocessing.Process``.
+            For python actors, details is a callable which is executed
+            in a ``multiprocessing.Process``. Additional positional arguments can be
+            supplied as well.
 
             For cpp actors, details is an executable path with optional arguments.
             The executable paths are assumed to be relative to
@@ -129,7 +130,7 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
                 # start python actor
                 proc = mp.Process(
                     target=_python_wrapper,
-                    args=(tmpdir, instance_name, env["MUSCLE_MANAGER"], actor),
+                    args=(tmpdir, instance_name, env["MUSCLE_MANAGER"], actor, *args),
                     name=instance_name,
                 )
                 proc.start()

--- a/integration_test/test_filters.py
+++ b/integration_test/test_filters.py
@@ -1,0 +1,127 @@
+import pytest
+from ymmsl.v0_2 import Operator
+
+from libmuscle import Instance, Message
+
+from .conftest import run_manager_with_actors
+
+
+def macro() -> None:
+    instance = Instance({Operator.O_I: ["out"]})
+
+    while instance.reuse_instance():
+        for i in range(4):
+            instance.send("out", Message(i, data=["macro", i]))
+
+
+def meso() -> None:
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_I: ["out"]})
+
+    reused = 0
+    while instance.reuse_instance():
+        msg = instance.receive("in")
+        for i in range(reused):
+            instance.send("out", Message(i, data=msg.data + ["meso", i]))
+        reused += 1
+
+
+def micro() -> None:
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_I: ["out"]})
+
+    while instance.reuse_instance():
+        msg = instance.receive("in")
+        for i in range(2):
+            instance.send("out", Message(i, data=msg.data + ["micro", i]))
+
+
+def pico(filters: str) -> None:
+    print("Running with conduit filter:", filters)
+    instance = Instance({Operator.F_INIT: ["macro", "meso", "micro"]})
+
+    reused = 0
+    expected_counts = [
+        [1, 0, 0],
+        [1, 0, 1],
+        [2, 0, 0],
+        [2, 0, 1],
+        [2, 1, 0],
+        [2, 1, 1],
+        [3, 0, 0],
+        [3, 0, 1],
+        [3, 1, 0],
+        [3, 1, 1],
+        [3, 2, 0],
+        [3, 2, 1],
+    ]
+    while instance.reuse_instance():
+        macro = instance.receive("macro")
+        meso = instance.receive("meso")
+        micro = instance.receive("micro")
+
+        print("Received:", macro.data, meso.data, micro.data)
+        message_counts = micro.data[1::2]
+        assert message_counts == expected_counts[reused]
+
+        # Test if macro message is padded or repeated, based on conduit filter filters
+        if filters == "pad pad" and any(message_counts[1:]):
+            assert macro.data is None
+        elif filters == "repeat pad" and message_counts[-1]:
+            assert macro.data is None
+        else:
+            assert macro.data == micro.data[:2]
+
+        assert micro.data[:4] == meso.data
+
+        assert micro.data[1::2] == expected_counts[reused]
+        reused += 1
+
+    assert reused == len(expected_counts)
+
+
+config = """
+ymmsl_version: v0.2
+models:
+  repeaters:
+    components:
+      macro:
+        description: macro
+        ports:
+          o_i: out
+        implementation: macro
+      meso:
+        description: meso
+        ports:
+          f_init: in
+          o_i: out
+        implementation: meso
+      micro:
+        description: micro
+        ports:
+          f_init: in
+          o_i: out
+        implementation: micro
+      pico:
+        description: pico
+        ports:
+          f_init: macro meso micro
+        implementation: pico
+    conduits:
+      macro.out:
+      - meso.in
+      - {filters} pico.macro
+      meso.out:
+      - micro.in
+      - repeat pico.meso
+      micro.out: pico.micro
+"""
+
+
+@pytest.mark.parametrize("filters", ["repeat repeat", "repeat pad", "pad pad"])
+def test_repeater_filters(tmp_path, filters):
+    actors = {
+        "macro": ("python", macro),
+        "meso": ("python", meso),
+        "micro": ("python", micro),
+        "pico": ("python", pico, filters),
+    }
+    run_manager_with_actors(config.format(filters=filters), tmp_path, actors)

--- a/integration_test/test_filters.py
+++ b/integration_test/test_filters.py
@@ -3,7 +3,7 @@ from ymmsl.v0_2 import Operator
 
 from libmuscle import Instance, Message
 
-from .conftest import run_manager_with_actors
+from .conftest import run_manager_with_actors, skip_if_python_only
 
 
 def macro() -> None:
@@ -123,5 +123,17 @@ def test_repeater_filters(tmp_path, filters):
         "meso": ("python", meso),
         "micro": ("python", micro),
         "pico": ("python", pico, filters),
+    }
+    run_manager_with_actors(config.format(filters=filters), tmp_path, actors)
+
+
+@skip_if_python_only
+@pytest.mark.parametrize("filters", ["repeat repeat", "repeat pad", "pad pad"])
+def test_repeater_filters_cpp(tmp_path, filters):
+    actors = {
+        "macro": ("python", macro),
+        "meso": ("python", meso),
+        "micro": ("python", micro),
+        "pico": ("cpp", "conduit_filters_test", filters),
     }
     run_manager_with_actors(config.format(filters=filters), tmp_path, actors)

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -33,6 +33,44 @@ using ymmsl::Settings;
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 
+namespace {
+
+/** Helper method to construct a Message from an MPPMessage.
+ * 
+ * N.B. since C++ enforces only const access to .settings and .data, we don't need to
+ * make a copy (unlike the Python equivalent).
+ */
+Message make_message(MPPMessage const & mpp_msg) {
+    Message message(
+        mpp_msg.timestamp,
+        mpp_msg.data,
+        mpp_msg.settings_overlay.as<Settings>()
+    );
+    if (mpp_msg.next_timestamp.is_set())
+        message.set_next_timestamp(mpp_msg.next_timestamp.get());
+    return message;
+}
+
+
+/** Helper template method to execute code for each slot of the given port.
+ * 
+ * Expects a function with arguments (Optional<int> slot, Reference port_ref)
+ */
+template<typename F>
+void for_each_slot(Port const & port, F&& f) {
+    Reference port_name(port.name);
+    if (!port.is_vector()) {
+        f({}, port_name);
+    } else {
+        int slot = 0; // Allow pre-receive to receive 1 message that updates port._length
+        do {
+            f(slot, port_name + slot);  
+        } while (++slot < port.get_length());
+    }
+}
+
+}
+
 Communicator::Communicator(
         ymmsl::Reference const & kernel,
         std::vector<int> const & index,
@@ -47,6 +85,8 @@ Communicator::Communicator(
     , server_()
     , clients_()
     , receive_timeout_(10.0)  // Notify manager, by default, after 10 seconds waiting in receive_message()
+    , f_init_repeaters_()
+    , f_init_repeat_cache_()
 {}
 
 std::vector<std::string> Communicator::get_locations() const {
@@ -56,6 +96,7 @@ std::vector<std::string> Communicator::get_locations() const {
 void Communicator::set_peer_info(PeerInfo const & peer_info) {
     peer_info_ = peer_info;
     timeline_manager_ = std::make_unique<TimelineManager>(port_manager_);
+    prepare_conduit_filters_();
 }
 
 void Communicator::finish_reuse_iteration() {
@@ -136,30 +177,48 @@ void Communicator::send_message(
 
 Communicator::FInitCacheType Communicator::pre_receive_f_init() {
     FInitCacheType cache;
+    std::unordered_map<::ymmsl::Reference, IterationCount> iterations;
 
-    auto pre_receive = [&](std::string & port_name, Optional<int> slot) {
-        Reference port_ref(port_name);
-        if (slot.is_set())
-            port_ref += slot.get();
-        
-        auto msg = receive_message_(port_name, slot);
-        cache.emplace(port_ref, msg);
-    };
-
+    // Pre-receive on ports without repeater filters:
     for (Port const & port : port_manager_.get_connected_ports(Operator::F_INIT, {})) {
         std::string port_name(port.name);
-        log_debug("Pre-receiving on port ", port_name);
-        if (!port.is_vector())
-            pre_receive(port_name, {});
-        else {
-            pre_receive(port_name, 0);
-            // The above receives the length, if needed, so now we can get the rest.
-            for (int slot = 1; slot < port.get_length(); ++slot)
-                pre_receive(port_name, slot);
+        if (f_init_repeaters_.count(port.name) == 0) {
+            log_debug("Pre-receiving on port ", port_name);
+            for_each_slot(port, [&](Optional<int> slot, Reference port_ref){
+                auto mpp_message = receive_message_(port_name, slot);
+                cache.emplace(port_ref, make_message(mpp_message));
+                iterations.emplace(port_ref, mpp_message.iteration);
+            });
         }
     }
 
     // Check if we have received milestones
+    auto milestone = verify_received_milestones_(cache);
+    if (milestone.is_set()) {
+        // Propagate milestone
+        broadcast_milestone_(milestone.get(), false);
+        if (milestone.get().is_final_milestone())  // Final milestone received
+            throw PortClosed();
+        // Clean up stale messages from the cache
+        IterationCount const milestone_iteration = milestone.get().iteration();
+        for (auto it = f_init_repeat_cache_.begin(); it != f_init_repeat_cache_.end(); ) {
+            if (it->second.iteration.size() >= milestone_iteration.size())
+                it = f_init_repeat_cache_.erase(it);
+            else
+                ++it;
+        }
+        // Pre-receive again to receive the actual messages
+        return pre_receive_f_init();
+    }
+
+    // Verify that all F_INIT messages agree on the iteration count
+    auto & cur_iteration = timeline_manager_->check_f_init_iterations(iterations);
+    // Put messages from repeater ports in the cache:
+    pre_receive_f_init_with_repeaters_(cur_iteration, cache);
+    return cache;
+}
+
+Optional<Milestone> Communicator::verify_received_milestones_(FInitCacheType const & cache) {
     std::vector<Optional<IterationCount>> milestone_iterations;
     std::vector<std::string> closed_ports;
     for (auto & item : cache) {
@@ -195,44 +254,90 @@ Communicator::FInitCacheType Communicator::pre_receive_f_init() {
             "report an issue."
         );
     }
-    if (milestone_iterations.at(0).is_set()) {
-        // Propagate milestone
-        Milestone milestone(milestone_iterations.at(0).get());
-        broadcast_milestone_(milestone, false);
-        if (milestone_iterations.at(0).get().empty())  // Final milestone received
-            throw PortClosed();
-        // Pre-receive again to receive the actual messages
-        return pre_receive_f_init();
-    }
+    if (milestone_iterations[0].is_set())
+        return Milestone(milestone_iterations[0].get());
+    return {};
+}
 
-    return cache;
+void Communicator::pre_receive_f_init_with_repeaters_(
+        IterationCount const & cur_iteration, FInitCacheType & cache)
+{
+    for (auto & item : f_init_repeaters_) {
+        auto & port_name = item.first;
+        auto & filters = item.second;
+        auto & port = port_manager_.get_port(port_name);
+
+        // If the message is not in the cache we need to receive again. We may need
+        // to receive and discard multiple messages here, see the tests
+        // (test_repeater_filters_discard_messages) for a scenario.
+        Reference port_ref(port_name);
+        if (port.is_vector())
+            port_ref += 0;
+        while (f_init_repeat_cache_.count(port_ref) == 0) {
+            log_debug("Pre-receiving on port ", port_name);
+            for_each_slot(port, [&](Optional<int> recv_slot, Reference recv_port_ref) {
+                auto mpp_msg = receive_message_(port_name, recv_slot);
+                if (is_subiteration(cur_iteration, mpp_msg.iteration)) {
+                    f_init_repeat_cache_.emplace(recv_port_ref, mpp_msg);
+                } else if(mpp_msg.iteration > cur_iteration) {
+                    throw std::runtime_error(
+                        "Internal error: Received a message from the future on "
+                        + port_desc(port_name, recv_slot) + ". Message iteration is "
+                        + to_string(mpp_msg.iteration) + ", while ours is " + to_string(cur_iteration) + "."
+                    );
+                }
+            });
+        }
+
+        // Repeat or pad the cached messages
+        bool pad_message = false;
+        std::size_t offset = cur_iteration.size() - filters.size();
+        for (std::size_t i = 0; i < filters.size(); ++i) {
+            if (filters[i] == ::ymmsl::ConduitFilter::PAD && cur_iteration[offset + i] > 0)
+                pad_message = true;
+        }
+        for_each_slot(port, [&](Optional<int> slot, Reference port_ref) {
+            auto & mpp_msg = f_init_repeat_cache_.at(port_ref);
+            if (!is_subiteration(cur_iteration, mpp_msg.iteration))
+                throw std::runtime_error(
+                    "Internal error: Invalid cached message for "
+                    + port_desc(port_name, slot) + ". Cached message iteration is "
+                    + to_string(mpp_msg.iteration) + ", while ours is " + to_string(cur_iteration) + "."
+                );
+            auto message = make_message(mpp_msg);
+            if (pad_message)
+                message.set_data(Data());
+            cache.emplace(port_ref, message);
+        });
+    }
 }
 
 Message Communicator::receive_s_message(
         std::string const & port_name,
         Optional<int> slot)
 {
+    timeline_manager_->check_receive_s(port_name, slot);
     // Instance should not need to bother about milestones, so we keep receiving
     // messages until we have actual data.
     while (true) {
         auto message = receive_message_(port_name, slot);
-        if (is_milestone(message.data())) {
-            if (Milestone(message.data()).is_final_milestone())
+        if (is_milestone(message.data)) {
+            if (Milestone(message.data).is_final_milestone())
                 throw PortClosed();
             // TODO: handle milestone, if needed
         } else {
-            return message;
+            timeline_manager_->record_received_s_message(
+                    port_name, slot, message.iteration);
+            return make_message(message);
         }
     }
 }
 
 
-Message Communicator::receive_message_(
+MPPMessage Communicator::receive_message_(
         std::string const & port_name,
         Optional<int> slot)
 {
-    timeline_manager_->check_receive(port_name, slot);
-
     Port & port = port_manager_.get_port(port_name);
     std::string port_and_slot = port_desc(port_name, slot);
     log_debug("Waiting for message on ", port_and_slot);
@@ -259,7 +364,6 @@ Message Communicator::receive_message_(
             port.get_num_messages(), msg.size());
 
     auto mpp_message = MPPMessage::from_bytes(msg);
-    Settings overlay_settings(mpp_message.settings_overlay.as<Settings>());
 
     recv_decode_event.stop();
 
@@ -272,26 +376,20 @@ Message Communicator::receive_message_(
             port.set_closed(slot);
     }
 
-    Message message(
-            mpp_message.timestamp, mpp_message.data, overlay_settings);
-
-    if (mpp_message.next_timestamp.is_set())
-        message.set_next_timestamp(mpp_message.next_timestamp.get());
-
     ProfileTimestamp start_recv, end_wait, end_transfer;
     std::tie(start_recv, end_wait, end_transfer) = std::get<1>(msg_and_profile);
     ProfileEvent recv_wait_event(
             ProfileEventType::receive_wait, start_recv,
             end_wait, port, mpp_message.port_length, slot,
-            port.get_num_messages(), msg.size(), message.timestamp());
+            port.get_num_messages(), msg.size(), mpp_message.timestamp);
 
     ProfileEvent recv_xfer_event(
             ProfileEventType::receive_transfer, end_wait,
             end_transfer, port, mpp_message.port_length, slot,
-            port.get_num_messages(), msg.size(), message.timestamp());
+            port.get_num_messages(), msg.size(), mpp_message.timestamp);
 
-    recv_decode_event.message_timestamp = message.timestamp();
-    receive_event.message_timestamp = message.timestamp();
+    recv_decode_event.message_timestamp = mpp_message.timestamp;
+    receive_event.message_timestamp = mpp_message.timestamp;
 
     if (port.is_vector()) {
         receive_event.port_length = port.get_length();
@@ -331,8 +429,6 @@ Message Communicator::receive_message_(
     if (!is_milestone(mpp_message.data)) {
         port.increment_num_messages(slot);
         log_debug("Received message on ", port_and_slot);
-        timeline_manager_->record_received_message(
-                port_name, slot, mpp_message.iteration.get());
     } else {
         Milestone milestone(mpp_message.data);
         if (milestone.is_final_milestone())
@@ -340,7 +436,7 @@ Message Communicator::receive_message_(
         else
             log_debug("Received ", std::string(milestone), " on ", port_and_slot);
     }
-    return message;
+    return mpp_message;
 }
 
 void Communicator::shutdown() {
@@ -474,6 +570,32 @@ void Communicator::close_incoming_ports_() {
 void Communicator::close_ports_() {
     close_outgoing_ports_();
     close_incoming_ports_();
+}
+
+void Communicator::prepare_conduit_filters_() {
+    // F_INIT repeat/pad filters
+    for (Port const & port : port_manager_.get_connected_ports(Operator::F_INIT, {})) {
+        std::vector<::ymmsl::ConduitFilter> filters = peer_info_.get().get_filters_for_receiver(kernel_ + port.name);
+        // Only keep the repeater filters, the sending component handles reducers:
+        filters.erase(
+            std::remove_if(filters.begin(), filters.end(), ::ymmsl::is_reducer),
+            filters.end());
+        if (!filters.empty())
+            f_init_repeaters_.emplace(port.name, filters);
+    }
+    // S repeat/pad filters are not implemented
+    for (Port const & port : port_manager_.get_connected_ports(Operator::S, {})) {
+        std::vector<::ymmsl::ConduitFilter> filters = peer_info_.get().get_filters_for_receiver(kernel_ + port.name);
+        // Only keep the repeater filters, the sending component handles reducers:
+        for (auto & filter: filters) {
+            if (is_repeater(filter))
+                throw std::runtime_error(
+                    "Repeater filters are not implemented for S ports, you may connect "
+                    "the conduit to an F_INIT port instead."
+                );
+        }
+    }
+    // TODO: reducer filters
 }
 
 } }

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -9,6 +9,7 @@
 #include <libmuscle/mmp_client.hpp>
 #include <libmuscle/mpp_client.hpp>
 #include <libmuscle/mpp_server.hpp>
+#include <libmuscle/mpp_message.hpp>
 #include <libmuscle/namespace.hpp>
 #include <libmuscle/peer_info.hpp>
 #include <libmuscle/port.hpp>
@@ -45,6 +46,7 @@ class Communicator {
     public:
         using PortMessageCounts = std::unordered_map<std::string, std::vector<int>>;
         using FInitCacheType = std::unordered_map<::ymmsl::Reference, Message>;
+        using MPPCacheType = std::unordered_map<::ymmsl::Reference, MPPMessage>;
 
         /** Create a Communicator.
          *
@@ -101,6 +103,8 @@ class Communicator {
                 Optional<int> slot = {});
 
         /** Receive on all connected F_INIT port (including muscle_settings_in).
+         * 
+         * This method assumes that there is at least one connected F_INIT port.
          * 
          * @return The received messages.
          */
@@ -162,9 +166,22 @@ class Communicator {
     PRIVATE:
         using Ports_ = std::unordered_map<std::string, Port>;
 
+        /** Check if the received messages have consistent milestones.
+         * 
+         * @return Unset if no milestones were received, the received milestone otherwise.
+         */
+        Optional<Milestone> verify_received_milestones_(FInitCacheType const & cache);
+
+        /** Handle pre-receive F_INIT for ports with repeater filters.
+         * 
+         * @param cur_iteration Iteration count for the new reuse loop.
+         * @param cache F_INIT cache to add messages to.
+         */
+        void pre_receive_f_init_with_repeaters_(IterationCount const & cur_iteration, FInitCacheType & cache);
+
         /** Implementation for receive_message.
          */
-        Message receive_message_(
+        MPPMessage receive_message_(
                 std::string const & port_name,
                 Optional<int> slot = {}
                 );
@@ -217,6 +234,11 @@ class Communicator {
          */
         void close_ports_();
 
+        /** Check which ports are connected with a conduit filter and initialize the
+         *  associated logic.
+         */
+        void prepare_conduit_filters_();
+
         ymmsl::Reference kernel_;
         std::vector<int> index_;
         PortManager & port_manager_;
@@ -227,6 +249,11 @@ class Communicator {
         Optional<PeerInfo> peer_info_;
         double receive_timeout_;
         std::unique_ptr<TimelineManager> timeline_manager_;
+        
+        /** List of repeater filters to be applied to each F_INIT port. */
+        std::unordered_map<std::string, std::vector<::ymmsl::ConduitFilter>> f_init_repeaters_;
+        /** Message cache for F_INIT ports with repeater filters. */
+        MPPCacheType f_init_repeat_cache_;
 };
 
 } }

--- a/src/cpp/libmuscle/mpp_message.hpp
+++ b/src/cpp/libmuscle/mpp_message.hpp
@@ -69,7 +69,7 @@ class MPPMessage {
         DataConstRef settings_overlay;
         int message_number;
         DataConstRef data;
-        Optional<IterationCount> iteration;
+        IterationCount iteration;
 
     private:
         static MPPMessage from_dict_(DataConstRef const & dict);

--- a/src/cpp/libmuscle/tests/conduit_filters_test.cpp
+++ b/src/cpp/libmuscle/tests/conduit_filters_test.cpp
@@ -1,0 +1,70 @@
+/* This is a part of the integration test suite, and is run from a Python
+ * test in /integration_test. It is not a unit test.
+ */
+#include <cassert>
+#include <iostream>
+
+#include <libmuscle/libmuscle.hpp>
+#include <ymmsl/ymmsl.hpp>
+
+
+using libmuscle::Data;
+using libmuscle::DataConstRef;
+using libmuscle::Instance;
+using libmuscle::Message;
+using ymmsl::Operator;
+
+// See corresponding Python actor in integration_test/test_filters
+void pico(int argc, char * argv[]) {
+    if (argc < 2) throw std::runtime_error("Missing filters argument");
+    std::string filters = std::string(argv[1]);
+    std::cout << "Running with conduit filter: '" << filters << "'" << std::endl;
+    assert(filters == "pad pad" || filters == "repeat pad" || filters == "repeat repeat");
+
+    Instance instance(argc, argv, {{Operator::F_INIT, {"macro", "meso", "micro"}}});
+
+    int reused = 0;
+    std::vector<std::vector<int>> expected_counts{
+        {1, 0, 0},
+        {1, 0, 1},
+        {2, 0, 0},
+        {2, 0, 1},
+        {2, 1, 0},
+        {2, 1, 1},
+        {3, 0, 0},
+        {3, 0, 1},
+        {3, 1, 0},
+        {3, 1, 1},
+        {3, 2, 0},
+        {3, 2, 1}
+    };
+    while (instance.reuse_instance()) {
+        auto macro = instance.receive("macro");
+        auto meso = instance.receive("meso");
+        auto micro = instance.receive("micro");
+
+        std::vector<int> message_counts{
+            micro.data()[1].as<int>(),
+            micro.data()[3].as<int>(),
+            micro.data()[5].as<int>()};
+        assert(message_counts == expected_counts[reused]);
+
+        if (filters == "pad pad" && (message_counts[1] || message_counts[2])) {
+            assert(macro.data().is_nil());
+        } else if (filters == "repeat pad" && message_counts[2]) {
+            assert(macro.data().is_nil());
+        } else {
+            assert(macro.data()[0].as<std::string>() == micro.data()[0].as<std::string>());
+            assert(macro.data()[1].as<int>() == micro.data()[1].as<int>());
+        }
+
+        ++reused;
+    }
+    assert(reused == expected_counts.size());
+}
+
+int main(int argc, char * argv[]) {
+    pico(argc, argv);
+    return EXIT_SUCCESS;
+}
+

--- a/src/cpp/libmuscle/tests/fixtures.hpp
+++ b/src/cpp/libmuscle/tests/fixtures.hpp
@@ -203,8 +203,6 @@ struct TimelineStateFixture {
         TimelineStateFixture() {
             timeline_state_.iteration = IterationCount({1});
             timeline_state_.send_participated = {};
-            timeline_state_.receive_participated = {
-                    PortAndSlot("in", OptionalSlot())};
             timeline_state_.subtimeline_states = {};
         }
 };

--- a/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
@@ -17,9 +17,10 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
     public:
         MockTimelineManager(ReturnValue) {
             NAME_MOCK_MEM_FUN(MockTimelineManager, constructor);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, check_f_init_iterations);
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_send_message);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_message);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive_s);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_s_message);
             NAME_MOCK_MEM_FUN(MockTimelineManager, reset);
             NAME_MOCK_MEM_FUN(MockTimelineManager, finish_reuse_iteration);
             NAME_MOCK_MEM_FUN(MockTimelineManager, get_state);
@@ -38,14 +39,18 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
         MockFun<Void, Obj<PortManager const *>> constructor;
 
         MockFun<
+            Val<IterationCount const &>,
+            Val<std::unordered_map<::ymmsl::Reference, IterationCount>>> check_f_init_iterations;
+
+        MockFun<
             Val<IterationCount>, Val<std::string const &>,
             Val<Optional<int>>> check_send_message;
 
-        MockFun<Void, Val<std::string const &>, Val<Optional<int>>> check_receive;
+        MockFun<Void, Val<std::string const &>, Val<Optional<int>>> check_receive_s;
 
         MockFun<
             Void, Val<std::string const &>, Val<Optional<int>>,
-            Val<IterationCount const &>> record_received_message;
+            Val<IterationCount const &>> record_received_s_message;
 
         MockFun<Void> reset;
 

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -134,6 +134,7 @@ struct libmuscle_communicator2 : libmuscle_communicator {
         // disable receive timeouts for these tests, so we can check call
         // signatures: mpp_client->receive.called_with(..., nullptr)
         connected_communicator_.set_receive_timeout(-1.0);
+        connected_communicator_.timeline_manager_->check_f_init_iterations.return_value = IterationCount({});
     }
 };
 
@@ -171,8 +172,7 @@ TEST_F(libmuscle_communicator2, send_message) {
     ASSERT_EQ(overlay["s0"].as<int64_t>(), 0);
     ASSERT_EQ(overlay["s1"].as<std::string>(), "1");
     ASSERT_EQ(encoded_msg.data.as<std::string>(), "test");
-    ASSERT_TRUE(encoded_msg.iteration.is_set());
-    ASSERT_EQ(encoded_msg.iteration.get(), IterationCount({2, 0}));
+    ASSERT_EQ(encoded_msg.iteration, IterationCount({2, 0}));
 }
 
 TEST_F(libmuscle_communicator2, send_message_disconnected) {

--- a/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
@@ -1,0 +1,285 @@
+// Inject mocks
+#define LIBMUSCLE_MOCK_LOGGER <mocks/mock_logger.hpp>
+#define LIBMUSCLE_MOCK_MMP_CLIENT <mocks/mock_mmp_client.hpp>
+#define LIBMUSCLE_MOCK_MPP_CLIENT <mocks/mock_mpp_client.hpp>
+#define LIBMUSCLE_MOCK_MPP_SERVER <mocks/mock_mpp_server.hpp>
+#define LIBMUSCLE_MOCK_PROFILER <mocks/mock_profiler.hpp>
+
+// into the real implementation under test
+#include <ymmsl/ymmsl.hpp>
+
+#include <libmuscle/data.cpp>   // needs to be above milestone.cpp
+#include <libmuscle/communicator.cpp>
+#include <libmuscle/endpoint.cpp>
+#include <libmuscle/mark.cpp>
+#include <libmuscle/mcp/data_pack.cpp>
+#include <libmuscle/mpp_message.cpp>
+#include <libmuscle/mcp/tcp_util.cpp>
+#include <libmuscle/mcp/transport_client.cpp>
+#include <libmuscle/message.cpp>
+#include <libmuscle/milestone.cpp>
+#include <libmuscle/peer_info.cpp>
+#include <libmuscle/port.cpp>
+#include <libmuscle/profiling.cpp>
+#include <libmuscle/receive_timeout_handler.cpp>
+#include <libmuscle/timeline_manager.cpp>
+#include <libmuscle/timestamp.cpp>
+#include <libmuscle/util.cpp>
+
+// Test code dependencies
+#include <memory>
+#include <stdexcept>
+#include <gtest/gtest.h>
+#include <libmuscle/communicator.hpp>
+#include <libmuscle/namespace.hpp>
+#include <mocks/mock_mmp_client.hpp>
+#include <mocks/mock_mpp_client.hpp>
+#include <mocks/mock_mpp_server.hpp>
+#include <mocks/mock_logger.hpp>
+#include <mocks/mock_profiler.hpp>
+
+
+int main(int argc, char *argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+
+using libmuscle::_MUSCLE_IMPL_NS::encode_iteration;
+using libmuscle::_MUSCLE_IMPL_NS::Communicator;
+using libmuscle::_MUSCLE_IMPL_NS::DataConstRef;
+using libmuscle::_MUSCLE_IMPL_NS::IterationCount;
+using libmuscle::_MUSCLE_IMPL_NS::MPPMessage;
+using libmuscle::_MUSCLE_IMPL_NS::MockLogger;
+using libmuscle::_MUSCLE_IMPL_NS::MockProfiler;
+using libmuscle::_MUSCLE_IMPL_NS::MockMMPClient;
+using libmuscle::_MUSCLE_IMPL_NS::MockMPPClient;
+using libmuscle::_MUSCLE_IMPL_NS::MockMPPServer;
+using libmuscle::_MUSCLE_IMPL_NS::PeerInfo;
+using libmuscle::_MUSCLE_IMPL_NS::PortClosed;
+using libmuscle::_MUSCLE_IMPL_NS::PortManager;
+using libmuscle::_MUSCLE_IMPL_NS::mcp::ProfileData;
+using libmuscle::_MUSCLE_IMPL_NS::mcp::TimeoutHandler;
+
+using ymmsl::Conduit;
+using ymmsl::ConduitFilter;
+using ymmsl::Operator;
+using ymmsl::Port;
+
+struct libmuscle_repeater_communicator
+    : ::testing::TestWithParam<std::string>
+{
+    RESET_MOCKS(MockLogger, MockMMPClient, MockMPPClient, MockMPPServer, MockProfiler);
+    
+    MockProfiler profiler_;
+    MockMMPClient manager_;
+
+    PortManager port_manager_;
+    Communicator communicator_;
+
+    libmuscle_repeater_communicator()
+        : port_manager_({}, {})
+        , communicator_("component", {}, port_manager_, profiler_, manager_)
+    {
+        std::string repeat_filter = GetParam();
+        PeerInfo peer_info(
+            "component",
+            {},
+            {
+                Conduit("parent1.out", "component.unfiltered"),
+                Conduit("parent2.out", "component.repeated", repeat_filter),
+                Conduit("parent2.out", "component.twicerepeated", repeat_filter + " " + repeat_filter)
+            },
+            {{"parent1", {}}, {"parent2", {}}, {"parent3", {}}},
+            {{"parent1", {}}, {"parent2", {}}, {"parent3", {}}},
+            {
+                Port("unfiltered", Operator::F_INIT),
+                Port("repeated", Operator::F_INIT),
+                Port("twicerepeated", Operator::F_INIT)
+            }
+        );
+        port_manager_.connect_ports(peer_info);
+        communicator_.set_peer_info(peer_info);
+    }
+
+    void TearDown() override {
+        communicator_.shutdown();
+    }
+};
+
+class IterationOrMilestone {
+    public:
+        IterationCount iteration;
+        bool is_milestone;
+};
+
+IterationOrMilestone M(IterationCount iteration) {
+    return {iteration, true};
+}
+
+IterationOrMilestone I(IterationCount iteration) {
+    return {iteration, false};
+}
+
+
+
+/** Helper method to mock MPPClient.receiev ,so it gives data with correct message
+ * numbers and iteration counts.
+ */
+void mock_receive_messages(
+    std::unordered_map<Reference, std::vector<IterationOrMilestone>> const & data)
+{
+    std::unordered_map<Reference, int> idx_per_port;
+    std::unordered_map<Reference, int> num_per_port;
+
+    for (auto & item : data) {
+        idx_per_port.emplace(item.first, 0);
+        num_per_port.emplace(item.first, 0);
+    }
+
+    // Capture a copy of the data, the local variables go out-of-scope at the end of
+    // this method:
+    MockMPPClient::return_value.receive.side_effect = [data, idx_per_port, num_per_port](
+            Reference ref, TimeoutHandler *handler
+        ) mutable -> std::tuple<std::vector<char>, ProfileData>
+    {
+        int & idx = idx_per_port.at(ref);
+        int & num = num_per_port.at(ref);
+        auto iteration_or_milestone = data.at(ref).at(idx);
+        auto & iteration = iteration_or_milestone.iteration;
+
+        DataConstRef dcr = iteration_or_milestone.is_milestone ? 
+            DataConstRef(Milestone(iteration)) : DataConstRef(encode_iteration(iteration));
+
+        MPPMessage msg("snd", "recv", {}, 0.0, {}, Settings(), num, dcr, iteration);
+        auto encoded = msg.encoded();
+
+        ++idx;
+        if (!iteration_or_milestone.is_milestone) ++num;
+        return {encoded, ProfileData()};
+    };
+}
+
+
+TEST_P(libmuscle_repeater_communicator, repeater_filters) {
+    mock_receive_messages({
+        {"component.twicerepeated", {
+            I({}), M({})
+        }},
+        {"component.repeated", {
+            I({0}), I({1}), I({2}), M({})
+        }},
+        {"component.unfiltered", {
+            I({0, 0}),
+            I({0, 1}),
+            M({0}),
+            // parent is allowed to send 0 messages on its O_I port in an iteration
+            M({1}),
+            I({2, 0}),
+            M({2}),
+            M({})
+        }}
+    });
+
+    bool is_padded = GetParam() == "pad";
+
+    auto cache = communicator_.pre_receive_f_init();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({0, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({0}));
+    ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive_f_init();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({0, 1}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("repeated").data().is_nil());
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({0}));
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive_f_init();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    ASSERT_THROW(communicator_.pre_receive_f_init(), PortClosed);
+}
+
+TEST_P(libmuscle_repeater_communicator, repeater_filters_discard_messages) {
+    mock_receive_messages({
+        {"component.twicerepeated", {
+            I({0}), I({1}), I({2}), M({})
+        }},
+        {"component.repeated", {
+            // Grandparent doesn't send on O_I in its first iteration
+            M({0}),
+            I({1, 0}),
+            I({1, 1}),
+            I({1, 2}),
+            M({1}),
+            I({2, 0}),
+            I({2, 1}),
+            M({2}),
+            M({})
+        }},
+        {"component.unfiltered", {
+            M({0}),
+            // parent doesn't send messages on O_I in the first couple of iterations
+            // component will need to discard the corresponding messages from the grandparent
+            M({1, 0}),
+            M({1, 1}),
+            M({1, 2}),
+            M({1}),
+            I({2, 0, 0}),
+            M({2, 0}),
+            I({2, 1, 0}),
+            I({2, 1, 1}),
+            M({2, 1}),
+            M({2}),
+            M({})
+        }}
+    });
+
+    bool is_padded = GetParam() == "pad";
+
+    auto cache = communicator_.pre_receive_f_init();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 0, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive_f_init();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 1, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 1}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive_f_init();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 1, 1}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("repeated").data().is_nil());
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 1}));
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    ASSERT_THROW(communicator_.pre_receive_f_init(), PortClosed);
+}
+
+
+INSTANTIATE_TEST_SUITE_P(
+    repeated, libmuscle_repeater_communicator, ::testing::Values("repeat", "pad"));

--- a/src/cpp/libmuscle/tests/test_mpp_message.cpp
+++ b/src/cpp/libmuscle/tests/test_mpp_message.cpp
@@ -106,5 +106,5 @@ TEST(test_mcp_message, iteration_roundtrip) {
             );
 
     auto m_out = MPPMessage::from_bytes(m.encoded());
-    ASSERT_EQ(m_out.iteration.get(), IterationCount({0, 2}));
+    ASSERT_EQ(m_out.iteration, IterationCount({0, 2}));
 }

--- a/src/cpp/libmuscle/tests/test_snapshot.cpp
+++ b/src/cpp/libmuscle/tests/test_snapshot.cpp
@@ -76,8 +76,6 @@ TEST_F(libmuscle_snapshot, test_snapshot) {
               snapshot2.timeline_state.iteration.get());
     ASSERT_EQ(snapshot_.timeline_state.send_participated,
               snapshot2.timeline_state.send_participated);
-    ASSERT_EQ(snapshot_.timeline_state.receive_participated,
-              snapshot2.timeline_state.receive_participated);
     ASSERT_EQ(snapshot_.timeline_state.subtimeline_states.size(),
               snapshot2.timeline_state.subtimeline_states.size());
 }

--- a/src/cpp/libmuscle/tests/test_snapshot_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_snapshot_manager.cpp
@@ -145,7 +145,6 @@ TEST_F(libmuscle_snapshot_manager, test_save_load_snapshot) {
     ASSERT_EQ(restored_state.iteration.is_set(), timeline_state_.iteration.is_set());
     ASSERT_EQ(restored_state.iteration.get(), timeline_state_.iteration.get());
     ASSERT_EQ(restored_state.send_participated, timeline_state_.send_participated);
-    ASSERT_EQ(restored_state.receive_participated, timeline_state_.receive_participated);
     ASSERT_EQ(
             restored_state.subtimeline_states.size(),
             timeline_state_.subtimeline_states.size());

--- a/src/cpp/libmuscle/tests/test_timeline_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_timeline_manager.cpp
@@ -20,6 +20,7 @@ int main(int argc, char *argv[]) {
 }
 
 
+using libmuscle::_MUSCLE_IMPL_NS::is_subiteration;
 using libmuscle::_MUSCLE_IMPL_NS::AlreadyParticipated;
 using libmuscle::_MUSCLE_IMPL_NS::ExpectedActions;
 using libmuscle::_MUSCLE_IMPL_NS::IterationCount;
@@ -99,12 +100,12 @@ std::unique_ptr<PortManager> make_port_manager(
     return port_manager;
 }
 
-/* check_receive + record_received_message, as Communicator::receive_message does. */
+/* check_receive_s + record_received_s_message, as Communicator::receive_message does. */
 void check_received(
         TimelineManager & tm, std::string const & port_name, Optional<int> slot,
         IterationCount const & iteration) {
-    tm.check_receive(port_name, slot);
-    tm.record_received_message(port_name, slot, iteration);
+    tm.check_receive_s(port_name, slot);
+    tm.record_received_s_message(port_name, slot, iteration);
 }
 
 }   // anonymous namespace
@@ -157,30 +158,32 @@ struct libmuscle_vector_timeline_manager : libmuscle_timeline_manager {
 };
 
 
+TEST_F(libmuscle_full_timeline_manager, is_subiteration) {
+    ASSERT_TRUE(is_subiteration({}, {}));
+    ASSERT_TRUE(is_subiteration({1, 2}, {1, 2}));
+    ASSERT_TRUE(is_subiteration({1, 2}, {1}));
+    ASSERT_TRUE(is_subiteration({1, 2}, {}));
+    ASSERT_FALSE(is_subiteration({1, 2}, {1, 2, 3}));
+    ASSERT_FALSE(is_subiteration({1, 2}, {1, 1}));
+}
+
 // -- Main timeline: F_INIT / O_F --
 
-TEST_F(libmuscle_full_timeline_manager, f_init_receive_allowed_once) {
-    check_received(*tm_, "in_f", {}, {});
-    ASSERT_THROW(tm_->check_receive("in_f"), AlreadyParticipated);
-}
-
-TEST_F(libmuscle_full_timeline_manager, settings_in_receive_allowed_once) {
-    check_received(*tm_, "muscle_settings_in", {}, {});
-    ASSERT_THROW(tm_->check_receive("muscle_settings_in"), AlreadyParticipated);
-}
-
-TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_adopts_iteration) {
-    IterationCount first = {3};
-    check_received(*tm_, "in_f", {}, first);
-    check_received(*tm_, "muscle_settings_in", {}, first);
+TEST_F(libmuscle_full_timeline_manager, check_finit_iterations) {
+    IterationCount first = {1, 2, 3, 4};
+    ASSERT_EQ(tm_->check_f_init_iterations({
+        {"in_f", first},
+        {"muscle_settings_in", first},
+    }), first);
 
     ASSERT_EQ(tm_->check_send_message("out_f"), first);
 }
 
-TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_raises_on_mismatch) {
-    check_received(*tm_, "in_f", {}, {3});
-    ASSERT_THROW(
-            tm_->record_received_message("muscle_settings_in", {}, {4}), MessageOutOfSync);
+TEST_F(libmuscle_full_timeline_manager, check_finit_iterations_when_iteration_differs) {
+    ASSERT_THROW(tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {4}},
+    }), std::runtime_error);
 }
 
 TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_connections) {
@@ -192,8 +195,10 @@ TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_conne
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_f_blocked_while_subtimeline_incomplete) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     tm_->check_send_message("out_a1");  // starts :A1, but doesn't complete it
 
@@ -201,8 +206,10 @@ TEST_F(libmuscle_full_timeline_manager, o_f_blocked_while_subtimeline_incomplete
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_f_send_records_iteration_and_participation) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount({3}));
@@ -213,16 +220,20 @@ TEST_F(libmuscle_full_timeline_manager, o_f_send_records_iteration_and_participa
 // -- Sub-timeline O_I/S leadership races --
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_first_send_starts_subtimeline_at_zero) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     IterationCount iteration = tm_->check_send_message("out_a1");
     ASSERT_EQ(iteration, IterationCount({3, 0}));
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_second_send_blocked_until_all_s_received) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
@@ -232,8 +243,10 @@ TEST_F(libmuscle_full_timeline_manager, o_i_leads_second_send_blocked_until_all_
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_advances_once_all_s_received) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     IterationCount first = tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, first);
@@ -245,17 +258,21 @@ TEST_F(libmuscle_full_timeline_manager, o_i_leads_advances_once_all_s_received) 
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_first_receive_starts_subtimeline) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     check_received(*tm_, "in_a1", {}, {7});
     // second receive on the same port before O_I sends anything is blocked
-    ASSERT_THROW(tm_->check_receive("in_a1"), PortBlocked);
+    ASSERT_THROW(tm_->check_receive_s("in_a1"), PortBlocked);
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     check_received(*tm_, "in_a1", {}, {7});
     // in_a1_2 hasn't received yet, so S hasn't fully led :A1 yet
@@ -264,8 +281,10 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_iteration) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     check_received(*tm_, "in_a1", {}, {7});
     check_received(*tm_, "in_a1_2", {}, {7});
@@ -273,16 +292,18 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_itera
     tm_->check_send_message("out_a1");
 
     // an equal-or-earlier iteration on the already-participated S port is out of sync
-    tm_->check_receive("in_a1");
-    ASSERT_THROW(tm_->record_received_message("in_a1", {}, {7}), MessageOutOfSync);
+    tm_->check_receive_s("in_a1");
+    ASSERT_THROW(tm_->record_received_s_message("in_a1", {}, {7}), MessageOutOfSync);
 
     // a strictly later one advances the sub-iteration
     check_received(*tm_, "in_a1", {}, {8});
 }
 
 TEST_F(libmuscle_full_timeline_manager, many_o_i_one_s_mirror_scenario) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
 
     // :A2 has two O_I ports (out_a2, out_a2_2) and one S port (in_a2)
     tm_->check_send_message("out_a2");
@@ -299,31 +320,39 @@ TEST_F(libmuscle_full_timeline_manager, many_o_i_one_s_mirror_scenario) {
 // -- Reuse loop completion / reset --
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_raises_when_incomplete) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
     // out_f never sent
 
     ASSERT_THROW(tm_->finish_reuse_iteration(), ReuseLoopIncomplete);
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_resets_when_complete) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
     tm_->check_send_message("out_f");
 
     tm_->finish_reuse_iteration();
 
     // fully reset: the same sequence works again from scratch
-    check_received(*tm_, "in_f", {}, {4});
-    check_received(*tm_, "muscle_settings_in", {}, {4});
+    tm_->check_f_init_iterations({
+        {"in_f", {4}},
+        {"muscle_settings_in", {4}},
+    });
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount({4}));
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeline_unused) {
     // a sub-timeline never touched this iteration doesn't block completion
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
     tm_->check_send_message("out_f");
 
     ASSERT_NO_THROW(tm_->finish_reuse_iteration());
@@ -333,8 +362,10 @@ TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeli
 // -- Snapshot state round-trip --
 
 TEST_F(libmuscle_full_timeline_manager, get_state_and_restore_state_round_trip) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
     // in_a1_2 not yet received, so :A1 is incomplete, and out_f not yet sent
@@ -348,14 +379,15 @@ TEST_F(libmuscle_full_timeline_manager, get_state_and_restore_state_round_trip) 
     ASSERT_EQ(state.iteration.is_set(), restored_state.iteration.is_set());
     ASSERT_EQ(state.iteration.get(), restored_state.iteration.get());
     ASSERT_EQ(state.send_participated, restored_state.send_participated);
-    ASSERT_EQ(state.receive_participated, restored_state.receive_participated);
     ASSERT_EQ(
             state.subtimeline_states.size(), restored_state.subtimeline_states.size());
 }
 
 TEST_F(libmuscle_full_timeline_manager, state_data_round_trip_through_msgpack_shape) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_f_init_iterations({
+        {"in_f", {3}},
+        {"muscle_settings_in", {3}},
+    });
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
 
@@ -366,7 +398,6 @@ TEST_F(libmuscle_full_timeline_manager, state_data_round_trip_through_msgpack_sh
     ASSERT_EQ(state.iteration.is_set(), round_tripped.iteration.is_set());
     ASSERT_EQ(state.iteration.get(), round_tripped.iteration.get());
     ASSERT_EQ(state.send_participated, round_tripped.send_participated);
-    ASSERT_EQ(state.receive_participated, round_tripped.receive_participated);
     ASSERT_EQ(
             state.subtimeline_states.size(), round_tripped.subtimeline_states.size());
 }

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -60,6 +60,28 @@ Optional<IterationCount> decode_iteration(DataConstRef const & data) {
 }
 
 
+bool is_subiteration(IterationCount const & c1, IterationCount const & c2) {
+    if (c1.size() < c2.size())
+        return false;
+    for (std::size_t i = 0; i < c2.size(); ++i) {
+        if (c1[i] != c2[i])
+            return false;
+    }
+    return true;
+}
+
+std::string to_string(IterationCount const & iteration) {
+    std::ostringstream oss;
+    oss << "[";
+    for (std::size_t i = 0; i < iteration.size(); ++i) {
+        if (i > 0) oss << ", ";
+        oss << iteration[i];
+    }
+    oss << "]";
+    return oss.str();
+}
+
+
 Data SubTimelineState::to_data() const {
     Data first_op;
     if (first_operator.is_set())
@@ -91,7 +113,6 @@ Data TimelineState::to_data() const {
     return Data::dict(
             "iteration", encode_iteration(iteration),
             "send_participated", encode_participated(send_participated),
-            "receive_participated", encode_participated(receive_participated),
             "subtimeline_states", subtimelines);
 }
 
@@ -99,7 +120,6 @@ TimelineState TimelineState::from_data(DataConstRef const & data) {
     TimelineState state;
     state.iteration = decode_iteration(data["iteration"]);
     state.send_participated = decode_participated(data["send_participated"]);
-    state.receive_participated = decode_participated(data["receive_participated"]);
 
     auto subtimelines = data["subtimeline_states"];
     for (std::size_t i = 0; i < subtimelines.size(); ++i)
@@ -389,7 +409,6 @@ void SubTimelineManager::missing_actions(ExpectedActions & result) const {
 
 TimelineManager::TimelineManager(PortManager const & port_manager)
     : port_manager_(port_manager)
-    , receive_(port_manager.get_connected_ports(Operator::F_INIT, Optional<Timeline>()))
     , send_(port_manager.get_connected_ports(Operator::O_F, Optional<Timeline>()))
     , submanagers_()
     , iteration_()
@@ -399,6 +418,29 @@ TimelineManager::TimelineManager(PortManager const & port_manager)
 
     if (!port_manager_.has_f_init_connections())
         iteration_ = IterationCount();
+}
+
+IterationCount const & TimelineManager::check_f_init_iterations(
+        std::unordered_map<::ymmsl::Reference, IterationCount> const & iterations) {
+    if (iteration_.is_set()) throw std::logic_error("Internal error: iteration_ is set.");
+    if (iterations.empty()) throw std::logic_error("Internal error: missing iterations.");
+
+    IterationCount const & first = iterations.begin()->second;
+    for (auto const & item : iterations) {
+        if (item.second != first) {
+            std::ostringstream oss;
+            oss << "Pre-received F_INIT messages from parallel timelines:";
+            for (auto const & ii : iterations) {
+                oss << "\n- " << ii.first << ": " << to_string(ii.second);
+            }
+            oss << "\nPlease verify that all connected instances send the same ";
+            oss << "number of messages on their O_I ports.";
+            throw std::runtime_error(oss.str());
+        }
+    }
+
+    iteration_ = first;
+    return iteration_.get();
 }
 
 IterationCount TimelineManager::check_send_message(
@@ -429,29 +471,18 @@ IterationCount TimelineManager::check_send_o_f_(Port const & port, Optional<int>
     return iteration_.get();
 }
 
-void TimelineManager::check_receive(std::string const & port_name, Optional<int> slot) {
+void TimelineManager::check_receive_s(std::string const & port_name, Optional<int> slot) {
     Port const & port = port_manager_.get_port(port_name);
-
-    if (port.oper == Operator::F_INIT) {
-        if (receive_.has_participated(port_name, slot))
-            throw AlreadyParticipated(port, slot);
-    } else if (port.oper == Operator::S)
-        submanagers_.at(port.timeline).check_receive(port, slot);
+    if (port.oper != Operator::S)
+        throw std::logic_error("Internal error: port.oper != Operator::S");
+    submanagers_.at(port.timeline).check_receive(port, slot);
 }
 
-void TimelineManager::record_received_message(
+void TimelineManager::record_received_s_message(
         std::string const & port_name, Optional<int> slot, IterationCount const & iteration) {
     Port const & port = port_manager_.get_port(port_name);
-
-    if (port.oper == Operator::F_INIT) {
-        if (!iteration_.is_set())
-            iteration_ = iteration;
-        else if (iteration != iteration_.get())
-            throw MessageOutOfSync(port, slot);
-        receive_.participate(port_name, slot);
-        return;
-    }
-
+    if (port.oper != Operator::S)
+        throw std::logic_error("Internal error: port.oper != Operator::S");
     submanagers_.at(port.timeline).record_received_message(port, slot, iteration);
 }
 
@@ -459,7 +490,6 @@ void TimelineManager::reset() {
     iteration_ = port_manager_.has_f_init_connections() ?
             Optional<IterationCount>() : Optional<IterationCount>(IterationCount());
     send_.reset();
-    receive_.reset();
     for (auto & item : submanagers_)
         item.second.reset();
 }
@@ -474,13 +504,13 @@ IterationCount TimelineManager::finish_reuse_iteration() {
         }
     }
 
-    if (receive_.all_participated() && send_.all_participated() && subtimelines_complete) {
+    if (send_.all_participated() && subtimelines_complete) {
         reset();
         return iteration;
     }
 
     ExpectedActions expected;
-    expected_actions(&send_, &receive_, expected);
+    expected_actions(&send_, nullptr, expected);
     for (auto const & item : submanagers_) {
         if (!item.second.is_complete())
             item.second.missing_actions(expected);
@@ -493,7 +523,6 @@ TimelineState TimelineManager::get_state() const {
     TimelineState state;
     state.iteration = iteration_;
     state.send_participated = send_.participated;
-    state.receive_participated = receive_.participated;
     for (auto const & item : submanagers_)
         state.subtimeline_states.emplace(
                 static_cast<std::string>(item.first), item.second.get_state());
@@ -503,7 +532,6 @@ TimelineState TimelineManager::get_state() const {
 void TimelineManager::restore_state(TimelineState const & state) {
     iteration_ = state.iteration;
     send_.participated = state.send_participated;
-    receive_.participated = state.receive_participated;
     for (auto & item : submanagers_) {
         auto it = state.subtimeline_states.find(static_cast<std::string>(item.first));
         if (it != state.subtimeline_states.end())

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -42,6 +42,14 @@ Optional<IterationCount> decode_iteration(DataConstRef const & data);
 using ExpectedAction = std::tuple<std::string, Port, std::vector<int>>;
 using ExpectedActions = std::vector<ExpectedAction>;
 
+/** Check if c1 is a sub-iteration of c2, or if c1 is equal to c2.
+ */
+bool is_subiteration(IterationCount const & c1, IterationCount const & c2);
+
+/** String representation of IterationCount
+ */
+std::string to_string(IterationCount const & iteration);
+
 /** A single sub-timeline's state, as returned by SubTimelineManager::get_state()
  * for saving in a snapshot. */
 struct SubTimelineState {
@@ -66,7 +74,6 @@ struct SubTimelineState {
 struct TimelineState {
     Optional<IterationCount> iteration;
     std::vector<PortAndSlot> send_participated;
-    std::vector<PortAndSlot> receive_participated;
     std::unordered_map<std::string, SubTimelineState> subtimeline_states;
 
     Data to_data() const;
@@ -277,6 +284,11 @@ class TimelineManager {
          */
         explicit TimelineManager(PortManager const & port_manager);
 
+        /** Set current iteration count from pre-received F_INIT messages.
+         */
+        IterationCount const & check_f_init_iterations(
+            std::unordered_map<::ymmsl::Reference, IterationCount> const & iterations);
+
         /** Check and update the timeline state before sending on the given
          * port.
          *
@@ -293,28 +305,23 @@ class TimelineManager {
         IterationCount check_send_message(
                 std::string const & port_name, Optional<int> slot = {});
 
-        /** Check that receiving on the given port is currently allowed.
+        /** Check that receiving on the given S port is currently allowed.
          *
-         * An F_INIT port may receive once after the reuse loop starts and
-         * before any other ports are used. Whether an S port may receive is
-         * delegated to the corresponding SubTimelineManager.
-         *
-         * @param port_name Name of the F_INIT or S port about to receive.
+         * @param port_name Name of the S port about to receive.
          * @param slot The slot being received on, if this is a vector port.
          */
-        void check_receive(std::string const & port_name, Optional<int> slot = {});
+        void check_receive_s(std::string const & port_name, Optional<int> slot = {});
 
-        /** Record that a message has been received on the given port.
+        /** Record that a message has been received on the given S port.
          *
          * check_receive already established that this receive is allowed.
          *
-         * @param port_name Name of the F_INIT or S port a message was
-         *      received on.
+         * @param port_name Name of the S port a message was received on.
          * @param slot The slot the message was received on, if this is a
          *      vector port.
          * @param iteration The iteration the received message was sent with.
          */
-        void record_received_message(
+        void record_received_s_message(
                 std::string const & port_name, Optional<int> slot,
                 IterationCount const & iteration);
 
@@ -352,7 +359,6 @@ class TimelineManager {
         IterationCount check_send_o_f_(Port const & port, Optional<int> slot);
 
         PortManager const & port_manager_;
-        TimelinePorts receive_;
         TimelinePorts send_;
         std::unordered_map<::ymmsl::Timeline, SubTimelineManager> submanagers_;
         Optional<IterationCount> iteration_;

--- a/src/cpp/ymmsl/ymmsl.hpp
+++ b/src/cpp/ymmsl/ymmsl.hpp
@@ -13,6 +13,10 @@ namespace ymmsl {
     using impl::allows_receiving;
     using impl::operator_name;
     using impl::operator_for_name;
+    using impl::is_reducer;
+    using impl::is_repeater;
+    using impl::conduit_filter_name;
+    using impl::conduit_filter_for_name;
     using impl::Conduit;
     using impl::ConduitFilter;
     using impl::Identifier;

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -1,7 +1,9 @@
 import logging
+from collections.abc import Iterator
+from copy import deepcopy
 from typing import Any, Optional, cast
 
-from ymmsl.v0_2 import Operator, Reference, Settings
+from ymmsl.v0_2 import ConduitFilter, Operator, Reference, Settings
 
 from libmuscle.endpoint import Endpoint
 from libmuscle.mcp.tcp_util import SocketClosed
@@ -15,14 +17,21 @@ from libmuscle.port_manager import PortManager
 from libmuscle.profiler import Profiler
 from libmuscle.profiling import ProfileEvent, ProfileEventType, ProfileTimestamp
 from libmuscle.receive_timeout_handler import Deadlock, ReceiveTimeoutHandler
-from libmuscle.timeline_manager import IterationCount, TimelineManager, TimelineState
+from libmuscle.timeline_manager import (
+    IterationCount,
+    PortAndSlot,
+    TimelineManager,
+    TimelineState,
+    is_subiteration,
+)
 from libmuscle.util import port_desc
 
 _logger = logging.getLogger(__name__)
 
 
 MessageObject = Any
-FInitCacheType = dict[tuple[str, Optional[int]], "Message"]
+FInitCacheType = dict[PortAndSlot, "Message"]
+_MPPCacheType = dict[PortAndSlot, MPPMessage]
 
 
 class PortClosed(Exception):
@@ -73,6 +82,30 @@ class Message:
         self.settings = settings
 
 
+def _make_message(mpp_msg: MPPMessage, copy: bool = False) -> Message:
+    """Create a Message object from the provided MPPMessage.
+
+    Args:
+        mpp_msg: The MPPMessage object to create the Message from.
+        copy: Whether to deepcopy the data and settings.
+    """
+    return Message(
+        mpp_msg.timestamp,
+        mpp_msg.next_timestamp,
+        deepcopy(mpp_msg.data) if copy else mpp_msg.data,
+        deepcopy(mpp_msg.settings_overlay) if copy else mpp_msg.settings_overlay,
+    )
+
+
+def _yield_slots(port: Port) -> Iterator[Optional[int]]:
+    """Iterator over the slots in the port."""
+    if not port.is_vector():
+        yield None
+    else:
+        yield 0  # Allow pre-receive to receive 1 message that updates port._length
+        yield from range(1, port.get_length())
+
+
 class Communicator:
     """Communication engine for MUSCLE3.
 
@@ -116,6 +149,11 @@ class Communicator:
         # indexed by remote instance id
         self._clients: dict[Reference, MPPClient] = {}
 
+        self._f_init_repeaters: dict[str, list[ConduitFilter]] = {}
+        """List of repeater filters to be applied to each F_INIT port."""
+        self._f_init_repeat_cache: _MPPCacheType = {}
+        """Message cache for F_INIT ports with repeater filters."""
+
     def get_locations(self) -> list[str]:
         """Returns a list of locations that we can be reached at.
 
@@ -140,6 +178,7 @@ class Communicator:
         """
         self._peer_info = peer_info
         self._timeline_manager = TimelineManager(self._port_manager)
+        self._prepare_conduit_filters()
 
     def set_receive_timeout(self, receive_timeout: float) -> None:
         """Update the timeout after which the manager is notified that we are waiting
@@ -251,26 +290,51 @@ class Communicator:
     def pre_receive_f_init(self) -> FInitCacheType:
         """Receive on all connected F_INIT port (including muscle_settings_in).
 
+        This method assumes that there is at least one connected F_INIT port.
+
         Returns:
             f_init_cache: The received messages.
         """
         cache: FInitCacheType = {}
 
-        def pre_receive(port_name: str, slot: Optional[int]) -> None:
-            cache[(port_name, slot)] = self._receive_message(port_name, slot)
-
+        iterations: dict[PortAndSlot, IterationCount] = {}
+        # Pre-receive on ports without repeater filters:
         for port in self._port_manager.get_connected_ports(Operator.F_INIT):
             port_name = str(port.name)
-            _logger.debug("Pre-receiving on port %s", port_name)
-            if not port.is_vector():
-                pre_receive(port_name, None)
-            else:
-                pre_receive(port_name, 0)
-                # The above receives the length, if needed, so now we can get the rest.
-                for slot in range(1, port.get_length()):
-                    pre_receive(port_name, slot)
+            if port_name not in self._f_init_repeaters:
+                _logger.debug("Pre-receiving on port %s", port_name)
+                for slot in _yield_slots(port):
+                    mpp_message = self._receive_message(port_name, slot)
+                    cache[(port_name, slot)] = _make_message(mpp_message)
+                    iterations[(port_name, slot)] = mpp_message.iteration
 
         # Check if we have received milestones
+        milestone = self._verify_received_milestones(cache)
+        if milestone is not None:
+            self._broadcast_milestone(milestone, False)
+            if milestone.is_final_milestone():
+                raise PortClosed()
+            # Clean up stale messages from the cache
+            self._f_init_repeat_cache = {
+                key: message
+                for key, message in self._f_init_repeat_cache.items()
+                if len(message.iteration) < len(milestone.iteration)
+            }
+            # Pre-receive again to receive the actual messages
+            return self.pre_receive_f_init()
+
+        # Verify that all F_INIT messages agree on the iteration count
+        cur_iteration = self._timeline_manager.check_finit_iterations(iterations)
+        # Put messages from repeater ports in the cache:
+        self._pre_receive_finit_with_repeaters(cur_iteration, cache)
+        return cache
+
+    def _verify_received_milestones(self, cache: FInitCacheType) -> Optional[Milestone]:
+        """Check if the received messages have consistent milestones.
+
+        Returns:
+            None if no milestones were received, the received Milestone otherwise.
+        """
         milestone_iterations: list[Optional[IterationCount]] = []
         closed_ports: set[str] = set()
         for (port_name, _), message in cache.items():
@@ -291,16 +355,60 @@ class Communicator:
                 f"F_INIT: {milestone_iterations}. This is not supposed to happen and "
                 "may be a bug in libmuscle. Please report an issue."
             )
-        if milestone_iterations[0] is not None:
-            # Propagate milestone
-            milestone = Milestone(milestone_iterations[0])
-            self._broadcast_milestone(milestone, False)
-            if milestone.is_final_milestone():
-                raise PortClosed()
-            # Pre-receive again to receive the actual messages
-            return self.pre_receive_f_init()
+        (iteration,) = milestone_iterations
+        return None if iteration is None else Milestone(iteration)
 
-        return cache
+    def _pre_receive_finit_with_repeaters(
+        self, cur_iteration: IterationCount, cache: FInitCacheType
+    ) -> None:
+        """Handle pre-receive F_INIT for ports with repeater filters.
+
+        Determines if we need to receive again based on the current iteration count and
+        the previously received messages for those ports.
+
+        Args:
+            cur_iteration: Iteration count for the new reuse loop.
+            cache: F_INIT cache to add messages to.
+        """
+        for port_name in self._f_init_repeaters:
+            port = self._port_manager.get_port(port_name)
+
+            # If the message is not in the cache we need to receive again. We may need
+            # to receive and discard multiple messages here, see the tests
+            # (test_repeater_filters_discard_messages) for a scenario.
+            slot = 0 if port.is_vector() else None
+            while (port_name, slot) not in self._f_init_repeat_cache:
+                _logger.debug("Pre-receiving on port %s", port_name)
+                for recv_slot in _yield_slots(port):
+                    mpp_msg = self._receive_message(port_name, recv_slot)
+                    if is_subiteration(cur_iteration, mpp_msg.iteration):
+                        self._f_init_repeat_cache[(port_name, recv_slot)] = mpp_msg
+                    elif mpp_msg.iteration > cur_iteration:
+                        raise RuntimeError(
+                            "Internal error: Received a message from the future on "
+                            f"{port_desc(port_name, slot)}. Message iteration is "
+                            f"{mpp_msg.iteration}, while ours is {cur_iteration}."
+                        )
+
+            # Repeat or pad the cached messages
+            filters = self._f_init_repeaters[port_name]
+            pad_message = any(
+                filter is ConduitFilter.PAD and cur_iteration[-len(filters) + i] > 0
+                for i, filter in enumerate(filters)
+            )
+            for slot in _yield_slots(port):
+                mpp_msg = self._f_init_repeat_cache[(port_name, slot)]
+                if not is_subiteration(cur_iteration, mpp_msg.iteration):
+                    raise RuntimeError(
+                        "Internal error: Invalid cached message for "
+                        f"{port_desc(port_name, slot)}. Cached message iteration is "
+                        f"{mpp_msg.iteration}, while ours is {cur_iteration}."
+                    )
+                # Create a deepcopy, so users won't alter the message we cache:
+                message = _make_message(mpp_msg, copy=True)
+                if pad_message:
+                    message.data = None
+                cache[(port_name, slot)] = message
 
     def receive_s_message(self, port_name: str, slot: Optional[int] = None) -> Message:
         """Receive a message and attached settings overlay on an "S" port.
@@ -322,6 +430,7 @@ class Communicator:
             RuntimeError: If the network connection had an error, or the
                     message number was incorrect.
         """
+        self._timeline_manager.check_receive_s(port_name, slot)
         # Instance should not need to bother about milestones, so we keep receiving
         # messages until we have actual data:
         while True:
@@ -331,12 +440,13 @@ class Communicator:
                     raise PortClosed()
                 # TODO: handle milestone, if needed
             else:
-                return message
+                self._timeline_manager.record_received_s_message(
+                    port_name, slot, message.iteration
+                )
+                return _make_message(message)
 
-    def _receive_message(self, port_name: str, slot: Optional[int]) -> Message:
+    def _receive_message(self, port_name: str, slot: Optional[int]) -> MPPMessage:
         """Implementation for receive_message."""
-        self._timeline_manager.check_receive(port_name, slot)
-
         port = self._port_manager.get_port(port_name)
         port_and_slot = port_desc(port_name, slot)
         _logger.debug("Waiting for message on %s", port_and_slot)
@@ -404,13 +514,6 @@ class Communicator:
             if milestone.is_final_milestone():
                 port.set_closed(slot)
 
-        message = Message(
-            mpp_message.timestamp,
-            mpp_message.next_timestamp,
-            mpp_message.data,
-            mpp_message.settings_overlay,
-        )
-
         recv_wait_event = ProfileEvent(
             ProfileEventType.RECEIVE_WAIT,
             profile[0],
@@ -420,7 +523,7 @@ class Communicator:
             slot,
             port.get_num_messages(),
             len(memoryview(mpp_message_bytes)),
-            message.timestamp,
+            mpp_message.timestamp,
         )
 
         recv_xfer_event = ProfileEvent(
@@ -432,11 +535,11 @@ class Communicator:
             slot,
             port.get_num_messages(),
             len(memoryview(mpp_message_bytes)),
-            message.timestamp,
+            mpp_message.timestamp,
         )
 
-        recv_decode_event.message_timestamp = message.timestamp
-        receive_event.message_timestamp = message.timestamp
+        recv_decode_event.message_timestamp = mpp_message.timestamp
+        receive_event.message_timestamp = mpp_message.timestamp
 
         if port.is_vector():
             receive_event.port_length = port.get_length()
@@ -477,15 +580,12 @@ class Communicator:
         if milestone is None:
             port.increment_num_messages(slot)
             _logger.debug(f"Received message on {port_and_slot}")
-            self._timeline_manager.record_received_message(
-                port_name, slot, mpp_message.iteration
-            )
         elif milestone.is_final_milestone():
             _logger.debug(f"Port {port_and_slot} is now closed")
         else:
             _logger.debug("Received %s on %s", milestone, port_and_slot)
 
-        return message
+        return mpp_message
 
     def shutdown(self) -> None:
         """Shuts down the Communicator, closing connections."""
@@ -609,3 +709,24 @@ class Communicator:
         """
         self._close_outgoing_ports()
         self._close_incoming_ports()
+
+    def _prepare_conduit_filters(self) -> None:
+        """Check which ports are connected with a conduit filter and initialize the
+        associated logic.
+        """
+        # F_INIT repeat/pad filters
+        for port in self._port_manager.get_connected_ports(Operator.F_INIT):
+            filters = self._peer_info.get_filters_for_receiver(self._kernel + port.name)
+            # Only keep the repeater filters, the sending component handles reducers:
+            filters = [filter for filter in filters if filter.is_repeater()]
+            if filters:
+                self._f_init_repeaters[str(port.name)] = filters
+        # S repeat/pad filters are not implemented
+        for port in self._port_manager.get_connected_ports(Operator.S):
+            filters = self._peer_info.get_filters_for_receiver(self._kernel + port.name)
+            if any(filter.is_repeater() for filter in filters):
+                raise NotImplementedError(
+                    "Repeater filters are not implemented for S ports, you may connect "
+                    "the conduit to an F_INIT port instead."
+                )
+        # TODO: reducer filters

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -324,9 +324,9 @@ class Communicator:
             return self.pre_receive_f_init()
 
         # Verify that all F_INIT messages agree on the iteration count
-        cur_iteration = self._timeline_manager.check_finit_iterations(iterations)
+        cur_iteration = self._timeline_manager.check_f_init_iterations(iterations)
         # Put messages from repeater ports in the cache:
-        self._pre_receive_finit_with_repeaters(cur_iteration, cache)
+        self._pre_receive_f_init_with_repeaters(cur_iteration, cache)
         return cache
 
     def _verify_received_milestones(self, cache: FInitCacheType) -> Optional[Milestone]:
@@ -358,19 +358,16 @@ class Communicator:
         (iteration,) = milestone_iterations
         return None if iteration is None else Milestone(iteration)
 
-    def _pre_receive_finit_with_repeaters(
+    def _pre_receive_f_init_with_repeaters(
         self, cur_iteration: IterationCount, cache: FInitCacheType
     ) -> None:
         """Handle pre-receive F_INIT for ports with repeater filters.
-
-        Determines if we need to receive again based on the current iteration count and
-        the previously received messages for those ports.
 
         Args:
             cur_iteration: Iteration count for the new reuse loop.
             cache: F_INIT cache to add messages to.
         """
-        for port_name in self._f_init_repeaters:
+        for port_name, filters in self._f_init_repeaters.items():
             port = self._port_manager.get_port(port_name)
 
             # If the message is not in the cache we need to receive again. We may need
@@ -386,12 +383,11 @@ class Communicator:
                     elif mpp_msg.iteration > cur_iteration:
                         raise RuntimeError(
                             "Internal error: Received a message from the future on "
-                            f"{port_desc(port_name, slot)}. Message iteration is "
+                            f"{port_desc(port_name, recv_slot)}. Message iteration is "
                             f"{mpp_msg.iteration}, while ours is {cur_iteration}."
                         )
 
             # Repeat or pad the cached messages
-            filters = self._f_init_repeaters[port_name]
             pad_message = any(
                 filter is ConduitFilter.PAD and cur_iteration[-len(filters) + i] > 0
                 for i, filter in enumerate(filters)

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -296,8 +296,8 @@ class Communicator:
             f_init_cache: The received messages.
         """
         cache: FInitCacheType = {}
-
         iterations: dict[PortAndSlot, IterationCount] = {}
+
         # Pre-receive on ports without repeater filters:
         for port in self._port_manager.get_connected_ports(Operator.F_INIT):
             port_name = str(port.name)

--- a/src/python/libmuscle/test/conftest.py
+++ b/src/python/libmuscle/test/conftest.py
@@ -48,7 +48,6 @@ def timeline_state() -> TimelineState:
     return TimelineState(
         iteration=[1],
         send_participated=[],
-        receive_participated=[["in", None]],
         subtimeline_states={},
     )
 

--- a/src/python/libmuscle/test/test_communicator_conduit_filters.py
+++ b/src/python/libmuscle/test/test_communicator_conduit_filters.py
@@ -1,0 +1,211 @@
+from typing import Union
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ymmsl.v0_2 import Conduit, ConduitFilter, Operator, Port, Settings
+from ymmsl.v0_2 import Identifier as Id
+from ymmsl.v0_2 import Reference as Ref
+
+from libmuscle.communicator import Communicator, PortClosed
+from libmuscle.mpp_message import Milestone, MPPMessage
+from libmuscle.peer_info import PeerInfo
+from libmuscle.port_manager import PortManager
+from libmuscle.timeline_manager import IterationCount
+
+
+@pytest.fixture
+def mpp_client():
+    with patch("libmuscle.communicator.MPPClient") as MPPClient:
+        yield MPPClient.return_value
+
+
+@pytest.fixture(params=["repeat", "pad"])
+def repeat_filter(request):
+    return request.param
+
+
+@pytest.fixture()
+def repeater_communicator(repeat_filter, mpp_client):
+    port_manager = PortManager([], None)
+    communicator = Communicator(
+        Ref("component"), [], port_manager, MagicMock(), MagicMock()
+    )
+    peer_info = PeerInfo(
+        Ref("component"),
+        [],
+        [
+            Conduit("parent1.out", "component.unfiltered"),
+            Conduit("parent2.out", "component.repeated", repeat_filter),
+            Conduit(
+                "parent3.out",
+                "component.twicerepeated",
+                repeat_filter + " " + repeat_filter,
+            ),
+        ],
+        {Ref("parent1"): [], Ref("parent2"): [], Ref("parent3"): []},
+        {Ref("parent1"): [], Ref("parent2"): [], Ref("parent3"): []},
+        [
+            Port(Id(name), Operator.F_INIT)
+            for name in ["unfiltered", "repeated", "twicerepeated"]
+        ],
+    )
+    port_manager.connect_ports(peer_info)
+    communicator.set_peer_info(peer_info)
+    assert communicator._f_init_repeaters == {
+        "repeated": [ConduitFilter(repeat_filter)],
+        "twicerepeated": [ConduitFilter(repeat_filter)] * 2,
+    }
+    yield communicator
+    communicator.shutdown()
+
+
+def mock_receive_messages(
+    mpp_client, data: dict[str, list[Union[IterationCount, Milestone]]]
+):
+    """Helper method to mock MPPClient.receive, so it gives data with correct message
+    numbers and iteration counts.
+
+    Args:
+        data: A list of IterationCount or Milestone for each port (component.port_name).
+            This will end up filling both the MPPMessage.iteration and MPPMessage.data
+            fields. MPPMessage.message_number is derived from the number of
+            non-Milestone messages sent so far.
+    """
+
+    def message_maker(data: list[Union[IterationCount, Milestone]]):
+        num = 0
+        for item in data:
+            iteration = item.iteration if isinstance(item, Milestone) else item
+            yield (
+                MPPMessage(
+                    Ref("snd"),
+                    Ref("rcv"),
+                    None,
+                    0.0,
+                    None,
+                    Settings(),
+                    num,
+                    item,
+                    iteration,
+                ).encoded(),
+                MagicMock(),
+            )
+            if not isinstance(item, Milestone):
+                num += 1
+
+    def side_effect(peer, _):
+        return next(iterators[peer])
+
+    iterators = {Ref(key): message_maker(value) for key, value in data.items()}
+    mpp_client.receive.side_effect = side_effect
+
+
+def test_repeater_filters(repeater_communicator, mpp_client, repeat_filter):
+    twicerepeated_messages = [[], Milestone([])]
+    repeated_messages = [[0], [1], [2], Milestone([])]
+    unfiltered_messages = [
+        [0, 0],
+        [0, 1],
+        Milestone([0]),
+        # parent is allowed to send 0 messages on its O_I port in an iteration
+        Milestone([1]),
+        [2, 0],
+        Milestone([2]),
+        Milestone([]),
+    ]
+    mock_receive_messages(
+        mpp_client,
+        {
+            "component.twicerepeated": twicerepeated_messages,
+            "component.repeated": repeated_messages,
+            "component.unfiltered": unfiltered_messages,
+        },
+    )
+
+    is_padded = repeat_filter == "pad"
+
+    cache = repeater_communicator.pre_receive_f_init()
+    assert cache[("unfiltered", None)].data == [0, 0]
+    assert cache[("repeated", None)].data == [0]
+    assert cache[("twicerepeated", None)].data == []
+    repeater_communicator.finish_reuse_iteration()
+
+    cache = repeater_communicator.pre_receive_f_init()
+    assert cache[("unfiltered", None)].data == [0, 1]
+    assert cache[("repeated", None)].data == (None if is_padded else [0])
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [])
+    repeater_communicator.finish_reuse_iteration()
+
+    cache = repeater_communicator.pre_receive_f_init()
+    assert cache[("unfiltered", None)].data == [2, 0]
+    assert cache[("repeated", None)].data == [2]
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [])
+    repeater_communicator.finish_reuse_iteration()
+
+    with pytest.raises(PortClosed):
+        repeater_communicator.pre_receive_f_init()
+
+
+def test_repeater_filters_discard_messages(
+    repeater_communicator, mpp_client, repeat_filter
+):
+    twicerepeated_messages = [[0], [1], [2], Milestone([])]
+    repeated_messages = [
+        # Grandparent doesn't send on O_I in its first iteration:
+        Milestone([0]),
+        [1, 0],
+        [1, 1],
+        [1, 2],
+        Milestone([1]),
+        [2, 0],
+        [2, 1],
+        Milestone([2]),
+        Milestone([]),
+    ]
+    unfiltered_messages = [
+        Milestone([0]),
+        # parent doesn't send messages on O_I in the first couple of iterations
+        # component will need to discard the corresponding messages in repeated_messages
+        Milestone([1, 0]),
+        Milestone([1, 1]),
+        Milestone([1, 2]),
+        Milestone([1]),
+        [2, 0, 0],
+        Milestone([2, 0]),
+        [2, 1, 0],
+        [2, 1, 1],
+        Milestone([2, 1]),
+        Milestone([2]),
+        Milestone([]),
+    ]
+    mock_receive_messages(
+        mpp_client,
+        {
+            "component.twicerepeated": twicerepeated_messages,
+            "component.repeated": repeated_messages,
+            "component.unfiltered": unfiltered_messages,
+        },
+    )
+
+    is_padded = repeat_filter == "pad"
+
+    cache = repeater_communicator.pre_receive_f_init()
+    assert cache[("unfiltered", None)].data == [2, 0, 0]
+    assert cache[("repeated", None)].data == [2, 0]
+    assert cache[("twicerepeated", None)].data == [2]
+    repeater_communicator.finish_reuse_iteration()
+
+    cache = repeater_communicator.pre_receive_f_init()
+    assert cache[("unfiltered", None)].data == [2, 1, 0]
+    assert cache[("repeated", None)].data == [2, 1]
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [2])
+    repeater_communicator.finish_reuse_iteration()
+
+    cache = repeater_communicator.pre_receive_f_init()
+    assert cache[("unfiltered", None)].data == [2, 1, 1]
+    assert cache[("repeated", None)].data == (None if is_padded else [2, 1])
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [2])
+    repeater_communicator.finish_reuse_iteration()
+
+    with pytest.raises(PortClosed):
+        repeater_communicator.pre_receive_f_init()

--- a/src/python/libmuscle/test/test_timeline_manager.py
+++ b/src/python/libmuscle/test/test_timeline_manager.py
@@ -115,7 +115,7 @@ def test_is_subiteration():
 def test_finish_reuse_iteration_ignores_muscle_settings_in_when_disconnected(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations({("in_f", None): []})
+    timeline_manager.check_f_init_iterations({("in_f", None): []})
     timeline_manager.check_send_message("out_f")
 
     timeline_manager.finish_reuse_iteration()
@@ -133,7 +133,7 @@ def test_check_send_message_o_f_blocked_when_subtimeline_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     timeline_manager.check_send_message("out_a1")
@@ -151,7 +151,7 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     # skipping the subtimelines is allowed
@@ -168,7 +168,7 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
 def test_check_send_message_o_f_marks_participated_and_returns_iteration(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
 
@@ -182,7 +182,7 @@ def test_check_send_message_o_f_marks_participated_and_returns_iteration(
 def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
 
@@ -198,7 +198,7 @@ def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
 def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     check_received(timeline_manager, "in_a1", None, [0])
@@ -215,7 +215,7 @@ def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
 def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     check_received(timeline_manager, "in_a1", None, [0])
@@ -249,7 +249,7 @@ def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
 def test_check_send_message_o_i_when_o_i_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
 
@@ -272,7 +272,7 @@ def test_check_send_message_o_i_when_o_i_leads_and_complete(
 def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     timeline_manager.check_send_message("out_a1")
@@ -290,7 +290,7 @@ def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
 def test_check_finit_iterations(
     timeline_manager: TimelineManager, iterationcount: IterationCount
 ) -> None:
-    result = timeline_manager.check_finit_iterations(
+    result = timeline_manager.check_f_init_iterations(
         {
             ("in_f", None): iterationcount.copy(),
             ("muscle_settings_in", None): iterationcount.copy(),
@@ -304,7 +304,7 @@ def test_check_finit_iterations_when_iteration_differs(
 ) -> None:
     """All F_INIT messages should have the same iteration count."""
     with pytest.raises(RuntimeError, match="parallel timelines"):
-        timeline_manager.check_finit_iterations(
+        timeline_manager.check_f_init_iterations(
             {("in_f", None): [3], ("muscle_settings_in", None): [4]}
         )
 
@@ -312,7 +312,7 @@ def test_check_finit_iterations_when_iteration_differs(
 def test_check_receive_message_s_starts_subtimeline_with_s_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
 
@@ -327,7 +327,7 @@ def test_check_receive_message_s_starts_subtimeline_with_s_leading(
 def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     timeline_manager.check_send_message("out_a2")
@@ -344,7 +344,7 @@ def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
 def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     timeline_manager.check_send_message("out_a2")
@@ -370,7 +370,7 @@ def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
 def test_check_receive_message_s_when_s_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
 
@@ -401,7 +401,7 @@ def test_check_receive_message_s_when_s_leads_and_complete(
 def test_check_receive_message_s_blocked_when_s_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_finit_iterations(
+    timeline_manager.check_f_init_iterations(
         {("in_f", None): [], ("muscle_settings_in", None): []}
     )
     check_received(timeline_manager, "in_a2", None, [1])
@@ -420,7 +420,7 @@ def test_finish_reuse_iteration_resets_when_complete(
 ) -> None:
     # Drive one full reuse loop iteration, using :A1's sub-timeline, to
     # completion.
-    assert timeline_manager.check_finit_iterations(
+    assert timeline_manager.check_f_init_iterations(
         {("in_f", None): [3], ("muscle_settings_in", None): [3]}
     ) == [3]
     timeline_manager.check_send_message("out_a1")
@@ -443,7 +443,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 ) -> None:
     # Start a reuse loop iteration but leave it incomplete: :A1's
     # sub-timeline is started but never finishes, and O_F never sends.
-    assert timeline_manager.check_finit_iterations(
+    assert timeline_manager.check_f_init_iterations(
         {("in_f", None): [4], ("muscle_settings_in", None): [4]}
     ) == [4]
     timeline_manager.check_send_message("out_a1")
@@ -464,7 +464,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 def test_get_state_and_restore_state_round_trip(
     timeline_manager: TimelineManager,
 ) -> None:
-    assert timeline_manager.check_finit_iterations(
+    assert timeline_manager.check_f_init_iterations(
         {("in_f", None): [3], ("muscle_settings_in", None): [3]}
     ) == [3]
     timeline_manager.check_send_message("out_a1")

--- a/src/python/libmuscle/test/test_timeline_manager.py
+++ b/src/python/libmuscle/test/test_timeline_manager.py
@@ -15,6 +15,7 @@ from libmuscle.timeline_manager import (
     PortBlocked,
     ReuseLoopIncomplete,
     TimelineManager,
+    is_subiteration,
 )
 
 
@@ -97,30 +98,24 @@ def check_received(
     slot: Optional[int],
     iteration: IterationCount,
 ) -> None:
-    timeline_manager.check_receive(port, slot)
-    timeline_manager.record_received_message(port, slot, iteration)
+    timeline_manager.check_receive_s(port, slot)
+    timeline_manager.record_received_s_message(port, slot, iteration)
 
 
-def test_finish_reuse_iteration_blocked_when_muscle_settings_in_not_received(
-    timeline_manager: TimelineManager,
-) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    timeline_manager.check_send_message("out_f")
-    # muscle_settings_in is never received this iteration
-
-    with pytest.raises(ReuseLoopIncomplete) as exc_info:
-        timeline_manager.finish_reuse_iteration()
-
-    assert exc_info.value.expected == expected(
-        timeline_manager, ("receive", "muscle_settings_in", [])
-    )
+def test_is_subiteration():
+    assert is_subiteration([], [])
+    assert is_subiteration([1, 2], [1, 2])
+    assert is_subiteration([1, 2], [1])
+    assert is_subiteration([1, 2], [])
+    assert not is_subiteration([1, 2], [1, 2, 3])
+    assert not is_subiteration([1, 2], [1, 1])
 
 
 @pytest.mark.parametrize("include_settings", [False], indirect=True)
 def test_finish_reuse_iteration_ignores_muscle_settings_in_when_disconnected(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
+    timeline_manager.check_finit_iterations({("in_f", None): []})
     timeline_manager.check_send_message("out_f")
 
     timeline_manager.finish_reuse_iteration()
@@ -138,8 +133,9 @@ def test_check_send_message_o_f_blocked_when_subtimeline_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so the :A1 sub-timeline is incomplete
 
@@ -155,8 +151,9 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     # skipping the subtimelines is allowed
     timeline_manager.check_send_message("out_f")
 
@@ -171,8 +168,9 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
 def test_check_send_message_o_f_marks_participated_and_returns_iteration(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
 
     assert not timeline_manager._send.has_participated("out_f", None)
     iteration = timeline_manager.check_send_message("out_f")
@@ -184,8 +182,9 @@ def test_check_send_message_o_f_marks_participated_and_returns_iteration(
 def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
 
     iteration = timeline_manager.check_send_message("out_a1")
 
@@ -199,8 +198,9 @@ def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
 def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     check_received(timeline_manager, "in_a1", None, [0])
     # "in_a1_2" never received, so S hasn't fully led :A1 yet
 
@@ -215,13 +215,14 @@ def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
 def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     check_received(timeline_manager, "in_a1", None, [0])
 
-    timeline_manager.check_receive("in_a1_2")
+    timeline_manager.check_receive_s("in_a1_2")
     with pytest.raises(MessageOutOfSync) as exc_info:
-        timeline_manager.record_received_message("in_a1_2", None, [7])
+        timeline_manager.record_received_s_message("in_a1_2", None, [7])
     assert exc_info.value.port == timeline_manager._port_manager.get_port("in_a1_2")
     assert exc_info.value.slot is None
 
@@ -248,14 +249,15 @@ def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
 def test_check_send_message_o_i_when_o_i_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
 
     first_iteration = timeline_manager.check_send_message("out_a1")
-    timeline_manager.check_receive("in_a1")
-    timeline_manager.record_received_message("in_a1", None, first_iteration)
-    timeline_manager.check_receive("in_a1_2")
-    timeline_manager.record_received_message("in_a1_2", None, first_iteration)
+    timeline_manager.check_receive_s("in_a1")
+    timeline_manager.record_received_s_message("in_a1", None, first_iteration)
+    timeline_manager.check_receive_s("in_a1_2")
+    timeline_manager.record_received_s_message("in_a1_2", None, first_iteration)
 
     second_iteration = timeline_manager.check_send_message("out_a1")
 
@@ -270,8 +272,9 @@ def test_check_send_message_o_i_when_o_i_leads_and_complete(
 def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so the sub-iteration is incomplete
 
@@ -283,57 +286,35 @@ def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
     )
 
 
-def test_check_receive_f_init_allowed_when_not_yet_participated(
-    timeline_manager: TimelineManager,
+@pytest.mark.parametrize("iterationcount", ([], [1], [4], [1, 2, 3, 4]))
+def test_check_finit_iterations(
+    timeline_manager: TimelineManager, iterationcount: IterationCount
 ) -> None:
-    timeline_manager.check_receive("in_f")
-    assert not timeline_manager._receive.has_participated("in_f", None)
-
-    timeline_manager.record_received_message("in_f", None, [3])
-    assert timeline_manager._iteration == [3]
-    assert timeline_manager._receive.has_participated("in_f", None)
-
-    check_received(timeline_manager, "muscle_settings_in", None, [3])
-
-    assert timeline_manager._iteration == [3]
-    assert timeline_manager._receive.has_participated("muscle_settings_in", None)
-
-
-def test_check_receive_f_init_raises_already_participated_when_received_twice(
-    timeline_manager: TimelineManager,
-) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-
-    with pytest.raises(AlreadyParticipated) as exc_info:
-        timeline_manager.check_receive("in_f")
-
-    assert exc_info.value.port == timeline_manager._port_manager.get_port("in_f")
-    assert exc_info.value.slot is None
-    assert exc_info.value.action == "receive"
-
-
-def test_record_received_message_f_init_raises_when_iteration_differs(
-    timeline_manager: TimelineManager,
-) -> None:
-    """Once the main timeline has started, an F_INIT message for a different
-    iteration is rejected."""
-    check_received(timeline_manager, "in_f", None, [3])
-    timeline_manager.check_receive("muscle_settings_in")
-
-    with pytest.raises(MessageOutOfSync) as exc_info:
-        timeline_manager.record_received_message("muscle_settings_in", None, [4])
-
-    assert exc_info.value.port == timeline_manager._port_manager.get_port(
-        "muscle_settings_in"
+    result = timeline_manager.check_finit_iterations(
+        {
+            ("in_f", None): iterationcount.copy(),
+            ("muscle_settings_in", None): iterationcount.copy(),
+        }
     )
-    assert exc_info.value.slot is None
+    assert result == iterationcount
+
+
+def test_check_finit_iterations_when_iteration_differs(
+    timeline_manager: TimelineManager,
+) -> None:
+    """All F_INIT messages should have the same iteration count."""
+    with pytest.raises(RuntimeError, match="parallel timelines"):
+        timeline_manager.check_finit_iterations(
+            {("in_f", None): [3], ("muscle_settings_in", None): [4]}
+        )
 
 
 def test_check_receive_message_s_starts_subtimeline_with_s_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
 
     check_received(timeline_manager, "in_a2", None, [0])
 
@@ -346,13 +327,14 @@ def test_check_receive_message_s_starts_subtimeline_with_s_leading(
 def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     timeline_manager.check_send_message("out_a2")
     # "out_a2_2" never sent, so O_I hasn't fully led :A2 yet
 
     with pytest.raises(PortBlocked) as exc_info:
-        timeline_manager.check_receive("in_a2")
+        timeline_manager.check_receive_s("in_a2")
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("send", "out_a2_2", [])
@@ -362,8 +344,9 @@ def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
 def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     timeline_manager.check_send_message("out_a2")
     timeline_manager.check_send_message("out_a2_2")
 
@@ -377,7 +360,7 @@ def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
     # A second receive on in_a2 cannot advance the sub-iteration itself: with O_I
     # leading, only a new O_I send is allowed to do that.
     with pytest.raises(PortBlocked) as exc_info:
-        timeline_manager.check_receive("in_a2")
+        timeline_manager.check_receive_s("in_a2")
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("send", "out_a2", []), ("send", "out_a2_2", [])
@@ -387,8 +370,9 @@ def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
 def test_check_receive_message_s_when_s_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
 
     check_received(timeline_manager, "in_a2", None, [1])
 
@@ -398,9 +382,9 @@ def test_check_receive_message_s_when_s_leads_and_complete(
     timeline_manager.check_send_message("out_a2")
     timeline_manager.check_send_message("out_a2_2")
 
-    timeline_manager.check_receive("in_a2")
+    timeline_manager.check_receive_s("in_a2")
     with pytest.raises(MessageOutOfSync) as exc_info:
-        timeline_manager.record_received_message("in_a2", None, first_iteration)
+        timeline_manager.record_received_s_message("in_a2", None, first_iteration)
     assert exc_info.value.port == timeline_manager._port_manager.get_port("in_a2")
     assert exc_info.value.slot is None
 
@@ -417,13 +401,14 @@ def test_check_receive_message_s_when_s_leads_and_complete(
 def test_check_receive_message_s_blocked_when_s_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_finit_iterations(
+        {("in_f", None): [], ("muscle_settings_in", None): []}
+    )
     check_received(timeline_manager, "in_a2", None, [1])
     # neither "out_a2" nor "out_a2_2" received, so the sub-iteration is incomplete
 
     with pytest.raises(PortBlocked) as exc_info:
-        timeline_manager.check_receive("in_a2")
+        timeline_manager.check_receive_s("in_a2")
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("send", "out_a2", []), ("send", "out_a2_2", [])
@@ -435,8 +420,9 @@ def test_finish_reuse_iteration_resets_when_complete(
 ) -> None:
     # Drive one full reuse loop iteration, using :A1's sub-timeline, to
     # completion.
-    check_received(timeline_manager, "in_f", None, [3])
-    check_received(timeline_manager, "muscle_settings_in", None, [3])
+    assert timeline_manager.check_finit_iterations(
+        {("in_f", None): [3], ("muscle_settings_in", None): [3]}
+    ) == [3]
     timeline_manager.check_send_message("out_a1")
     check_received(timeline_manager, "in_a1", None, [3, 0])
     check_received(timeline_manager, "in_a1_2", None, [3, 0])
@@ -457,8 +443,9 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 ) -> None:
     # Start a reuse loop iteration but leave it incomplete: :A1's
     # sub-timeline is started but never finishes, and O_F never sends.
-    check_received(timeline_manager, "in_f", None, [4])
-    check_received(timeline_manager, "muscle_settings_in", None, [4])
+    assert timeline_manager.check_finit_iterations(
+        {("in_f", None): [4], ("muscle_settings_in", None): [4]}
+    ) == [4]
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so :A1 is incomplete, and
     # "out_f" is never sent either
@@ -477,8 +464,9 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 def test_get_state_and_restore_state_round_trip(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [3])
-    check_received(timeline_manager, "muscle_settings_in", None, [3])
+    assert timeline_manager.check_finit_iterations(
+        {("in_f", None): [3], ("muscle_settings_in", None): [3]}
+    ) == [3]
     timeline_manager.check_send_message("out_a1")
     check_received(timeline_manager, "in_a1", None, [3, 0])
     # "in_a1_2" not yet received, so :A1 is incomplete, and "out_f" not yet sent

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -252,7 +252,7 @@ class TimelineManager:
             None if self._port_manager.has_f_init_connections() else []
         )
 
-    def check_finit_iterations(
+    def check_f_init_iterations(
         self, iterations: dict[PortAndSlot, IterationCount]
     ) -> IterationCount:
         """Set current iteration count from pre-received F_INIT messages."""
@@ -338,7 +338,7 @@ class TimelineManager:
         """Check that receiving on the given S port is currently allowed.
 
         Args:
-            port_name: Name of the F_INIT or S port about to receive.
+            port_name: Name of the S port about to receive.
             slot: The slot being received on, if this is a vector port.
         """
         port = self._port_manager.get_port(port_name)
@@ -356,7 +356,7 @@ class TimelineManager:
         check_receive already established that this receive is allowed.
 
         Args:
-            port_name: Name of the F_INIT or S port a message was received on.
+            port_name: Name of the S port a message was received on.
             slot: The slot the message was received on, if this is a vector port.
             iteration: The iteration the received message was sent with.
         """

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from typing import Optional, TypedDict
 
@@ -11,6 +12,8 @@ from libmuscle.util import port_desc
 PortAndSlot: TypeAlias = tuple[str, Optional[int]]  # (port_name, slot)
 IterationCount: TypeAlias = list[int]  # nested iteration counts of a message
 ExpectedActions: TypeAlias = list[tuple[str, Port, list[int]]]
+
+_logger = logging.getLogger(__name__)
 
 
 class SubTimelineState(TypedDict):
@@ -35,7 +38,6 @@ class TimelineState:
 
     iteration: Optional[IterationCount]
     send_participated: list[PortAndSlot]
-    receive_participated: list[PortAndSlot]
     subtimeline_states: dict[str, SubTimelineState]
 
 
@@ -58,6 +60,11 @@ def _expected_message(subject: str, expected: ExpectedActions) -> str:
         f"Not allowed to {subject} yet: was expecting one of the following"
         f" instead:\n{bullets}"
     )
+
+
+def is_subiteration(c1: IterationCount, c2: IterationCount) -> bool:
+    """Check if c1 is a sub-iteration of c2, or if c1 is equal to c2."""
+    return c1[: len(c2)] == c2
 
 
 class TimelineError(RuntimeError):
@@ -232,8 +239,6 @@ class TimelineManager:
             port_manager: The (already connected) port manager for this instance.
         """
         self._port_manager = port_manager
-
-        self._receive = TimelinePorts(port_manager.get_connected_ports(Operator.F_INIT))
         self._send = TimelinePorts(port_manager.get_connected_ports(Operator.O_F))
 
         subtimelines = port_manager.list_subtimelines()
@@ -246,6 +251,28 @@ class TimelineManager:
         self._iteration: Optional[IterationCount] = (
             None if self._port_manager.has_f_init_connections() else []
         )
+
+    def check_finit_iterations(
+        self, iterations: dict[PortAndSlot, IterationCount]
+    ) -> IterationCount:
+        """Set current iteration count from pre-received F_INIT messages."""
+        assert self._iteration is None
+        assert iterations
+        first, *remainder = iterations.values()
+        for it in remainder:
+            if it != first:
+                raise RuntimeError(
+                    "Pre-received F_INIT messages from parallel timelines:\n"
+                    + "\n".join(
+                        f"- {port_desc(port, slot)}: {it}"
+                        for (port, slot), it in iterations.items()
+                    )
+                    + "\nPlease verify that all connected instances send the same "
+                    "number of messages on their O_I ports."
+                )
+
+        self._iteration = first
+        return self._iteration
 
     def check_send_message(
         self, port_name: str, slot: Optional[int] = None
@@ -307,61 +334,34 @@ class TimelineManager:
 
         return self._iteration
 
-    def check_receive(self, port_name: str, slot: Optional[int] = None) -> None:
-        """Check that receiving on the given port is currently allowed.
-
-        An F_INIT port may receive once after the reuse loop starts and before any other
-        ports are used.
-
-        Whether an S port may receive is delegated to the corresponding
-        SubTimelineManager.
+    def check_receive_s(self, port_name: str, slot: Optional[int] = None) -> None:
+        """Check that receiving on the given S port is currently allowed.
 
         Args:
             port_name: Name of the F_INIT or S port about to receive.
             slot: The slot being received on, if this is a vector port.
         """
         port = self._port_manager.get_port(port_name)
+        assert port.operator is Operator.S
+        self._submanagers[port.timeline].check_receive(port, slot)
 
-        if port.operator is Operator.F_INIT:
-            if self._receive.has_participated(port_name, slot):
-                raise AlreadyParticipated(port, slot)
-        elif port.operator is Operator.S:
-            self._submanagers[port.timeline].check_receive(port, slot)
-
-    def record_received_message(
+    def record_received_s_message(
         self,
         port_name: str,
         slot: Optional[int],
         iteration: IterationCount,
     ) -> None:
-        """Record that a message has been received on the given port.
+        """Record that a message has been received on the given S port.
 
         check_receive already established that this receive is allowed.
 
-        For an F_INIT port, if the main timeline has not started yet, its
-        iteration is adopted from the message, otherwise the message must carry
-        the same iteration the main timeline is already on.
-
-        For an S port, recording the message is delegated directly to the
-        corresponding SubTimelineManager.
-
         Args:
-            port_name: Name of the F_INIT or S port a message was received
-                on.
-            slot: The slot the message was received on, if this is a vector
-                port.
+            port_name: Name of the F_INIT or S port a message was received on.
+            slot: The slot the message was received on, if this is a vector port.
             iteration: The iteration the received message was sent with.
         """
         port = self._port_manager.get_port(port_name)
-
-        if port.operator is Operator.F_INIT:
-            if self._iteration is None:
-                self._iteration = iteration
-            elif iteration != self._iteration:
-                raise MessageOutOfSync(port, slot)
-            self._receive.participate(port_name, slot)
-            return
-
+        assert port.operator is Operator.S
         self._submanagers[port.timeline].record_received_message(port, slot, iteration)
 
     def reset(self) -> None:
@@ -373,7 +373,6 @@ class TimelineManager:
         """
         self._iteration = None if self._port_manager.has_f_init_connections() else []
         self._send.reset()
-        self._receive.reset()
         for stm in self._submanagers.values():
             stm.reset()
 
@@ -390,15 +389,13 @@ class TimelineManager:
         """
         assert self._iteration is not None
         iteration = self._iteration
-        if (
-            self._receive.all_participated()
-            and self._send.all_participated()
-            and all(stm.is_complete() for stm in self._submanagers.values())
+        if self._send.all_participated() and all(
+            stm.is_complete() for stm in self._submanagers.values()
         ):
             self.reset()
             return iteration
 
-        expected = _expected_actions(self._send, self._receive)
+        expected = _expected_actions(self._send)
         for stm in self._submanagers.values():
             if not stm.is_complete():
                 expected += _expected_actions(stm._send, stm._receive)
@@ -409,11 +406,10 @@ class TimelineManager:
         """Return the main timeline's iteration and participation, and every
         sub-timeline's state, for saving in a snapshot.
         """
-        # N.B. we only sort send/receive participated to test equality.
+        # N.B. we only sort send.participated to test equality.
         return TimelineState(
             iteration=self._iteration,
             send_participated=sorted(self._send.participated),
-            receive_participated=sorted(self._receive.participated),
             subtimeline_states={
                 str(tl): stm.get_state() for tl, stm in self._submanagers.items()
             },
@@ -430,7 +426,6 @@ class TimelineManager:
         """
         self._iteration = state.iteration
         self._send.participated = {(p, s) for p, s in state.send_participated}
-        self._receive.participated = {(p, s) for p, s in state.receive_participated}
         for tl, stm in self._submanagers.items():
             sub_state = state.subtimeline_states.get(str(tl))
             if sub_state is not None:


### PR DESCRIPTION
This PR adds support for "repeater" conduit filters connected to F_INIT ports.

This updates the logic for pre-receiving F_INIT messages to:
1. Receive op unfiltered F_INIT ports
2. Check received messages for consistency of Milestones and Iteration counts
3. If milestone received:
   1. Check if cached repeated messages are still valid, discard those that are too old
   2. Go back to 1
4. For each repeated F_INIT port
   1. If there is no message in the cache, we need to receive it from the peer. This is a while loop because we may need to receive any number of messages (see comment and associated test case).
   2. Copy the message from the cache
   3. Set data to nil if we need to pad rather than repeat

This PR also removes the F_INIT receive checks in the TimelineManager. The pre-receive logic in communicator is responsible for consistency now.

N.B.
1. I did not add support for repeated messages on S ports. In principle this is possible to add, but it would further complicate the implementation. Users are now instructed to connect to an F_INIT port instead. @LourensVeen Do you know of a use case where it makes sense to connect a conduit `output -> repeat -> o_i port` instead of `output -> f_init port`?
2. The F_INIT message cache should be saved and restored when making checkpoints. I will add this in the following PR to keep the scope of this one somewhat manageable.