### PR TITLE
Close muscle_settings_in on shutdown

### DIFF
--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -457,8 +457,6 @@ void Communicator::drain_incoming_vector_port_(std::string const & port_name) {
 void Communicator::close_incoming_ports_() {
     for (auto op : {Operator::F_INIT, Operator::S}) {
         for (Port const & port : port_manager_.get_connected_ports(op, {})) {
-            if (!port.is_connected())
-                continue;
             try {
                 if (port.is_vector())
                     drain_incoming_vector_port_(port.name);

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -455,22 +455,29 @@ void Communicator::drain_incoming_vector_port_(std::string const & port_name) {
 }
 
 void Communicator::close_incoming_ports_() {
-    for (auto const & oper_ports : port_manager_.list_ports()) {
-        if (allows_receiving(oper_ports.first)) {
-            for (auto const & port_name : oper_ports.second) {
-                auto const & port = port_manager_.get_port(port_name);
-                if (!port.is_connected())
-                    continue;
+    for (auto op : {Operator::F_INIT, Operator::S}) {
+        for (Port const & port : port_manager_.get_connected_ports(op, {})) {
+            if (!port.is_connected())
+                continue;
+            try {
                 if (port.is_vector())
-                    drain_incoming_vector_port_(port_name);
+                    drain_incoming_vector_port_(port.name);
                 else
-                    drain_incoming_port_(port_name);
+                    drain_incoming_port_(port.name);
+            } catch (std::runtime_error & exc) {
+                auto peer_port = peer_info_.get().get_peer_ports(port.name)[0];
+                Reference peer_name(peer_port.cbegin(), std::prev(peer_port.cend()));
+                log_warning(
+                    "Connection with peer '", peer_name, "' was lost at the end of the "
+                    "simulation, probably because it crashed.");
             }
         }
     }
 }
 
 void Communicator::close_ports_() {
+    if (!peer_info_.is_set())
+        return;  // Not connected yet, no ports to close
     close_outgoing_ports_();
     close_incoming_ports_();
 }

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -580,25 +580,24 @@ class Communicator:
         there will be no more messages, and allows the sending instance to shut down
         cleanly.
         """
-        for operator, port_names in self._port_manager.list_ports().items():
-            if operator.allows_receiving():
-                for port_name in port_names:
-                    port = self._port_manager.get_port(port_name)
-                    if not port.is_connected():
-                        continue
-                    try:
-                        if not port.is_vector():
-                            self._drain_incoming_port(port_name)
-                        else:
-                            self._drain_incoming_vector_port(port_name)
-                    except RuntimeError:
-                        peer_port = self._peer_info.get_peer_ports(port.name)[0]
-                        peer_name = str(peer_port[:-1])
-                        _logger.warning(
-                            "Connection with peer '%s' was lost at the end of the "
-                            "simulation, probably because it crashed.",
-                            peer_name,
-                        )
+        for operator in (Operator.F_INIT, Operator.S):
+            for port in self._port_manager.get_connected_ports(operator):
+                port_name = str(port.name)
+                if not port.is_connected():
+                    continue
+                try:
+                    if not port.is_vector():
+                        self._drain_incoming_port(port_name)
+                    else:
+                        self._drain_incoming_vector_port(port_name)
+                except RuntimeError:
+                    peer_port = self._peer_info.get_peer_ports(port.name)[0]
+                    peer_name = str(peer_port[:-1])
+                    _logger.warning(
+                        "Connection with peer '%s' was lost at the end of the "
+                        "simulation, probably because it crashed.",
+                        peer_name,
+                    )
 
     def _close_ports(self) -> None:
         """Closes all ports.
@@ -606,5 +605,7 @@ class Communicator:
         This sends a close port message on all slots of all outgoing
         ports, then receives one on all incoming ports.
         """
+        if not hasattr(self, "_peer_info"):
+            return  # Not connected yet, no ports to close
         self._close_outgoing_ports()
         self._close_incoming_ports()

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -583,8 +583,6 @@ class Communicator:
         for operator in (Operator.F_INIT, Operator.S):
             for port in self._port_manager.get_connected_ports(operator):
                 port_name = str(port.name)
-                if not port.is_connected():
-                    continue
                 try:
                     if not port.is_vector():
                         self._drain_incoming_port(port_name)


### PR DESCRIPTION
Update Communicator.close_ports:

- Close `muscle_settings_in` port (if connected), which was never done previously
- Skip closing ports when not connected yet

N.B. builds on top of #406, which should be merged first.