### PR TITLE
Refactor decide reuse instance

### DIFF
--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -58,12 +58,6 @@ void Communicator::set_peer_info(PeerInfo const & peer_info) {
     timeline_manager_ = std::make_unique<TimelineManager>(port_manager_);
 }
 
-void Communicator::finish_reuse_iteration() {
-    assert(timeline_manager_);
-    IterationCount finished_iteration = timeline_manager_->finish_reuse_iteration();
-    broadcast_milestone_(Milestone(finished_iteration), true);
-}
-
 TimelineState Communicator::get_state() const {
     assert(timeline_manager_);
     return timeline_manager_->get_state();
@@ -135,6 +129,11 @@ void Communicator::send_message(
 }
 
 Communicator::FInitCacheType Communicator::pre_receive_f_init() {
+    assert(timeline_manager_);
+    auto finished_iteration = timeline_manager_->start_reuse_iteration();
+    if (finished_iteration.is_set())
+        broadcast_milestone_(Milestone(finished_iteration.get()), true);
+
     FInitCacheType cache;
 
     auto pre_receive = [&](std::string & port_name, Optional<int> slot) {
@@ -195,7 +194,7 @@ Communicator::FInitCacheType Communicator::pre_receive_f_init() {
             "report an issue."
         );
     }
-    if (milestone_iterations.at(0).is_set()) {
+    if (!milestone_iterations.empty() && milestone_iterations.at(0).is_set()) {
         // Propagate milestone
         Milestone milestone(milestone_iterations.at(0).get());
         broadcast_milestone_(milestone, false);

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -133,10 +133,6 @@ class Communicator {
          */
         void shutdown();
 
-        /** Prepare the timeline manager for the next reuse loop.
-         */
-        void finish_reuse_iteration();
-
         /** Return the current state of the timeline manager, for saving in a
          * snapshot.
          */

--- a/src/cpp/libmuscle/instance.cpp
+++ b/src/cpp/libmuscle/instance.cpp
@@ -133,8 +133,8 @@ class Instance::Impl {
         SettingsManager settings_manager_;
         std::unique_ptr<SnapshotManager> snapshot_manager_;
         std::unique_ptr<TriggerManager> trigger_manager_;
-        Optional<bool> first_run_;
-        Optional<bool> do_reuse_;
+        bool first_run_;
+        bool did_pre_receive_;
         bool do_resume_;
         bool do_init_;
         std::unordered_map<::ymmsl::Reference, Message> f_init_cache_;
@@ -157,9 +157,8 @@ class Instance::Impl {
                 bool is_send, bool allow_slot_out_of_range = false);
 
         void handle_receive_settings_();
-        bool pre_receive_();
+        void pre_receive_();
         Optional<double> f_init_max_timestamp_();
-        bool decide_reuse_instance_();
         void save_snapshot_(
                 Optional<Message> message, bool final,
                 Optional<double> f_init_max_timestamp);
@@ -193,10 +192,10 @@ Instance::Impl::Impl(
 #endif
     , declared_ports_(ports)
     , settings_manager_()
-    , first_run_()
-    , do_reuse_()
+    , first_run_(true)
+    , did_pre_receive_(false)
     , do_resume_(false)
-    , do_init_(false)
+    , do_init_(true)
     , f_init_cache_()
     , is_shut_down_(false)
     , flags_(flags)
@@ -274,34 +273,87 @@ bool Instance::Impl::reuse_instance() {
     api_guard_->verify_reuse_instance();
 
     bool do_reuse;
-    if (do_reuse_.is_set()) {
-        // thank you, should_save_final_snapshot, for running this already
-        do_reuse = do_reuse_.get();
-        do_reuse_ = {};
-    } else {
-        do_reuse = decide_reuse_instance_();
-    }
+    Error error;
 
-    // now first_run_, do_resume_ and do_init_ are also set correctly
 #ifdef MUSCLE_ENABLE_MPI
     if (mpi_barrier_.is_root()) {
+        try {
 #endif
-        bool do_implicit_checkpoint = (
-                !first_run_.get() &&
+    if (first_run_ && snapshot_manager_->resuming_from_intermediate()) {
+        do_resume_ = true;
+        do_init_ = false;
+        do_reuse = true;
+    } else {
+        bool do_implicit_checkpoint;
+        if (first_run_ && snapshot_manager_->resuming_from_final()) {
+            do_resume_ = true;
+            do_init_ = true;
+            first_run_ = false;
+            do_implicit_checkpoint = false;
+        } else {
+            do_resume_ = false;
+            do_init_ = true;
+            do_implicit_checkpoint = (
+                !first_run_ &&
                 !(InstanceFlags::USES_CHECKPOINT_API & flags_) &&
                 (!!(InstanceFlags::STATE_NOT_REQUIRED_FOR_NEXT_USE & flags_) or
                  !!(InstanceFlags::KEEPS_NO_STATE_FOR_NEXT_USE & flags_)));
+        }
+
+        if (!did_pre_receive_) pre_receive_();
+        did_pre_receive_ = false;
+        // We should enter an iteration of the reuse loop when it is the first run,
+        // or if we have new F_INIT messages in the cache:
+        do_reuse = first_run_ || !f_init_cache_.empty();
 
         if (do_implicit_checkpoint) {
             if (trigger_manager_->should_save_final_snapshot(
                     do_reuse, f_init_max_timestamp_()))
                 save_snapshot_({}, true, f_init_max_timestamp_());
         }
+    }
 
 #ifdef MUSCLE_ENABLE_MPI
+        } catch (std::exception const & exc) {
+            error = exc;
+        }
+        mpi_barrier_.signal();
+        error.bcast(mpi_comm_, mpi_root_);
+        error.throw_if_error();
+
+        int do_reuse_mpi[3] = {do_reuse, do_resume_, do_init_};
+        MPI_Bcast(do_reuse_mpi, 3, MPI_INT, mpi_root_, mpi_comm_);
+
+        // Broadcast settings overlay
+        auto soverlay_data = Data(settings_manager_.overlay);
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, soverlay_data);
+        int size = sbuf.size();
+        MPI_Bcast(&size, 1, MPI_INT, mpi_root_, mpi_comm_);
+        MPI_Bcast(sbuf.data(), size, MPI_CHAR, mpi_root_, mpi_comm_);
+    } else {
+        mpi_barrier_.wait();
+        error.bcast(mpi_comm_, mpi_root_);
+        error.throw_if_error();
+
+        int do_reuse_mpi[3];
+        MPI_Bcast(do_reuse_mpi, 3, MPI_INT, mpi_root_, mpi_comm_);
+        do_reuse = do_reuse_mpi[0];
+        do_resume_ = do_reuse_mpi[1];
+        do_init_ = do_reuse_mpi[2];
+
+        // Apply settings overlay
+        int size = 0;
+        MPI_Bcast(&size, 1, MPI_INT, mpi_root_, mpi_comm_);
+        std::vector<char> buf(size);
+        MPI_Bcast(&buf[0], size, MPI_CHAR, mpi_root_, mpi_comm_);
+        auto zone = std::make_shared<msgpack::zone>();
+        DataConstRef soverlay_data = mcp::unpack_data(zone, &buf[0], size);
+        settings_manager_.overlay = soverlay_data.as<Settings>();
     }
 #endif
 
+    first_run_ = false;
     if (!do_reuse) {
         shutdown_();
     }
@@ -734,13 +786,15 @@ void Instance::Impl::save_snapshot(Message message) {
 bool Instance::Impl::should_save_final_snapshot() {
     api_guard_->verify_should_save_final_snapshot();
 
-    do_reuse_ = decide_reuse_instance_();
     bool result;
 #ifdef MUSCLE_ENABLE_MPI
     if (mpi_barrier_.is_root()) {
 #endif
+        pre_receive_();
+        did_pre_receive_ = true;
+        bool do_reuse = !f_init_cache_.empty();  // Reuse if we received new messages
         result = trigger_manager_->should_save_final_snapshot(
-                do_reuse_.get(), f_init_max_timestamp_());
+                do_reuse, f_init_max_timestamp_());
 #ifdef MUSCLE_ENABLE_MPI
         mpi_barrier_.signal();
         int result_mpi = result;
@@ -917,14 +971,15 @@ void Instance::Impl::handle_receive_settings_() {
  *
  * @return true iff no ports were closed.
  */
-bool Instance::Impl::pre_receive_() {
+void Instance::Impl::pre_receive_() {
     ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
 
     try {
         f_init_cache_ = communicator_->pre_receive_f_init();
     } catch (PortClosed &err) {
         profiler_->record_event(std::move(sw_event));
-        return false;
+        f_init_cache_.clear();
+        return;
     } catch (std::runtime_error &err) {
         shutdown_(err.what());
         throw;
@@ -945,7 +1000,6 @@ bool Instance::Impl::pre_receive_() {
             item.second.unset_settings();
         }
     }
-    return true;
 }
 
 /** Return max timestamp of pre-received F_INIT messages
@@ -958,116 +1012,6 @@ Optional<double> Instance::Impl::f_init_max_timestamp_() {
             result = timestamp;
     }
     return result;
-}
-
-/** Decide whether and how to reuse the instance.
- *
- * This sets self._first_run, self._do_resume and self._do_init, and
- * returns whether to reuse one more time. This is the real top of
- * the reuse loop, and it gets called by reuse_instance and
- * should_save_final_snapshot.
- */
-bool Instance::Impl::decide_reuse_instance_() {
-    if (!first_run_.is_set())
-        first_run_ = true;
-    else
-        first_run_ = false;
-
-    bool do_reuse;
-
-    Error error;
-
-#ifdef MUSCLE_ENABLE_MPI
-    int rank;
-    MPI_Comm_rank(mpi_comm_, &rank);
-
-    if (mpi_barrier_.is_root()) {
-        try {
-#endif
-            if (!first_run_.get())
-                communicator_->finish_reuse_iteration();
-
-            bool f_init_connected = port_manager_->has_f_init_connections();
-            if (first_run_.get() && snapshot_manager_->resuming_from_intermediate()) {
-                // resume from intermediate
-                do_resume_ = true;
-                do_init_ = false;
-                do_reuse = true;
-            } else if (first_run_.get() && snapshot_manager_->resuming_from_final()) {
-                // resume from final
-                if (f_init_connected) {
-                    bool got_f_init_messages = pre_receive_();
-                    do_resume_ = true;
-                    do_init_ = true;
-                    do_reuse = got_f_init_messages;
-                } else {
-                    do_resume_ = false;
-                    do_init_ = false;
-                    do_reuse = false;
-                }
-            } else {
-                // fresh start or resuming from implicit snapshot
-                do_resume_ = false;
-
-                if (!f_init_connected) {
-                    // simple straight single run without resuming
-                    do_init_ = first_run_.get();
-                    do_reuse = first_run_.get();
-                } else {
-                    // not resuming and f_init connected, run while we get messages
-                    bool got_f_init_messages = pre_receive_();
-                    do_init_ = got_f_init_messages;
-                    do_reuse = got_f_init_messages;
-                }
-            }
-
-#ifdef MUSCLE_ENABLE_MPI
-        }
-        catch (std::exception const & exc) {
-            error = exc;
-        }
-
-        mpi_barrier_.signal();
-        error.bcast(mpi_comm_, mpi_root_);
-        error.throw_if_error();
-
-        int do_reuse_mpi[3] = {do_reuse, do_resume_, do_init_};
-        MPI_Bcast(do_reuse_mpi, 3, MPI_INT, mpi_root_, mpi_comm_);
-    } else {
-        mpi_barrier_.wait();
-        error.bcast(mpi_comm_, mpi_root_);
-        error.throw_if_error();
-
-        int do_reuse_mpi[3];
-        MPI_Bcast(do_reuse_mpi, 3, MPI_INT, mpi_root_, mpi_comm_);
-        do_reuse = do_reuse_mpi[0];
-        do_resume_ = do_reuse_mpi[1];
-        do_init_ = do_reuse_mpi[2];
-    }
-#endif
-
-
-#ifdef MUSCLE_ENABLE_MPI
-    if (mpi_barrier_.is_root()) {
-        auto soverlay_data = Data(settings_manager_.overlay);
-        msgpack::sbuffer sbuf;
-        msgpack::pack(sbuf, soverlay_data);
-        int size = sbuf.size();
-        MPI_Bcast(&size, 1, MPI_INT, mpi_root_, mpi_comm_);
-        MPI_Bcast(sbuf.data(), size, MPI_CHAR, mpi_root_, mpi_comm_);
-    }
-    else {
-        int size = 0;
-        MPI_Bcast(&size, 1, MPI_INT, mpi_root_, mpi_comm_);
-        std::vector<char> buf(size);
-        MPI_Bcast(&buf[0], size, MPI_CHAR, mpi_root_, mpi_comm_);
-        auto zone = std::make_shared<msgpack::zone>();
-        DataConstRef soverlay_data = mcp::unpack_data(zone, &buf[0], size);
-        settings_manager_.overlay = soverlay_data.as<Settings>();
-    }
-#endif
-
-    return do_reuse;
 }
 
 /** Save a snapshot to disk and notify manager.

--- a/src/cpp/libmuscle/instance.cpp
+++ b/src/cpp/libmuscle/instance.cpp
@@ -134,7 +134,7 @@ class Instance::Impl {
         std::unique_ptr<SnapshotManager> snapshot_manager_;
         std::unique_ptr<TriggerManager> trigger_manager_;
         bool first_run_;
-        bool did_pre_receive_;
+        Optional<bool> do_reuse_;
         bool do_resume_;
         bool do_init_;
         std::unordered_map<::ymmsl::Reference, Message> f_init_cache_;
@@ -157,7 +157,7 @@ class Instance::Impl {
                 bool is_send, bool allow_slot_out_of_range = false);
 
         void handle_receive_settings_();
-        void pre_receive_();
+        bool pre_receive_();
         Optional<double> f_init_max_timestamp_();
         void save_snapshot_(
                 Optional<Message> message, bool final,
@@ -193,7 +193,7 @@ Instance::Impl::Impl(
     , declared_ports_(ports)
     , settings_manager_()
     , first_run_(true)
-    , did_pre_receive_(false)
+    , do_reuse_()
     , do_resume_(false)
     , do_init_(true)
     , f_init_cache_()
@@ -300,11 +300,14 @@ bool Instance::Impl::reuse_instance() {
                  !!(InstanceFlags::KEEPS_NO_STATE_FOR_NEXT_USE & flags_)));
         }
 
-        if (!did_pre_receive_) pre_receive_();
-        did_pre_receive_ = false;
-        // We should enter an iteration of the reuse loop when it is the first run,
-        // or if we have new F_INIT messages in the cache:
-        do_reuse = first_run_ || !f_init_cache_.empty();
+        if (do_reuse_.is_set()) {
+            // thank you, should_save_final_snapshot, for running this already
+            do_reuse = do_reuse_.get();
+            do_reuse_ = {};
+        } else {
+            bool has_messages = pre_receive_();
+            do_reuse = first_run_ || has_messages;
+        }
 
         if (do_implicit_checkpoint) {
             if (trigger_manager_->should_save_final_snapshot(
@@ -790,11 +793,9 @@ bool Instance::Impl::should_save_final_snapshot() {
 #ifdef MUSCLE_ENABLE_MPI
     if (mpi_barrier_.is_root()) {
 #endif
-        pre_receive_();
-        did_pre_receive_ = true;
-        bool do_reuse = !f_init_cache_.empty();  // Reuse if we received new messages
+        do_reuse_ = pre_receive_();
         result = trigger_manager_->should_save_final_snapshot(
-                do_reuse, f_init_max_timestamp_());
+                do_reuse_.get(), f_init_max_timestamp_());
 #ifdef MUSCLE_ENABLE_MPI
         mpi_barrier_.signal();
         int result_mpi = result;
@@ -971,7 +972,7 @@ void Instance::Impl::handle_receive_settings_() {
  *
  * @return true iff no ports were closed.
  */
-void Instance::Impl::pre_receive_() {
+bool Instance::Impl::pre_receive_() {
     ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
 
     try {
@@ -979,11 +980,12 @@ void Instance::Impl::pre_receive_() {
     } catch (PortClosed &err) {
         profiler_->record_event(std::move(sw_event));
         f_init_cache_.clear();
-        return;
+        return false;
     } catch (std::runtime_error &err) {
         shutdown_(err.what());
         throw;
     }
+    bool has_messages = !f_init_cache_.empty();
 
     // Handle received settings
     if (port_manager_->settings_in_connected())
@@ -1000,6 +1002,7 @@ void Instance::Impl::pre_receive_() {
             item.second.unset_settings();
         }
     }
+    return has_messages;
 }
 
 /** Return max timestamp of pre-received F_INIT messages

--- a/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
@@ -96,11 +96,11 @@ class MockCommunicator : public MockClass<MockCommunicator> {
             NAME_MOCK_MEM_FUN(MockCommunicator, get_locations);
             NAME_MOCK_MEM_FUN(MockCommunicator, set_peer_info);
             NAME_MOCK_MEM_FUN(MockCommunicator, send_message);
+            NAME_MOCK_MEM_FUN(MockCommunicator, pre_receive_f_init);
             NAME_MOCK_MEM_FUN(MockCommunicator, receive_s_message);
             NAME_MOCK_MEM_FUN(MockCommunicator, shutdown);
             NAME_MOCK_MEM_FUN(MockCommunicator, set_receive_timeout);
             NAME_MOCK_MEM_FUN(MockCommunicator, get_receive_timeout);
-            NAME_MOCK_MEM_FUN(MockCommunicator, finish_reuse_iteration);
             NAME_MOCK_MEM_FUN(MockCommunicator, get_state);
             NAME_MOCK_MEM_FUN(MockCommunicator, restore_state);
         }
@@ -144,8 +144,6 @@ class MockCommunicator : public MockClass<MockCommunicator> {
         MockFun<Void, Val<double>> set_receive_timeout;
 
         MockFun<Val<double>> get_receive_timeout;
-
-        MockFun<Void> finish_reuse_iteration;
 
         MockFun<Val<TimelineState>> get_state;
 

--- a/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
@@ -21,7 +21,7 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive);
             NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_message);
             NAME_MOCK_MEM_FUN(MockTimelineManager, reset);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, finish_reuse_iteration);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, start_reuse_iteration);
             NAME_MOCK_MEM_FUN(MockTimelineManager, get_state);
             NAME_MOCK_MEM_FUN(MockTimelineManager, restore_state);
         }
@@ -49,7 +49,7 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
 
         MockFun<Void> reset;
 
-        MockFun<Val<IterationCount>> finish_reuse_iteration;
+        MockFun<Val<Optional<IterationCount>>> start_reuse_iteration;
 
         MockFun<Val<TimelineState>> get_state;
 

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -61,6 +61,7 @@ using libmuscle::_MUSCLE_IMPL_NS::MockMPPClient;
 using libmuscle::_MUSCLE_IMPL_NS::MockMPPServer;
 using libmuscle::_MUSCLE_IMPL_NS::MockPortManager;
 using libmuscle::_MUSCLE_IMPL_NS::MockProfiler;
+using libmuscle::_MUSCLE_IMPL_NS::MockTimelineManager;
 using libmuscle::_MUSCLE_IMPL_NS::MPPMessage;
 using libmuscle::_MUSCLE_IMPL_NS::Optional;
 using libmuscle::_MUSCLE_IMPL_NS::PeerDims;
@@ -94,6 +95,7 @@ struct libmuscle_communicator
         : communicator_("component", {}, connected_port_manager_, profiler_, manager_)
     {
         port_manager_.settings_in_connected.return_value = false;
+        MockTimelineManager::return_value.start_reuse_iteration.return_value = Optional<IterationCount>();
     }
 };
 

--- a/src/cpp/libmuscle/tests/test_instance.cpp
+++ b/src/cpp/libmuscle/tests/test_instance.cpp
@@ -183,7 +183,9 @@ struct libmuscle_instance : ConnectedPortManagerHelper {
         , settings_manager_(instance_.impl_()->settings_manager_)
         , snapshot_manager_(*instance_.impl_()->snapshot_manager_)
         , trigger_manager_(*instance_.impl_()->trigger_manager_)
-    {}
+    {
+        communicator_.pre_receive_f_init.return_value = MockCommunicator::FInitCacheType();
+    }
 };
 
 
@@ -209,7 +211,9 @@ struct libmuscle_instance_dont_apply_overlay : ConnectedPortManagerHelper {
         , settings_manager_(instance_dont_apply_overlay_.impl_()->settings_manager_)
         , snapshot_manager_(*instance_dont_apply_overlay_.impl_()->snapshot_manager_)
         , trigger_manager_(*instance_dont_apply_overlay_.impl_()->trigger_manager_)
-    {}
+    {
+        communicator_.pre_receive_f_init.return_value = MockCommunicator::FInitCacheType();
+    }
 };
 
 
@@ -422,10 +426,12 @@ TEST_F(libmuscle_instance, reuse_set_overlay) {
 }
 
 TEST_F(libmuscle_instance, reuse_closed_port) {
+    ASSERT_TRUE(instance_.reuse_instance());  // First iteration: should always reuse
     communicator_.pre_receive_f_init.side_effect = [](
         ) -> MockCommunicator::FInitCacheType {
             throw PortClosed();
         };
+    ASSERT_THROW(communicator_.pre_receive_f_init(), PortClosed);
     ASSERT_FALSE(instance_.reuse_instance());
 }
 
@@ -436,13 +442,11 @@ TEST_F(libmuscle_instance, reuse_no_f_init_ports) {
     ASSERT_FALSE(instance_.reuse_instance());
 }
 
-TEST_F(libmuscle_instance, reuse_subsequent_iteration_finishes_reuse_iteration) {
+TEST_F(libmuscle_instance, reuse_always_prereceives) {
     port_manager_.has_f_init_connections.return_value = false;
 
     instance_.reuse_instance();
-    ASSERT_FALSE(communicator_.finish_reuse_iteration.called());
-    instance_.reuse_instance();
-    ASSERT_TRUE(communicator_.finish_reuse_iteration.called_once());
+    ASSERT_TRUE(communicator_.pre_receive_f_init.called_once());
 }
 
 TEST_F(libmuscle_instance, send_message) {
@@ -553,7 +557,6 @@ TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings) {
 
 TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings_default) {
     port_manager_.get_port("in").is_connected_ = false;
-    communicator_.pre_receive_f_init.return_value = MockCommunicator::FInitCacheType();
 
     instance_dont_apply_overlay_.reuse_instance();
 

--- a/src/cpp/libmuscle/tests/test_timeline_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_timeline_manager.cpp
@@ -120,6 +120,7 @@ struct libmuscle_timeline_manager : ::testing::Test {
             bool include_settings = false) {
         port_manager_ = make_port_manager(declared_ports, timelines, {}, include_settings);
         tm_ = std::make_unique<TimelineManager>(*port_manager_);
+        ASSERT_FALSE(tm_->start_reuse_iteration().is_set());
     }
 };
 
@@ -153,6 +154,7 @@ struct libmuscle_vector_timeline_manager : libmuscle_timeline_manager {
         port_manager_ = make_port_manager(
                 PortsDescription{{Operator::O_F, {"out_v[]"}}}, {}, {{"out_v", {3}}});
         tm_ = std::make_unique<TimelineManager>(*port_manager_);
+        tm_->start_reuse_iteration();
     }
 };
 
@@ -303,7 +305,7 @@ TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_raises_when_incom
     check_received(*tm_, "muscle_settings_in", {}, {3});
     // out_f never sent
 
-    ASSERT_THROW(tm_->finish_reuse_iteration(), ReuseLoopIncomplete);
+    ASSERT_THROW(tm_->start_reuse_iteration(), ReuseLoopIncomplete);
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_resets_when_complete) {
@@ -311,7 +313,7 @@ TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_resets_when_compl
     check_received(*tm_, "muscle_settings_in", {}, {3});
     tm_->check_send_message("out_f");
 
-    tm_->finish_reuse_iteration();
+    tm_->start_reuse_iteration();
 
     // fully reset: the same sequence works again from scratch
     check_received(*tm_, "in_f", {}, {4});
@@ -326,7 +328,7 @@ TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeli
     check_received(*tm_, "muscle_settings_in", {}, {3});
     tm_->check_send_message("out_f");
 
-    ASSERT_NO_THROW(tm_->finish_reuse_iteration());
+    ASSERT_NO_THROW(tm_->start_reuse_iteration());
 }
 
 
@@ -385,7 +387,7 @@ TEST_F(libmuscle_vector_timeline_manager, each_slot_participates_independently) 
 TEST_F(libmuscle_vector_timeline_manager, reuse_loop_incomplete_lists_missing_slots) {
     tm_->check_send_message("out_v", 0);
 
-    ASSERT_THROW(tm_->finish_reuse_iteration(), ReuseLoopIncomplete);
+    ASSERT_THROW(tm_->start_reuse_iteration(), ReuseLoopIncomplete);
 }
 
 TEST_F(libmuscle_vector_timeline_manager, finish_reuse_iteration_ok_once_all_slots_sent) {
@@ -393,5 +395,5 @@ TEST_F(libmuscle_vector_timeline_manager, finish_reuse_iteration_ok_once_all_slo
     tm_->check_send_message("out_v", 1);
     tm_->check_send_message("out_v", 2);
 
-    ASSERT_NO_THROW(tm_->finish_reuse_iteration());
+    ASSERT_NO_THROW(tm_->start_reuse_iteration());
 }

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -396,9 +396,6 @@ TimelineManager::TimelineManager(PortManager const & port_manager)
 {
     for (auto const & tl : port_manager_.list_subtimelines())
         submanagers_.emplace(tl, SubTimelineManager(tl, port_manager_));
-
-    if (!port_manager_.has_f_init_connections())
-        iteration_ = IterationCount();
 }
 
 IterationCount TimelineManager::check_send_message(
@@ -464,8 +461,8 @@ void TimelineManager::reset() {
         item.second.reset();
 }
 
-IterationCount TimelineManager::finish_reuse_iteration() {
-    IterationCount iteration(iteration_.get());
+Optional<IterationCount> TimelineManager::start_reuse_iteration() {
+    auto iteration = iteration_;
     bool subtimelines_complete = true;
     for (auto const & item : submanagers_) {
         if (!item.second.is_complete()) {
@@ -474,7 +471,10 @@ IterationCount TimelineManager::finish_reuse_iteration() {
         }
     }
 
-    if (receive_.all_participated() && send_.all_participated() && subtimelines_complete) {
+    if (!iteration.is_set() || (
+            receive_.all_participated()
+            && send_.all_participated()
+            && subtimelines_complete )) {
         reset();
         return iteration;
     }

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -326,16 +326,17 @@ class TimelineManager {
          */
         void reset();
 
-        /** Check if the current reuse loop iteration has finished and reset
-         * for the next one.
+        /** Called at the start of the reuse loop.
          *
+         * If this is not the first run, checks if the previous reuse loop is complete:
          * The reuse loop iteration is complete once every main-timeline port
          * has participated and every sub-timeline has either completed a
          * sub-iteration or wasn't used at all this reuse loop iteration.
          * 
-         * @return Iteration count of the finished reuse loop. 
+         * @return Iteration count of the finished reuse loop or None if this is the
+         *      first run.
          */
-        IterationCount finish_reuse_iteration();
+        Optional<IterationCount> start_reuse_iteration();
 
         /** Return the main timeline's iteration and participation, and every
          * sub-timeline's state, for saving in a snapshot. */

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -165,11 +165,6 @@ class Communicator:
         """
         self._timeline_manager.restore_state(state)
 
-    def finish_reuse_iteration(self) -> None:
-        """Finish the reuse iteration and send milestones."""
-        finished_iteration = self._timeline_manager.finish_reuse_iteration()
-        self._broadcast_milestone(Milestone(finished_iteration), True)
-
     def send_message(
         self,
         port_name: str,
@@ -254,6 +249,10 @@ class Communicator:
         Returns:
             f_init_cache: The received messages.
         """
+        finished_iteration = self._timeline_manager.start_reuse_iteration()
+        if finished_iteration is not None:
+            self._broadcast_milestone(Milestone(finished_iteration), True)
+
         cache: FInitCacheType = {}
 
         def pre_receive(port_name: str, slot: Optional[int]) -> None:
@@ -291,7 +290,7 @@ class Communicator:
                 f"F_INIT: {milestone_iterations}. This is not supposed to happen and "
                 "may be a bug in libmuscle. Please report an issue."
             )
-        if milestone_iterations[0] is not None:
+        if milestone_iterations and milestone_iterations[0] is not None:
             # Propagate milestone
             milestone = Milestone(milestone_iterations[0])
             self._broadcast_milestone(milestone, False)

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -156,20 +156,16 @@ class Instance:
         self._trigger_manager = TriggerManager()
         """Keeps track of checkpoints and triggers snapshots."""
 
-        self._first_run: Optional[bool] = None
+        self._first_run = True
         """Whether this is the first iteration of the reuse loop"""
 
-        self._do_reuse: Optional[bool] = None
-        """Whether to enter this iteration of the reuse loop
-
-        This is None during the reuse loop, and set between
-        should_save_final_snapshot and reuse_instance.
-        """
+        self._did_pre_receive = False
+        """Flag set to True iff should_save_final_snapshot already pre-received"""
 
         self._do_resume = False
         """Whether to resume on this iteration of the reuse loop"""
 
-        self._do_init = False
+        self._do_init = True
         """Whether to do f_init on this iteration of the reuse loop"""
 
         self._f_init_cache: FInitCacheType = {}
@@ -229,31 +225,43 @@ class Instance:
         """
         self._api_guard.verify_reuse_instance()
 
-        if self._do_reuse is not None:
-            # thank you, should_save_final_snapshot, for running this already
-            do_reuse = self._do_reuse
-            self._do_reuse = None
+        if self._first_run and self._snapshot_manager.resuming_from_intermediate():
+            self._do_resume = True
+            self._do_init = False
+            do_reuse = True
         else:
-            do_reuse = self._decide_reuse_instance()
+            if self._first_run and self._snapshot_manager.resuming_from_final():
+                self._do_resume = True
+                self._do_init = True
+                self._first_run = False
+                do_implicit_checkpoint = False
+            else:
+                self._do_resume = False
+                self._do_init = True
+                do_implicit_checkpoint = (
+                    not self._first_run
+                    and InstanceFlags.USES_CHECKPOINT_API not in self._flags
+                    and (
+                        InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE in self._flags
+                        or InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE in self._flags
+                    )
+                )
 
-        # now _first_run, _do_resume and _do_init are also set correctly
+            if not self._did_pre_receive:
+                self._pre_receive()
+            self._did_pre_receive = False
+            # We should enter an iteration of the reuse loop when it is the first run,
+            # or if we have new F_INIT messages in the cache:
+            do_reuse = self._first_run or bool(self._f_init_cache)
 
-        do_implicit_checkpoint = (
-            not self._first_run
-            and InstanceFlags.USES_CHECKPOINT_API not in self._flags
-            and (
-                InstanceFlags.STATE_NOT_REQUIRED_FOR_NEXT_USE in self._flags
-                or InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE in self._flags
-            )
-        )
+            if do_implicit_checkpoint:
+                if self._trigger_manager.should_save_final_snapshot(
+                    do_reuse, self.__f_init_max_timestamp
+                ):
+                    # store a None instead of a Message
+                    self._save_snapshot(None, True, self.__f_init_max_timestamp)
 
-        if do_implicit_checkpoint:
-            if self._trigger_manager.should_save_final_snapshot(
-                do_reuse, self.__f_init_max_timestamp
-            ):
-                # store a None instead of a Message
-                self._save_snapshot(None, True, self.__f_init_max_timestamp)
-
+        self._first_run = False
         if not do_reuse:
             self.__shutdown()
 
@@ -683,9 +691,11 @@ class Instance:
         """
         self._api_guard.verify_should_save_final_snapshot()
 
-        self._do_reuse = self._decide_reuse_instance()
+        self._pre_receive()
+        self._did_pre_receive = True
+        do_reuse = bool(self._f_init_cache)  # Reuse if we received new messages
         result = self._trigger_manager.should_save_final_snapshot(
-            self._do_reuse, self.__f_init_max_timestamp
+            do_reuse, self.__f_init_max_timestamp
         )
 
         self._api_guard.should_save_final_snapshot_done(result)
@@ -867,55 +877,6 @@ class Instance:
             "Timeout on receiving messages set to %f",
             self._communicator._receive_timeout,
         )
-
-    def _decide_reuse_instance(self) -> bool:
-        """Decide whether and how to reuse the instance.
-
-        This sets self._first_run, self._do_resume and self._do_init, and
-        returns whether to reuse one more time. This is the real top of
-        the reuse loop, and it gets called by reuse_instance and
-        should_save_final_snapshot.
-        """
-        if self._first_run is None:
-            self._first_run = True
-        elif self._first_run:
-            self._first_run = False
-
-        if not self._first_run:
-            self._communicator.finish_reuse_iteration()
-
-        # resume from intermediate
-        if self._first_run and self._snapshot_manager.resuming_from_intermediate():
-            self._do_resume = True
-            self._do_init = False
-            return True
-
-        f_init_connected = self._port_manager.has_f_init_connections()
-
-        # resume from final
-        if self._first_run and self._snapshot_manager.resuming_from_final():
-            if f_init_connected:
-                got_f_init_messages = self._pre_receive()
-                self._do_resume = True
-                self._do_init = True
-                return got_f_init_messages
-            else:
-                self._do_resume = False  # unused
-                self._do_init = False  # unused
-                return False
-
-        # fresh start or resuming from implicit snapshot
-        self._do_resume = False
-
-        # simple straight single run without resuming
-        if not f_init_connected:
-            self._do_init = self._first_run
-            return self._first_run
-
-        # not resuming and f_init connected, run while we get messages
-        got_f_init_messages = self._pre_receive()
-        self._do_init = got_f_init_messages
-        return got_f_init_messages
 
     def _save_snapshot(
         self,
@@ -1117,7 +1078,7 @@ class Instance:
                         self.__shutdown(err_msg)
                         raise RuntimeError(err_msg)
 
-    def _pre_receive(self) -> bool:
+    def _pre_receive(self) -> None:
         """Pre-receives on all ports.
 
         Returns:
@@ -1129,7 +1090,8 @@ class Instance:
             self._f_init_cache = self._communicator.pre_receive_f_init()
         except PortClosed:
             self._profiler.record_event(sw_event)
-            return False
+            self._f_init_cache.clear()
+            return
         except RuntimeError as exc:
             self.__shutdown(str(exc))
             raise
@@ -1146,7 +1108,6 @@ class Instance:
                 self.__apply_overlay(msg)
                 self.__check_compatibility(port_name, msg.settings)
                 msg.settings = None
-        return True
 
     def __handle_receive_settings(self) -> None:
         """Handle received settings on pre-received muscle_settings_in."""

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -159,8 +159,14 @@ class Instance:
         self._first_run = True
         """Whether this is the first iteration of the reuse loop"""
 
-        self._did_pre_receive = False
-        """Flag set to True iff should_save_final_snapshot already pre-received"""
+        self._do_reuse: Optional[bool] = None
+        """Whether to enter the next iteration of the reuse loop.
+
+        Possible values:
+        - None: not yet pre-received
+        - True: pre-received and a message was received
+        - False: pre-received, but no messages available anymore
+        """
 
         self._do_resume = False
         """Whether to resume on this iteration of the reuse loop"""
@@ -247,12 +253,13 @@ class Instance:
                     )
                 )
 
-            if not self._did_pre_receive:
-                self._pre_receive()
-            self._did_pre_receive = False
-            # We should enter an iteration of the reuse loop when it is the first run,
-            # or if we have new F_INIT messages in the cache:
-            do_reuse = self._first_run or bool(self._f_init_cache)
+            if self._do_reuse is not None:
+                # thank you, should_save_final_snapshot, for running this already
+                do_reuse = self._do_reuse
+                self._do_reuse = None
+            else:
+                has_messages = self._pre_receive()
+                do_reuse = self._first_run or has_messages
 
             if do_implicit_checkpoint:
                 if self._trigger_manager.should_save_final_snapshot(
@@ -691,11 +698,9 @@ class Instance:
         """
         self._api_guard.verify_should_save_final_snapshot()
 
-        self._pre_receive()
-        self._did_pre_receive = True
-        do_reuse = bool(self._f_init_cache)  # Reuse if we received new messages
+        self._do_reuse = self._pre_receive()
         result = self._trigger_manager.should_save_final_snapshot(
-            do_reuse, self.__f_init_max_timestamp
+            self._do_reuse, self.__f_init_max_timestamp
         )
 
         self._api_guard.should_save_final_snapshot_done(result)
@@ -1078,11 +1083,11 @@ class Instance:
                         self.__shutdown(err_msg)
                         raise RuntimeError(err_msg)
 
-    def _pre_receive(self) -> None:
+    def _pre_receive(self) -> bool:
         """Pre-receives on all ports.
 
         Returns:
-            True iff no ports were closed.
+            True if new F_INIT messages were received.
         """
         sw_event = ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, ProfileTimestamp())
 
@@ -1091,10 +1096,11 @@ class Instance:
         except PortClosed:
             self._profiler.record_event(sw_event)
             self._f_init_cache.clear()
-            return
+            return False
         except RuntimeError as exc:
             self.__shutdown(str(exc))
             raise
+        has_messages = bool(self._f_init_cache)
 
         # Handle received settings
         if self._port_manager.settings_in_connected():
@@ -1108,6 +1114,7 @@ class Instance:
                 self.__apply_overlay(msg)
                 self.__check_compatibility(port_name, msg.settings)
                 msg.settings = None
+        return has_messages
 
     def __handle_receive_settings(self) -> None:
         """Handle received settings on pre-received muscle_settings_in."""

--- a/src/python/libmuscle/test/test_communicator.py
+++ b/src/python/libmuscle/test/test_communicator.py
@@ -48,6 +48,7 @@ def mpp_client(MPPClient):
 @pytest.fixture
 def timeline_manager():
     with patch("libmuscle.communicator.TimelineManager") as MockTimelineManager:
+        MockTimelineManager.return_value.start_reuse_iteration.return_value = None
         yield MockTimelineManager
 
 
@@ -478,13 +479,14 @@ def test_shutdown(
 
 
 def test_send_milestone_at_reuse(
-    connected_communicator, timeline_manager, mock_ports, mpp_server
+    connected_communicator, timeline_manager, mock_ports, mpp_server, mpp_client
 ):
-    timeline_manager().finish_reuse_iteration.return_value = [1, 2]
+    mpp_client.receive.return_value = mock_mpp_receive(data=None, iteration=[1, 3])
+    timeline_manager().start_reuse_iteration.return_value = [1, 2]
 
-    connected_communicator.finish_reuse_iteration()
+    connected_communicator.pre_receive_f_init()
 
-    timeline_manager().finish_reuse_iteration.assert_called_once()
+    timeline_manager().start_reuse_iteration.assert_called_once()
     # Expect a milestone broadcasted to all O_I ports
     num_expected = mock_ports["out_v"].get_length() + mock_ports["out_r"].get_length()
     assert mpp_server.deposit.call_count == num_expected

--- a/src/python/libmuscle/test/test_instance.py
+++ b/src/python/libmuscle/test/test_instance.py
@@ -6,7 +6,7 @@ import pytest
 from ymmsl.v0_2 import Checkpoints, Operator, Settings
 from ymmsl.v0_2 import Reference as Ref
 
-from libmuscle.communicator import PortClosed
+from libmuscle.communicator import Message, PortClosed
 from libmuscle.instance import Instance, InstanceFlags
 from libmuscle.peer_info import PeerInfo
 
@@ -442,11 +442,13 @@ def test_reuse_set_overlay(
 
 
 def test_reuse_closed_port(instance, communicator):
+    assert instance.reuse_instance() is True  # First iteration: should always reuse
     communicator.pre_receive_f_init.side_effect = PortClosed()
     assert instance.reuse_instance() is False
 
 
 def test_reuse_no_closed_port(instance, communicator):
+    communicator.pre_receive_f_init.return_value = {("in", None): Message(1)}
     for _ in range(20):
         assert instance.reuse_instance() is True
     communicator.pre_receive_f_init.side_effect = PortClosed()
@@ -460,16 +462,11 @@ def test_reuse_no_f_init_ports(instance, connected_port_manager, communicator):
     assert instance.reuse_instance() is False
 
 
-def test_reuse_subsequent_iteration_finishes_reuse_iteration(
-    instance, connected_port_manager, communicator
-):
+def test_reuse_always_pre_receives(instance, connected_port_manager, communicator):
     connected_port_manager.has_f_init_connections.return_value = False
 
     instance.reuse_instance()
-    communicator.finish_reuse_iteration.assert_not_called()
-
-    instance.reuse_instance()
-    communicator.finish_reuse_iteration.assert_called_once()
+    communicator.pre_receive_f_init.assert_called_once()
 
 
 def test_send_message(instance, settings_manager, communicator):

--- a/src/python/libmuscle/test/test_timeline_manager.py
+++ b/src/python/libmuscle/test/test_timeline_manager.py
@@ -67,7 +67,9 @@ def timeline_manager(has_f_init: bool, include_settings: bool) -> TimelineManage
     peer_info = PeerInfo(Ref("component"), [], conduits, peer_dims, {}, ymmsl_ports)
     pm.connect_ports(peer_info)
 
-    return TimelineManager(pm)
+    tm = TimelineManager(pm)
+    assert tm.start_reuse_iteration() is None
+    return tm
 
 
 @pytest.fixture
@@ -79,6 +81,7 @@ def vector_timeline_manager() -> TimelineManager:
     pm.connect_ports(peer_info)
 
     tm = TimelineManager(pm)
+    assert tm.start_reuse_iteration() is None
     return tm
 
 
@@ -109,7 +112,7 @@ def test_finish_reuse_iteration_blocked_when_muscle_settings_in_not_received(
     # muscle_settings_in is never received this iteration
 
     with pytest.raises(ReuseLoopIncomplete) as exc_info:
-        timeline_manager.finish_reuse_iteration()
+        timeline_manager.start_reuse_iteration()
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("receive", "muscle_settings_in", [])
@@ -123,7 +126,7 @@ def test_finish_reuse_iteration_ignores_muscle_settings_in_when_disconnected(
     check_received(timeline_manager, "in_f", None, [])
     timeline_manager.check_send_message("out_f")
 
-    timeline_manager.finish_reuse_iteration()
+    timeline_manager.start_reuse_iteration()
 
 
 @pytest.mark.parametrize("has_f_init", [False], indirect=True)
@@ -444,7 +447,7 @@ def test_finish_reuse_iteration_resets_when_complete(
     # sub-timeline is considered complete.
     timeline_manager.check_send_message("out_f")
 
-    timeline_manager.finish_reuse_iteration()
+    timeline_manager.start_reuse_iteration()
 
     # A fresh, just-connected TimelineManager has never participated in
     # anything, so comparing against its state confirms everything was reset.
@@ -464,7 +467,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
     # "out_f" is never sent either
 
     with pytest.raises(ReuseLoopIncomplete) as exc_info:
-        timeline_manager.finish_reuse_iteration()
+        timeline_manager.start_reuse_iteration()
 
     assert exc_info.value.expected == expected(
         timeline_manager,
@@ -515,7 +518,7 @@ def test_vector_port_reuse_iteration_incomplete_lists_missing_slots(
     tm.check_send_message("out_v", 0)
 
     with pytest.raises(ReuseLoopIncomplete) as exc_info:
-        tm.finish_reuse_iteration()
+        tm.start_reuse_iteration()
 
     port_out_v = tm._port_manager.get_port("out_v")
     assert exc_info.value.expected == [("send", port_out_v, [1, 2])]

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -243,9 +243,7 @@ class TimelineManager:
 
         # A component with no connected F_INIT ports has no F_INIT message to
         # learn its iteration from, so its main timeline starts at [].
-        self._iteration: Optional[IterationCount] = (
-            None if self._port_manager.has_f_init_connections() else []
-        )
+        self._iteration: Optional[IterationCount] = None
 
     def check_send_message(
         self, port_name: str, slot: Optional[int] = None
@@ -377,20 +375,19 @@ class TimelineManager:
         for stm in self._submanagers.values():
             stm.reset()
 
-    def finish_reuse_iteration(self) -> IterationCount:
-        """Check if the current reuse loop iteration has finished and reset for the
-        next one.
+    def start_reuse_iteration(self) -> Optional[IterationCount]:
+        """Called at the start of the reuse loop.
 
+        If this is not the first run, checks if the previous reuse loop is complete:
         The reuse loop iteration is complete once every main-timeline port has
         participated and every sub-timeline has either completed a sub-iteration or
         wasn't used at all this reuse loop iteration.
 
         Returns:
-            Iteration count of the finished reuse loop.
+            Iteration count of the finished reuse loop or None if this is the first run.
         """
-        assert self._iteration is not None
         iteration = self._iteration
-        if (
+        if iteration is None or (
             self._receive.all_participated()
             and self._send.all_participated()
             and all(stm.is_complete() for stm in self._submanagers.values())


### PR DESCRIPTION
Simplify things by:
- Ensuring that `Communicator.pre_receive_f_init()` is always called at the beginning of the reuse loop.
  - We will need this for repeater conduit filters on S ports.
  - No separate `finish_reuse_iteration` call anymore, this is now handled during the pre_receive
  - TimelineManager is now also notified at the start of the reuse loop (`finish_reuse_iteration` -> `start_reuse_iteration`)
- Removing `Instance.decide_reuse_instance` and move most logic (back) to reuse_instance().
  - `should_check_final_checkpoint` needs to know only if new F_INIT messages are pre-received: all logic related to resuming from a snapshot and whether this is the first run is only relevant in reuse_instance()
  - This makes it easier to add the relevant Communicator state (the message cache) to the snapshots later