### PR TITLE
Refactor internal snapshot state

### DIFF
--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -58,14 +58,18 @@ void Communicator::set_peer_info(PeerInfo const & peer_info) {
     timeline_manager_ = std::make_unique<TimelineManager>(port_manager_);
 }
 
-TimelineState Communicator::get_state() const {
+CommunicatorState Communicator::get_state() const {
     assert(timeline_manager_);
-    return timeline_manager_->get_state();
+    return {
+        port_manager_.get_message_counts(),
+        timeline_manager_->get_state()
+    };
 }
 
-void Communicator::restore_state(TimelineState const & state) {
+void Communicator::restore_state(CommunicatorState const & state) {
     assert(timeline_manager_);
-    timeline_manager_->restore_state(state);
+    port_manager_.restore_message_counts(state.port_message_counts);
+    timeline_manager_->restore_state(state.timeline_state);
 }
 
 void Communicator::send_message(

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -4,6 +4,7 @@
 #include LIBMUSCLE_MOCK_COMMUNICATOR
 #else
 
+#include <libmuscle/communicator_state.hpp>
 #include <libmuscle/message.hpp>
 #include <libmuscle/milestone.hpp>
 #include <libmuscle/mmp_client.hpp>
@@ -136,11 +137,11 @@ class Communicator {
         /** Return the current state of the timeline manager, for saving in a
          * snapshot.
          */
-        TimelineState get_state() const;
+        CommunicatorState get_state() const;
 
         /** Restore the timeline manager to a previously saved state.
          */
-        void restore_state(TimelineState const & state);
+        void restore_state(CommunicatorState const & state);
 
         /** Update the timeout after which the manager is notified that we are
          * waiting for a message.

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -134,12 +134,15 @@ class Communicator {
          */
         void shutdown();
 
-        /** Return the current state of the timeline manager, for saving in a
-         * snapshot.
+        /** Return the current internal state for checkpointing.
+         * 
+         * This includes state for the communicator, port manager and timeline manager.
          */
         CommunicatorState get_state() const;
 
-        /** Restore the timeline manager to a previously saved state.
+        /** Restore a previously saved state.
+         * 
+         * @param state: The state to restore, as returned by get_state()
          */
         void restore_state(CommunicatorState const & state);
 

--- a/src/cpp/libmuscle/communicator_state.cpp
+++ b/src/cpp/libmuscle/communicator_state.cpp
@@ -1,0 +1,38 @@
+#include "communicator_state.hpp"
+
+
+namespace libmuscle { namespace _MUSCLE_IMPL_NS {
+
+Data CommunicatorState::to_data() const {
+    Data pmc = Data::dict();
+    for (const auto & kv : port_message_counts) {
+        Data counts = Data::nils(kv.second.size());
+        for (std::size_t i=0; i<kv.second.size(); ++i) {
+            counts[i] = kv.second[i];
+        }
+        pmc[kv.first] = counts;
+    }
+
+    return Data::dict(
+        "port_message_counts", pmc,
+        "timeline_state", timeline_state.to_data());
+}
+
+CommunicatorState CommunicatorState::from_data(DataConstRef const & data) {
+    CommunicatorState state;
+
+    auto data_pmc = data["port_message_counts"];
+    for (std::size_t i=0; i<data_pmc.size(); ++i) {
+        std::vector<int> counts;
+        for (std::size_t j=0; j<data_pmc.value(i).size(); ++j) {
+            counts.push_back(data_pmc.value(i)[j].as<int>());
+        }
+        state.port_message_counts[data_pmc.key(i)] = counts;
+    }
+
+    state.timeline_state = TimelineState::from_data(data["timeline_state"]);
+
+    return state;
+}
+
+} }

--- a/src/cpp/libmuscle/communicator_state.hpp
+++ b/src/cpp/libmuscle/communicator_state.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "libmuscle/data.hpp"
+#include "libmuscle/port_manager.hpp"
+#include "libmuscle/timeline_manager.hpp"
+
+namespace libmuscle { namespace _MUSCLE_IMPL_NS {
+
+class CommunicatorState {
+    public:
+        PortManager::PortMessageCounts port_message_counts;
+        TimelineState timeline_state;
+
+        /** Convert CommunicatorState into Data */
+        Data to_data() const;
+
+        /** Create CommunicatorState from Data */
+        static CommunicatorState from_data(DataConstRef const & data);
+};
+
+} }

--- a/src/cpp/libmuscle/instance.cpp
+++ b/src/cpp/libmuscle/instance.cpp
@@ -1,6 +1,7 @@
 #include <libmuscle/instance.hpp>
 
 #include <libmuscle/api_guard.hpp>
+#include <libmuscle/communicator_state.hpp>
 #include <libmuscle/communicator.hpp>
 #include <libmuscle/data.hpp>
 #include <libmuscle/mcp/data_pack.hpp>
@@ -124,6 +125,7 @@ class Instance::Impl {
         std::unique_ptr<Profiler> profiler_;
         std::unique_ptr<PortManager> port_manager_;
         std::unique_ptr<Communicator> communicator_;
+        Optional<CommunicatorState> communicator_state_;
 #ifdef MUSCLE_ENABLE_MPI
         int mpi_root_;
         MPI_Comm mpi_comm_;
@@ -229,7 +231,7 @@ Instance::Impl::Impl(
                 new Communicator(
                     name, index, *port_manager_, *profiler_, *manager_));
         snapshot_manager_.reset(new SnapshotManager(
-                instance_name_, *manager_, *port_manager_, *communicator_));
+                instance_name_, *manager_, *communicator_));
         trigger_manager_.reset(new TriggerManager());
 
         register_();
@@ -356,6 +358,7 @@ bool Instance::Impl::reuse_instance() {
     }
 #endif
 
+    communicator_state_ = {};
     first_run_ = false;
     if (!do_reuse) {
         shutdown_();
@@ -973,6 +976,7 @@ void Instance::Impl::handle_receive_settings_() {
  * @return true iff no ports were closed.
  */
 bool Instance::Impl::pre_receive_() {
+    communicator_state_ = communicator_->get_state();
     ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
 
     try {
@@ -1026,11 +1030,20 @@ Optional<double> Instance::Impl::f_init_max_timestamp_() {
 void Instance::Impl::save_snapshot_(
         Optional<Message> message, bool final,
         Optional<double> f_init_max_timestamp) {
+    CommunicatorState communicator_state;
+    if (final) {
+        assert(communicator_state_.is_set());
+        communicator_state = communicator_state_.get();
+    } else {
+        assert(!communicator_state_.is_set());
+        communicator_state = communicator_->get_state();
+    }
     auto triggers = trigger_manager_->get_triggers();
     auto walltime = trigger_manager_->elapsed_walltime();
     auto timestamp = snapshot_manager_->save_snapshot(
             message, final, triggers, walltime,
-            f_init_max_timestamp, settings_manager_.overlay);
+            f_init_max_timestamp, settings_manager_.overlay,
+            communicator_state);
     trigger_manager_->update_checkpoints(timestamp);
 }
 

--- a/src/cpp/libmuscle/snapshot.cpp
+++ b/src/cpp/libmuscle/snapshot.cpp
@@ -13,19 +13,17 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 Snapshot::Snapshot(
             std::vector<std::string> const & triggers,
             double wallclock_time,
-            std::unordered_map<std::string, std::vector<int>> const & port_message_counts,
             bool is_final_snapshot,
             Optional<Message> const & message,
             ::ymmsl::Settings const & settings_overlay,
-            TimelineState const & timeline_state
+            CommunicatorState const & communicator_state
             )
         : triggers(triggers)
         , wallclock_time(wallclock_time)
-        , port_message_counts(port_message_counts)
         , is_final_snapshot(is_final_snapshot)
         , message(message)
         , settings_overlay(settings_overlay)
-        , timeline_state(timeline_state)
+        , communicator_state(communicator_state)
     {}
 
 Snapshot Snapshot::from_bytes(std::vector<char> const & data) {
@@ -38,16 +36,6 @@ Snapshot Snapshot::from_bytes(std::vector<char> const & data) {
     auto data_triggers = dict["triggers"];
     for (std::size_t i=0; i<data_triggers.size(); ++i) {
         triggers.push_back(data_triggers[i].as<std::string>());
-    }
-
-    std::unordered_map<std::string, std::vector<int>> port_message_counts;
-    auto data_pmc = dict["port_message_counts"];
-    for (std::size_t i=0; i<data_pmc.size(); ++i) {
-        std::vector<int> counts;
-        for (std::size_t j=0; j<data_pmc.value(i).size(); ++j) {
-            counts.push_back(data_pmc.value(i)[j].as<int>());
-        }
-        port_message_counts[data_pmc.key(i)] = counts;
     }
 
     Optional<Message> message;
@@ -66,11 +54,10 @@ Snapshot Snapshot::from_bytes(std::vector<char> const & data) {
     return Snapshot(
             triggers,
             dict["wallclock_time"].as<double>(),
-            port_message_counts,
             dict["is_final_snapshot"].as<bool>(),
             message,
             dict["settings_overlay"].as<::ymmsl::Settings>(),
-            TimelineState::from_data(dict["timeline_state"])
+            CommunicatorState::from_data(dict["communicator_state"])
             );
 }
 
@@ -78,15 +65,6 @@ std::vector<char> Snapshot::to_bytes() const {
     Data d_triggers = Data::nils(triggers.size());
     for (std::size_t i=0; i<triggers.size(); ++i) {
         d_triggers[i] = triggers[i];
-    }
-
-    Data pmc = Data::dict();
-    for (const auto & kv : port_message_counts) {
-        Data counts = Data::nils(kv.second.size());
-        for (std::size_t i=0; i<kv.second.size(); ++i) {
-            counts[i] = kv.second[i];
-        }
-        pmc[kv.first] = counts;
     }
 
     msgpack::sbuffer sbuf;
@@ -107,11 +85,10 @@ std::vector<char> Snapshot::to_bytes() const {
         DataConstRef dict = DataConstRef::dict(
             "triggers", d_triggers,
             "wallclock_time", wallclock_time,
-            "port_message_counts", pmc,
             "is_final_snapshot", is_final_snapshot,
             "message", mpp_msg.encoded_as_dcr(),
             "settings_overlay", Data(settings_overlay),
-            "timeline_state", timeline_state.to_data());
+            "communicator_state", communicator_state.to_data());
 
         msgpack::pack(sbuf, dict);
 
@@ -119,11 +96,10 @@ std::vector<char> Snapshot::to_bytes() const {
         DataConstRef dict = DataConstRef::dict(
             "triggers", d_triggers,
             "wallclock_time", wallclock_time,
-            "port_message_counts", pmc,
             "is_final_snapshot", is_final_snapshot,
             "message", Data(),
             "settings_overlay", Data(settings_overlay),
-            "timeline_state", timeline_state.to_data());
+            "communicator_state", communicator_state.to_data());
 
         msgpack::pack(sbuf, dict);
     }
@@ -165,7 +141,7 @@ SnapshotMetadata SnapshotMetadata::from_snapshot(
             snapshot.wallclock_time,
             timestamp,
             next_timestamp,
-            snapshot.port_message_counts,
+            snapshot.communicator_state.port_message_counts,
             snapshot.is_final_snapshot,
             snapshot_filename);
 }

--- a/src/cpp/libmuscle/snapshot.hpp
+++ b/src/cpp/libmuscle/snapshot.hpp
@@ -4,9 +4,9 @@
 #include <string>
 #include <vector>
 
+#include <libmuscle/communicator_state.hpp>
 #include <libmuscle/message.hpp>
 #include <libmuscle/namespace.hpp>
-#include <libmuscle/timeline_manager.hpp>
 #include <libmuscle/util.hpp>
 
 #include <ymmsl/ymmsl.hpp>
@@ -22,11 +22,10 @@ class Snapshot {
         Snapshot(
                 std::vector<std::string> const & triggers,
                 double wallclock_time,
-                std::unordered_map<std::string, std::vector<int>> const & port_message_counts,
                 bool is_final_snapshot,
                 Optional<Message> const & message,
                 ::ymmsl::Settings const & settings_overlay,
-                TimelineState const & timeline_state = TimelineState());
+                CommunicatorState const & communicator_state);
 
         /** Create a snapshot object from binary data.
          *
@@ -44,11 +43,10 @@ class Snapshot {
 
         std::vector<std::string> triggers;
         double wallclock_time;
-        std::unordered_map<std::string, std::vector<int>> port_message_counts;
         bool is_final_snapshot;
         Optional<Message> message;
         ::ymmsl::Settings settings_overlay;
-        TimelineState timeline_state;
+        CommunicatorState communicator_state;
 };
 
 /** Metadata of a snapshot for sending to the muscle_manager.

--- a/src/cpp/libmuscle/snapshot_manager.cpp
+++ b/src/cpp/libmuscle/snapshot_manager.cpp
@@ -25,11 +25,9 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 SnapshotManager::SnapshotManager(
             ymmsl::Reference const & instance_id,
             MMPClient & manager,
-            PortManager & port_manager,
             Communicator & communicator)
         : instance_id_(instance_id)
         , manager_(manager)
-        , port_manager_(port_manager)
         , communicator_(communicator)
         , resume_from_snapshot_()
         , resume_overlay_()
@@ -96,14 +94,7 @@ Optional<double> SnapshotManager::prepare_resume(
         }
         resume_overlay_ = snapshot.settings_overlay;
 
-        port_manager_.restore_message_counts(snapshot.port_message_counts);
-        if (!snapshot.is_final_snapshot) {
-            // A final snapshot's timeline state includes a look-ahead
-            // F_INIT receive done to determine whether the instance would
-            // be reused. Resuming always redoes that receive, so restoring
-            // it here would make it look like it already happened.
-            communicator_.restore_state(snapshot.timeline_state);
-        }
+        communicator_.restore_state(snapshot.communicator_state);
         // Store a copy of the snapshot in the current run directory
         auto path = store_snapshot_(snapshot);
         auto metadata = SnapshotMetadata::from_snapshot(snapshot, path);
@@ -133,36 +124,12 @@ double SnapshotManager::save_snapshot(
         Optional<Message> message, bool is_final,
         std::vector<std::string> const & triggers, double wallclock_time,
         Optional<double> f_init_max_timestamp,
-        ::ymmsl::Settings settings_overlay) {
-    auto port_message_counts = port_manager_.get_message_counts();
-
-    if (is_final &&
-            std::find(triggers.begin(), triggers.end(), "at_end") == triggers.end()) {
-        // Decrease F_INIT port counts by one: F_INIT messages are already
-        // pre-received, but not yet processed by the user code. Therefore,
-        // the snapshot state should treat these as not-received.
-        // N.B. For a snapshot at the end of the simulation, there were no F_INIT
-        // messages, so we do not decrease.
-        auto all_ports = port_manager_.list_ports();
-        auto ports = all_ports.find(::ymmsl::Operator::F_INIT);
-        if (ports != all_ports.end()) {
-            for (auto const & port_name : ports->second) {
-                for (auto & count : port_message_counts[port_name]) {
-                    --count;
-                }
-            }
-        }
-        if (port_manager_.settings_in_connected()) {
-            for (auto & count : port_message_counts["muscle_settings_in"]) {
-                --count;
-            }
-        }
-    }
-
-    TimelineState timeline_state = communicator_.get_state();
+        ::ymmsl::Settings settings_overlay,
+        CommunicatorState const & communicator_state)
+{
     Snapshot snapshot(
-            triggers, wallclock_time, port_message_counts, is_final, message,
-            settings_overlay, timeline_state);
+            triggers, wallclock_time, is_final, message,
+            settings_overlay, communicator_state);
 
     auto path = store_snapshot_(snapshot);
     auto metadata = SnapshotMetadata::from_snapshot(snapshot, path);

--- a/src/cpp/libmuscle/snapshot_manager.hpp
+++ b/src/cpp/libmuscle/snapshot_manager.hpp
@@ -35,7 +35,6 @@ class SnapshotManager {
         SnapshotManager(
                 ymmsl::Reference const & instance_id,
                 MMPClient & manager,
-                PortManager & port_manager,
                 Communicator & communicator);
 
         /** Apply checkpoint info received from the manager.
@@ -90,7 +89,8 @@ class SnapshotManager {
                 Optional<Message> message, bool is_final,
                 std::vector<std::string> const & triggers, double wallclock_time,
                 Optional<double> f_init_max_timestamp,
-                ::ymmsl::Settings settings_overlay);
+                ::ymmsl::Settings settings_overlay,
+                CommunicatorState const & communicator_state);
 
         /** Load a previously stored snapshot from the filesystem.
          *
@@ -102,7 +102,6 @@ class SnapshotManager {
     private:
         ymmsl::Reference const & instance_id_;
         MMPClient & manager_;
-        PortManager & port_manager_;
         Communicator & communicator_;
         Optional<Snapshot> resume_from_snapshot_;
         ::ymmsl::Settings resume_overlay_;

--- a/src/cpp/libmuscle/tests/fixtures.hpp
+++ b/src/cpp/libmuscle/tests/fixtures.hpp
@@ -191,21 +191,24 @@ struct ConnectedPortManagerFixture {
 };
 
 
-struct TimelineStateFixture {
+struct CommunicatorStateFixture {
     public:
-        typedef ::libmuscle::_MUSCLE_IMPL_NS::TimelineState TimelineState;
+        typedef ::libmuscle::_MUSCLE_IMPL_NS::CommunicatorState CommunicatorState;
         typedef ::libmuscle::_MUSCLE_IMPL_NS::PortAndSlot PortAndSlot;
         typedef ::libmuscle::_MUSCLE_IMPL_NS::IterationCount IterationCount;
         typedef ::libmuscle::_MUSCLE_IMPL_NS::Optional<int> OptionalSlot;
 
-        TimelineState timeline_state_;
+        CommunicatorState communicator_state_;
 
-        TimelineStateFixture() {
-            timeline_state_.iteration = IterationCount({1});
-            timeline_state_.send_participated = {};
-            timeline_state_.receive_participated = {
+        CommunicatorStateFixture() {
+            communicator_state_.port_message_counts = {
+                {"in", {1}}, {"out", {4}}, {"muscle_settings_in", {0}}};
+
+            communicator_state_.timeline_state.iteration = IterationCount({1});
+            communicator_state_.timeline_state.send_participated = {};
+            communicator_state_.timeline_state.receive_participated = {
                     PortAndSlot("in", OptionalSlot())};
-            timeline_state_.subtimeline_states = {};
+            communicator_state_.timeline_state.subtimeline_states = {};
         }
 };
 

--- a/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <libmuscle/communicator_state.hpp>
 #include <libmuscle/logger.hpp>
 #include <libmuscle/message.hpp>
 #include <libmuscle/namespace.hpp>
@@ -145,9 +146,9 @@ class MockCommunicator : public MockClass<MockCommunicator> {
 
         MockFun<Val<double>> get_receive_timeout;
 
-        MockFun<Val<TimelineState>> get_state;
+        MockFun<Val<CommunicatorState>> get_state;
 
-        MockFun<Void, Val<TimelineState const &>> restore_state;
+        MockFun<Void, Val<CommunicatorState const &>> restore_state;
 };
 
 using Communicator = MockCommunicator;

--- a/src/cpp/libmuscle/tests/mocks/mock_snapshot_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_snapshot_manager.hpp
@@ -31,16 +31,15 @@ class MockSnapshotManager : public MockClass<MockSnapshotManager> {
         MockSnapshotManager(
                 ymmsl::Reference const & instance_id,
                 MMPClient & manager,
-                PortManager & port_manager,
                 Communicator & communicator)
         {
             init_from_return_value();
-            constructor(instance_id, manager, port_manager, communicator);
+            constructor(instance_id, manager, communicator);
         }
 
         MockFun<
             Void, Val<ymmsl::Reference const &>, Obj<MMPClient &>,
-            Obj<PortManager &>, Obj<Communicator &>> constructor;
+            Obj<Communicator &>> constructor;
 
         MockFun<
             Val<Optional<double>>, Val<Optional<std::string> const &>,
@@ -57,7 +56,7 @@ class MockSnapshotManager : public MockClass<MockSnapshotManager> {
         MockFun<
             Val<double>, Val<Optional<Message>>, Val<bool>,
             Val<std::vector<std::string> const &>, Val<double>, Val<Optional<double>>,
-            Val<::ymmsl::Settings>> save_snapshot;
+            Val<::ymmsl::Settings>, Val<CommunicatorState>> save_snapshot;
 
         MockFun<Val<Snapshot>, Val<std::string const &>> load_snapshot_from_file;
 };

--- a/src/cpp/libmuscle/tests/tcp_reconnect_test.cpp
+++ b/src/cpp/libmuscle/tests/tcp_reconnect_test.cpp
@@ -25,6 +25,7 @@ void inject_fault(int socket_fd);
 #include <libmuscle/api_guard.cpp>
 #include <libmuscle/checkpoint_triggers.cpp>
 #include <libmuscle/communicator.cpp>
+#include <libmuscle/communicator_state.cpp>
 #include <libmuscle/endpoint.cpp>
 #include <libmuscle/instance.cpp>
 #include <libmuscle/logger.cpp>

--- a/src/cpp/libmuscle/tests/test_instance.cpp
+++ b/src/cpp/libmuscle/tests/test_instance.cpp
@@ -45,6 +45,7 @@
 
 
 using libmuscle::_MUSCLE_IMPL_NS::APIGuard;
+using libmuscle::_MUSCLE_IMPL_NS::CommunicatorState;
 using libmuscle::_MUSCLE_IMPL_NS::Data;
 using libmuscle::_MUSCLE_IMPL_NS::DataConstRef;
 using libmuscle::_MUSCLE_IMPL_NS::Instance;
@@ -125,6 +126,7 @@ struct libmuscle_instance_base : ::testing::Test, ConnectedPortManagerFixture {
         mock_comm.get_locations.return_value = std::vector<std::string>(
                 {"tcp:test1,test2", "tcp:test3"});
         mock_comm.get_receive_timeout.return_value = 10.0;
+        mock_comm.get_state.return_value = CommunicatorState();
 
         auto & mock_port_manager = MockPortManager::return_value;
         mock_port_manager.settings_in_connected.return_value = false;

--- a/src/cpp/libmuscle/tests/test_snapshot.cpp
+++ b/src/cpp/libmuscle/tests/test_snapshot.cpp
@@ -25,18 +25,17 @@ int main(int argc, char *argv[]) {
 }
 
 /* Fixture */
-struct libmuscle_snapshot : TimelineStateFixture, ::testing::Test {
+struct libmuscle_snapshot : CommunicatorStateFixture, ::testing::Test {
     Snapshot snapshot_;
 
     libmuscle_snapshot()
         : snapshot_(
             {"test triggers"},
             15.3,
-            {{"in", {1}}, {"out", {4}}, {"muscle_settings_in", {0}}},
             true,
             Message(1.2, "test_data"),
             ::ymmsl::Settings({{"test", 1}}),
-            timeline_state_
+            communicator_state_
         ) {}
 };
 
@@ -44,11 +43,6 @@ TEST_F(libmuscle_snapshot, test_snapshot) {
     ASSERT_EQ(snapshot_.triggers.size(), 1);
     ASSERT_STREQ(snapshot_.triggers[0].c_str(), "test triggers");
     ASSERT_DOUBLE_EQ(snapshot_.wallclock_time, 15.3);
-    ASSERT_EQ(snapshot_.port_message_counts.size(), 3);
-    ASSERT_EQ(snapshot_.port_message_counts.at("in"), std::vector<int>({1}));
-    ASSERT_EQ(snapshot_.port_message_counts.at("out"), std::vector<int>({4}));
-    ASSERT_EQ(snapshot_.port_message_counts.at("muscle_settings_in"),
-              std::vector<int>({0}));
     ASSERT_TRUE(snapshot_.is_final_snapshot);
     ASSERT_TRUE(snapshot_.message.is_set());
     ASSERT_DOUBLE_EQ(snapshot_.message.get().timestamp(), 1.2);
@@ -63,30 +57,31 @@ TEST_F(libmuscle_snapshot, test_snapshot) {
 
     ASSERT_EQ(snapshot_.triggers, snapshot2.triggers);
     ASSERT_EQ(snapshot_.wallclock_time, snapshot2.wallclock_time);
-    ASSERT_EQ(snapshot_.port_message_counts, snapshot2.port_message_counts);
     ASSERT_EQ(snapshot_.is_final_snapshot, snapshot2.is_final_snapshot);
     ASSERT_EQ(snapshot_.message.get().timestamp(),
               snapshot2.message.get().timestamp());
     ASSERT_EQ(snapshot_.message.get().data().as<std::string>(),
               snapshot2.message.get().data().as<std::string>());
     ASSERT_EQ(snapshot_.settings_overlay, snapshot2.settings_overlay);
-    ASSERT_EQ(snapshot_.timeline_state.iteration.is_set(),
-              snapshot2.timeline_state.iteration.is_set());
-    ASSERT_EQ(snapshot_.timeline_state.iteration.get(),
-              snapshot2.timeline_state.iteration.get());
-    ASSERT_EQ(snapshot_.timeline_state.send_participated,
-              snapshot2.timeline_state.send_participated);
-    ASSERT_EQ(snapshot_.timeline_state.receive_participated,
-              snapshot2.timeline_state.receive_participated);
-    ASSERT_EQ(snapshot_.timeline_state.subtimeline_states.size(),
-              snapshot2.timeline_state.subtimeline_states.size());
+    ASSERT_EQ(snapshot_.communicator_state.port_message_counts,
+              snapshot2.communicator_state.port_message_counts);
+    ASSERT_EQ(snapshot_.communicator_state.timeline_state.iteration.is_set(),
+              snapshot2.communicator_state.timeline_state.iteration.is_set());
+    ASSERT_EQ(snapshot_.communicator_state.timeline_state.iteration.get(),
+              snapshot2.communicator_state.timeline_state.iteration.get());
+    ASSERT_EQ(snapshot_.communicator_state.timeline_state.send_participated,
+              snapshot2.communicator_state.timeline_state.send_participated);
+    ASSERT_EQ(snapshot_.communicator_state.timeline_state.receive_participated,
+              snapshot2.communicator_state.timeline_state.receive_participated);
+    ASSERT_EQ(snapshot_.communicator_state.timeline_state.subtimeline_states.size(),
+              snapshot2.communicator_state.timeline_state.subtimeline_states.size());
 }
 
 TEST_F(libmuscle_snapshot, test_snapshot_metadata) {
     auto metadata = SnapshotMetadata::from_snapshot(snapshot_, "test");
     ASSERT_EQ(metadata.triggers, snapshot_.triggers);
     ASSERT_EQ(metadata.wallclock_time, snapshot_.wallclock_time);
-    ASSERT_EQ(metadata.port_message_counts, snapshot_.port_message_counts);
+    ASSERT_EQ(metadata.port_message_counts, snapshot_.communicator_state.port_message_counts);
     ASSERT_EQ(metadata.is_final_snapshot, snapshot_.is_final_snapshot);
     ASSERT_EQ(metadata.timestamp, snapshot_.message.get().timestamp());
     ASSERT_EQ(metadata.next_timestamp.is_set(),
@@ -99,7 +94,7 @@ TEST_F(libmuscle_snapshot, test_message_with_settings) {
     settings["b"] = true;
     Message message(1.0, 2.0, "test_data", settings);
     Snapshot snapshot (
-            {}, 0, {}, false, message, {}, timeline_state_);
+            {}, 0, false, message, {}, communicator_state_);
     ASSERT_TRUE(snapshot.message.get().settings().at("b").as<bool>());
 
     auto binary_snapshot = snapshot.to_bytes();
@@ -111,7 +106,7 @@ TEST_F(libmuscle_snapshot, test_message_with_settings) {
 TEST_F(libmuscle_snapshot, test_implicit_snapshot) {
     Optional<Message> message;
     Snapshot snapshot(
-            {}, 0, {}, true, message, {}, timeline_state_);
+            {}, 0, true, message, {}, communicator_state_);
     ASSERT_FALSE(snapshot.message.is_set());
 
 

--- a/src/cpp/libmuscle/tests/test_snapshot_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_snapshot_manager.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
 
 
 struct libmuscle_snapshot_manager :
-        ::testing::Test, TempDirFixture, TimelineStateFixture {
+        ::testing::Test, TempDirFixture, CommunicatorStateFixture {
     RESET_MOCKS(
             ::libmuscle::_MUSCLE_IMPL_NS::MockCommunicator,
             ::libmuscle::_MUSCLE_IMPL_NS::MockMMPClient,
@@ -82,14 +82,14 @@ struct libmuscle_snapshot_manager :
             "test", {}, mock_port_manager_, mock_profiler_, mock_mmp_client_};
 
     libmuscle_snapshot_manager() {
-        communicator_.get_state.return_value = timeline_state_;
+        communicator_.get_state.return_value = communicator_state_;
     }
 };
 
 
 TEST_F(libmuscle_snapshot_manager, test_no_checkpointing) {
     SnapshotManager snapshot_manager(
-            "test", mock_mmp_client_, mock_port_manager_, communicator_);
+            "test", mock_mmp_client_, communicator_);
 
     snapshot_manager.prepare_resume({}, temp_dir_);
     ASSERT_FALSE(snapshot_manager.resuming_from_intermediate());
@@ -97,58 +97,46 @@ TEST_F(libmuscle_snapshot_manager, test_no_checkpointing) {
 }
 
 TEST_F(libmuscle_snapshot_manager, test_save_load_snapshot) {
-    mock_port_manager_.list_ports.return_value = PortsDescription(
-            {{Operator::S, {"in"}}, {Operator::O_I, {"out"}}});
-    PortMessageCounts port_message_counts = {
-            {"in", {1}},
-            {"out", {2}},
-            {"muscle_settings_in", {0}}};
-    mock_port_manager_.get_message_counts.return_value = port_message_counts;
-    mock_port_manager_.settings_in_connected.return_value = false;
-
     Reference instance_id("test[1]");
 
     SnapshotManager snapshot_manager(
-            instance_id, mock_mmp_client_, mock_port_manager_, communicator_);
+            instance_id, mock_mmp_client_, communicator_);
 
     snapshot_manager.prepare_resume({}, temp_dir_);
     ASSERT_FALSE(snapshot_manager.resuming_from_intermediate());
     ASSERT_FALSE(snapshot_manager.resuming_from_final());
 
     snapshot_manager.save_snapshot(
-            Message(0.2, "test data"), false, {"test"}, 13.0, {}, {});
+            Message(0.2, "test data"), false, {"test"}, 13.0, {}, {}, communicator_state_);
 
-    ASSERT_TRUE(mock_port_manager_.get_message_counts.called_with());
     ASSERT_TRUE(mock_mmp_client_.submit_snapshot_metadata.called());
     auto const & metadata = mock_mmp_client_.submit_snapshot_metadata.call_arg<0>();
     ASSERT_EQ(metadata.triggers, std::vector<std::string>({"test"}));
     ASSERT_EQ(metadata.wallclock_time, 13.0);
     ASSERT_EQ(metadata.timestamp, 0.2);
     ASSERT_FALSE(metadata.next_timestamp.is_set());
-    ASSERT_EQ(metadata.port_message_counts, port_message_counts);
+    ASSERT_EQ(metadata.port_message_counts, communicator_state_.port_message_counts);
     ASSERT_FALSE(metadata.is_final_snapshot);
     auto snapshot_path = metadata.snapshot_filename;
     ASSERT_EQ(snapshot_path, temp_dir_ + "/test-1_1.pack");
 
     SnapshotManager snapshot_manager2(
-            instance_id, mock_mmp_client_, mock_port_manager_, communicator_);
+            instance_id, mock_mmp_client_, communicator_);
     snapshot_manager2.prepare_resume(snapshot_path, temp_dir_);
-    ASSERT_TRUE(mock_port_manager_.restore_message_counts.called_once());
+    ASSERT_TRUE(communicator_.restore_state.called_once());
+    auto const & restored_state = communicator_.restore_state.call_arg<0>();
+    ASSERT_EQ(restored_state.port_message_counts, communicator_state_.port_message_counts);
+    ASSERT_EQ(restored_state.timeline_state.iteration.is_set(), communicator_state_.timeline_state.iteration.is_set());
+    ASSERT_EQ(restored_state.timeline_state.iteration.get(), communicator_state_.timeline_state.iteration.get());
+    ASSERT_EQ(restored_state.timeline_state.send_participated, communicator_state_.timeline_state.send_participated);
+    ASSERT_EQ(restored_state.timeline_state.receive_participated, communicator_state_.timeline_state.receive_participated);
     ASSERT_EQ(
-            mock_port_manager_.restore_message_counts.call_arg<0>(),
-            port_message_counts);
+            restored_state.timeline_state.subtimeline_states.size(),
+            communicator_state_.timeline_state.subtimeline_states.size());
 
     ASSERT_TRUE(snapshot_manager2.resuming_from_intermediate());
     ASSERT_FALSE(snapshot_manager2.resuming_from_final());
     ASSERT_TRUE(communicator_.restore_state.called_once());
-    auto const & restored_state = communicator_.restore_state.call_arg<0>();
-    ASSERT_EQ(restored_state.iteration.is_set(), timeline_state_.iteration.is_set());
-    ASSERT_EQ(restored_state.iteration.get(), timeline_state_.iteration.get());
-    ASSERT_EQ(restored_state.send_participated, timeline_state_.send_participated);
-    ASSERT_EQ(restored_state.receive_participated, timeline_state_.receive_participated);
-    ASSERT_EQ(
-            restored_state.subtimeline_states.size(),
-            timeline_state_.subtimeline_states.size());
 
     auto msg = snapshot_manager2.load_snapshot();
     ASSERT_DOUBLE_EQ(msg.timestamp(), 0.2);
@@ -156,7 +144,7 @@ TEST_F(libmuscle_snapshot_manager, test_save_load_snapshot) {
     ASSERT_EQ(msg.data().as<std::string>(), "test data");
 
     snapshot_manager2.save_snapshot(
-            Message(0.6, "test data2"), true, {"test"}, 42.2, 1.2, {});
+            Message(0.6, "test data2"), true, {"test"}, 42.2, 1.2, {}, communicator_state_);
 
     ASSERT_TRUE(mock_mmp_client_.submit_snapshot_metadata.called());
     auto const & metadata2 = mock_mmp_client_.submit_snapshot_metadata.call_arg<0>();
@@ -164,7 +152,7 @@ TEST_F(libmuscle_snapshot_manager, test_save_load_snapshot) {
     ASSERT_EQ(metadata2.wallclock_time, 42.2);
     ASSERT_EQ(metadata2.timestamp, 0.6);
     ASSERT_FALSE(metadata2.next_timestamp.is_set());
-    ASSERT_EQ(metadata2.port_message_counts, port_message_counts);
+    ASSERT_EQ(metadata2.port_message_counts, communicator_state_.port_message_counts);
     ASSERT_TRUE(metadata2.is_final_snapshot);
     snapshot_path = metadata2.snapshot_filename;
     ASSERT_EQ(snapshot_path, temp_dir_ + "/test-1_3.pack");
@@ -172,32 +160,24 @@ TEST_F(libmuscle_snapshot_manager, test_save_load_snapshot) {
     communicator_.restore_state.call_args_list.clear();
 
     SnapshotManager snapshot_manager3(
-            instance_id, mock_mmp_client_, mock_port_manager_, communicator_);
+            instance_id, mock_mmp_client_, communicator_);
     snapshot_manager3.prepare_resume(snapshot_path, temp_dir_);
     ASSERT_TRUE(snapshot_manager3.resuming_from_final());
-    ASSERT_FALSE(communicator_.restore_state.called());
+    ASSERT_TRUE(communicator_.restore_state.called_once());
 }
 
 TEST_F(libmuscle_snapshot_manager, test_save_load_implicit_snapshot) {
-    mock_port_manager_.list_ports.return_value = PortsDescription(
-            {{Operator::S, {"in"}}, {Operator::O_I, {"out"}}});
-    PortMessageCounts port_message_counts = {
-            {"in", {1}},
-            {"out", {2}},
-            {"muscle_settings_in", {0}}};
-    mock_port_manager_.get_message_counts.return_value = port_message_counts;
-    mock_port_manager_.settings_in_connected.return_value = false;
     Reference instance_id("test[1]");
 
     SnapshotManager snapshot_manager(
-            instance_id, mock_mmp_client_, mock_port_manager_, communicator_);
+            instance_id, mock_mmp_client_, communicator_);
 
     snapshot_manager.prepare_resume({}, temp_dir_);
     ASSERT_FALSE(snapshot_manager.resuming_from_intermediate());
     ASSERT_FALSE(snapshot_manager.resuming_from_final());
 
     // save implicit snapshot, i.e. Message=not set
-    snapshot_manager.save_snapshot({}, true, {"implicit"}, 1.0, 1.5, {});
+    snapshot_manager.save_snapshot({}, true, {"implicit"}, 1.0, 1.5, {}, communicator_state_);
 
     ASSERT_TRUE(mock_mmp_client_.submit_snapshot_metadata.called());
     auto const & metadata = mock_mmp_client_.submit_snapshot_metadata.call_arg<0>();
@@ -205,20 +185,16 @@ TEST_F(libmuscle_snapshot_manager, test_save_load_implicit_snapshot) {
     mock_mmp_client_.submit_snapshot_metadata.call_args_list.clear();
 
     SnapshotManager snapshot_manager2(
-            instance_id, mock_mmp_client_, mock_port_manager_, communicator_);
+            instance_id, mock_mmp_client_, communicator_);
 
     snapshot_manager2.prepare_resume(snapshot_path, temp_dir_);
-    ASSERT_TRUE(mock_port_manager_.restore_message_counts.called_once());
-    ASSERT_EQ(
-            mock_port_manager_.restore_message_counts.call_arg<0>(),
-            port_message_counts);
+    ASSERT_TRUE(communicator_.restore_state.called_once());
     ASSERT_TRUE(mock_mmp_client_.submit_snapshot_metadata.called_once());
     mock_mmp_client_.submit_snapshot_metadata.call_args_list.clear();
 
     ASSERT_FALSE(snapshot_manager2.resuming_from_intermediate());
     ASSERT_FALSE(snapshot_manager2.resuming_from_final());
-    ASSERT_FALSE(communicator_.restore_state.called());
-    snapshot_manager2.save_snapshot({}, true, {"implicit"}, 12.3, 2.5, {});
+    snapshot_manager2.save_snapshot({}, true, {"implicit"}, 12.3, 2.5, {}, communicator_state_);
     ASSERT_TRUE(mock_mmp_client_.submit_snapshot_metadata.called_once());
 }
 
@@ -229,7 +205,7 @@ TEST_F(libmuscle_snapshot_manager, test_load_snapshot_from_file_with_unknown_ver
     snapshot_file.close();
 
     SnapshotManager snapshot_manager(
-            "test", mock_mmp_client_, mock_port_manager_, communicator_);
+            "test", mock_mmp_client_, communicator_);
 
     try {
         snapshot_manager.load_snapshot_from_file(snapshot_path);
@@ -260,7 +236,7 @@ TEST_F(libmuscle_snapshot_manager, test_load_old_version_snapshot_raises) {
     snapshot_file.close();
 
     SnapshotManager snapshot_manager(
-            "test", mock_mmp_client_, mock_port_manager_, communicator_);
+            "test", mock_mmp_client_, communicator_);
 
     try {
         snapshot_manager.load_snapshot_from_file(snapshot_path);

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, cast
 
 from ymmsl.v0_2 import Operator, Reference, Settings
 
+from libmuscle.communicator_state import CommunicatorState
 from libmuscle.endpoint import Endpoint
 from libmuscle.mcp.tcp_util import SocketClosed
 from libmuscle.mmp_client import MMPClient
@@ -15,7 +16,7 @@ from libmuscle.port_manager import PortManager
 from libmuscle.profiler import Profiler
 from libmuscle.profiling import ProfileEvent, ProfileEventType, ProfileTimestamp
 from libmuscle.receive_timeout_handler import Deadlock, ReceiveTimeoutHandler
-from libmuscle.timeline_manager import IterationCount, TimelineManager, TimelineState
+from libmuscle.timeline_manager import IterationCount, TimelineManager
 from libmuscle.util import port_desc
 
 _logger = logging.getLogger(__name__)
@@ -151,19 +152,23 @@ class Communicator:
         """
         self._receive_timeout = receive_timeout
 
-    def get_state(self) -> TimelineState:
+    def get_state(self) -> CommunicatorState:
         """Return the current state of the timeline manager, for saving in a
         snapshot.
         """
-        return self._timeline_manager.get_state()
+        return CommunicatorState(
+            self._port_manager.get_message_counts(),
+            self._timeline_manager.get_state(),
+        )
 
-    def restore_state(self, state: TimelineState) -> None:
+    def restore_state(self, state: CommunicatorState) -> None:
         """Restore the timeline manager to a previously saved state.
 
         Args:
             state: The state to restore, as returned by get_state().
         """
-        self._timeline_manager.restore_state(state)
+        self._port_manager.restore_message_counts(state.port_message_counts)
+        self._timeline_manager.restore_state(state.timeline_state)
 
     def send_message(
         self,

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -153,8 +153,9 @@ class Communicator:
         self._receive_timeout = receive_timeout
 
     def get_state(self) -> CommunicatorState:
-        """Return the current state of the timeline manager, for saving in a
-        snapshot.
+        """Return the current internal state for checkpointing.
+
+        This includes states for the communicator, port manager and timeline manager.
         """
         return CommunicatorState(
             self._port_manager.get_message_counts(),
@@ -162,7 +163,7 @@ class Communicator:
         )
 
     def restore_state(self, state: CommunicatorState) -> None:
-        """Restore the timeline manager to a previously saved state.
+        """Restore a previously saved state.
 
         Args:
             state: The state to restore, as returned by get_state().

--- a/src/python/libmuscle/communicator_state.py
+++ b/src/python/libmuscle/communicator_state.py
@@ -1,0 +1,25 @@
+from dataclasses import asdict, dataclass
+
+from libmuscle.timeline_manager import TimelineState
+
+
+@dataclass
+class CommunicatorState:
+    port_message_counts: dict[str, list[int]]
+    timeline_state: TimelineState
+    # TODO: message cache
+
+    def asdict(self) -> dict:
+        """Convert CommunicatorState into a MsgPack-serializable dictionary."""
+        return {
+            "port_message_counts": self.port_message_counts,
+            "timeline_state": asdict(self.timeline_state),
+        }
+
+    @classmethod
+    def fromdict(cls, data: dict) -> "CommunicatorState":
+        """Create CommunicatorState from a MsgPack-serializable dictionary."""
+        return cls(
+            data["port_message_counts"],
+            TimelineState(**data["timeline_state"]),
+        )

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -10,6 +10,7 @@ from ymmsl.v0_2 import Identifier, Operator, Port, Reference, Settings, SettingV
 from libmuscle.api_guard import APIGuard
 from libmuscle.checkpoint_triggers import TriggerManager
 from libmuscle.communicator import Communicator, FInitCacheType, Message, PortClosed
+from libmuscle.communicator_state import CommunicatorState
 from libmuscle.logging import LogLevel
 from libmuscle.logging_handler import MuscleManagerHandler
 from libmuscle.mmp_client import MMPClient
@@ -142,6 +143,13 @@ class Instance:
         )
         """Communicator for this instance."""
 
+        self._communicator_state: Optional[CommunicatorState] = None
+        """Stored communicator state for final snapshots.
+
+        This allows us to store (and later restore) the communicator state before
+        pre-receiving messages.
+        """
+
         self._declared_ports = ports
         """Declared ports for this instance."""
 
@@ -149,7 +157,7 @@ class Instance:
         """Settings for this instance."""
 
         self._snapshot_manager = SnapshotManager(
-            self._instance_id, self.__manager, self._port_manager, self._communicator
+            self._instance_id, self.__manager, self._communicator
         )
         """Resumes, loads and saves snapshots."""
 
@@ -268,6 +276,7 @@ class Instance:
                     # store a None instead of a Message
                     self._save_snapshot(None, True, self.__f_init_max_timestamp)
 
+        self._communicator_state = None
         self._first_run = False
         if not do_reuse:
             self.__shutdown()
@@ -897,6 +906,13 @@ class Instance:
                 one
             f_init_max_timestamp: Timestamp for final snapshots
         """
+        if final:
+            assert self._communicator_state is not None
+            communicator_state = self._communicator_state
+        else:
+            assert self._communicator_state is None
+            communicator_state = self._communicator.get_state()
+
         triggers = self._trigger_manager.get_triggers()
         walltime = self._trigger_manager.elapsed_walltime()
         timestamp = self._snapshot_manager.save_snapshot(
@@ -906,6 +922,7 @@ class Instance:
             walltime,
             f_init_max_timestamp,
             self._settings_manager.overlay,
+            communicator_state,
         )
         self._trigger_manager.update_checkpoints(timestamp)
 
@@ -1089,6 +1106,7 @@ class Instance:
         Returns:
             True if new F_INIT messages were received.
         """
+        self._communicator_state = self._communicator.get_state()
         sw_event = ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, ProfileTimestamp())
 
         try:

--- a/src/python/libmuscle/snapshot.py
+++ b/src/python/libmuscle/snapshot.py
@@ -1,70 +1,27 @@
-from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass
-from typing import Optional, cast
+from dataclasses import dataclass
+from typing import ClassVar, Optional, cast
 
 import msgpack
 from typing_extensions import Buffer
 from ymmsl.v0_2 import Reference, Settings
 
 from libmuscle import communicator
+from libmuscle.communicator_state import CommunicatorState
 from libmuscle.mpp_message import MPPMessage
-from libmuscle.timeline_manager import TimelineState
 
 
-class Snapshot(ABC):
-    """Snapshot data structure.
+@dataclass
+class Snapshot:
+    """Snapshot data structure."""
 
-    This is an abstract base class, implementations are provided by subclasses.
-    """
+    SNAPSHOT_VERSION_BYTE: ClassVar[bytes] = b"2"
 
-    SNAPSHOT_VERSION_BYTE = b"\0"
-
-    def __init__(
-        self,
-        triggers: list[str],
-        wallclock_time: float,
-        port_message_counts: dict[str, list[int]],
-        is_final_snapshot: bool,
-        message: Optional["communicator.Message"],
-        settings_overlay: Settings,
-        timeline_state: TimelineState,
-    ) -> None:
-        self.triggers = triggers
-        self.wallclock_time = wallclock_time
-        self.port_message_counts = port_message_counts
-        self.is_final_snapshot = is_final_snapshot
-        self.message = message
-        # self.message is None for implicit snapshots, so we cannot store the
-        # Settings overlay in that message object.
-        self.settings_overlay = settings_overlay
-        self.timeline_state = timeline_state
-
-    @classmethod
-    @abstractmethod
-    def from_bytes(cls, data: bytes) -> "Snapshot":
-        """Create a snapshot object from binary data.
-
-        Args:
-            data: binary data representing the snapshot. Note that this must
-                **exclude** the versioning byte.
-        """
-        ...
-
-    @abstractmethod
-    def to_bytes(self) -> bytes:
-        """Convert the snapshot object to binary data.
-
-        Returns:
-            Binary data representing the snapshot. Note that this must
-                **exclude** the versioning byte.
-        """
-        ...
-
-
-class MsgPackSnapshot(Snapshot):
-    """Snapshot stored in messagepack format"""
-
-    SNAPSHOT_VERSION_BYTE = b"2"
+    triggers: list[str]
+    wallclock_time: float
+    is_final_snapshot: bool
+    message: Optional["communicator.Message"]
+    settings_overlay: Settings
+    communicator_state: CommunicatorState
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "Snapshot":
@@ -72,11 +29,10 @@ class MsgPackSnapshot(Snapshot):
         return cls(
             dct["triggers"],
             dct["wallclock_time"],
-            dct["port_message_counts"],
             dct["is_final_snapshot"],
             cls.bytes_to_message(dct["message"]),
             Settings(dct["settings_overlay"]),
-            TimelineState(**dct["timeline_state"]),
+            CommunicatorState.fromdict(dct["communicator_state"]),
         )
 
     def to_bytes(self) -> bytes:
@@ -86,11 +42,10 @@ class MsgPackSnapshot(Snapshot):
                 {
                     "triggers": self.triggers,
                     "wallclock_time": self.wallclock_time,
-                    "port_message_counts": self.port_message_counts,
                     "is_final_snapshot": self.is_final_snapshot,
                     "message": self.message_to_bytes(self.message),
                     "settings_overlay": self.settings_overlay.as_ordered_dict(),
-                    "timeline_state": asdict(self.timeline_state),
+                    "communicator_state": self.communicator_state.asdict(),
                 }
             ),
         )
@@ -150,7 +105,7 @@ class SnapshotMetadata:
             snapshot.wallclock_time,
             snapshot.message.timestamp if snapshot.message else float("NaN"),
             snapshot.message.next_timestamp if snapshot.message else None,
-            snapshot.port_message_counts,
+            snapshot.communicator_state.port_message_counts,
             snapshot.is_final_snapshot,
             snapshot_filename,
         )

--- a/src/python/libmuscle/snapshot_manager.py
+++ b/src/python/libmuscle/snapshot_manager.py
@@ -2,12 +2,12 @@ import logging
 from pathlib import Path
 from typing import Optional, cast
 
-from ymmsl.v0_2 import Operator, Reference, Settings
+from ymmsl.v0_2 import Reference, Settings
 
 from libmuscle.communicator import Communicator, Message
+from libmuscle.communicator_state import CommunicatorState
 from libmuscle.mmp_client import MMPClient
-from libmuscle.port_manager import PortManager
-from libmuscle.snapshot import MsgPackSnapshot, Snapshot, SnapshotMetadata
+from libmuscle.snapshot import Snapshot, SnapshotMetadata
 
 _logger = logging.getLogger(__name__)
 
@@ -30,7 +30,6 @@ class SnapshotManager:
         self,
         instance_id: Reference,
         manager: MMPClient,
-        port_manager: PortManager,
         communicator: Communicator,
     ) -> None:
         """Create a new snapshot manager
@@ -45,7 +44,6 @@ class SnapshotManager:
         # replace identifier[i] by identifier-i to use in snapshot file name
         # using a dash (-) because that is not allowed in Identifiers
         self._safe_id = str(instance_id).replace("[", "-").replace("]", "")
-        self._port_manager = port_manager
         self._communicator = communicator
         self._manager = manager
 
@@ -82,13 +80,7 @@ class SnapshotManager:
                 result = snapshot.message.timestamp
             self.resume_overlay = snapshot.settings_overlay
 
-            self._port_manager.restore_message_counts(snapshot.port_message_counts)
-            if not snapshot.is_final_snapshot:
-                # A final snapshot's timeline state includes a look-ahead
-                # F_INIT receive done to determine whether the instance would
-                # be reused. Resuming always redoes that receive, so restoring
-                # it here would make it look like it already happened.
-                self._communicator.restore_state(snapshot.timeline_state)
+            self._communicator.restore_state(snapshot.communicator_state)
             # Store a copy of the snapshot in the current run directory
             path = self.__store_snapshot(snapshot)
             metadata = SnapshotMetadata.from_snapshot(snapshot, str(path))
@@ -131,6 +123,7 @@ class SnapshotManager:
         wallclock_time: float,
         f_init_max_timestamp: Optional[float],
         settings_overlay: Settings,
+        communicator_state: CommunicatorState,
     ) -> float:
         """Save a (final) snapshot.
 
@@ -145,26 +138,13 @@ class SnapshotManager:
         Returns:
             Simulation time at which the snapshot was made.
         """
-        port_message_counts = self._port_manager.get_message_counts()
-        if final and "at_end" not in triggers:
-            # Decrease F_INIT port counts by one: F_INIT messages are already
-            # pre-received, but not yet processed by the user code. Therefore,
-            # the snapshot state should treat these as not-received.
-            # N.B. For a snapshot at the end of the simulation, there were no F_INIT
-            # messages, so we do not decrease.
-            for port in self._port_manager.get_connected_ports(Operator.F_INIT):
-                port_name = str(port.name)
-                new_counts = [i - 1 for i in port_message_counts[port_name]]
-                port_message_counts[port_name] = new_counts
-
-        snapshot = MsgPackSnapshot(
+        snapshot = Snapshot(
             triggers,
             wallclock_time,
-            port_message_counts,
             final,
             msg,
             settings_overlay,
-            self._communicator.get_state(),
+            communicator_state,
         )
 
         path = self.__store_snapshot(snapshot)
@@ -198,8 +178,8 @@ class SnapshotManager:
             version = snapshot_file.read(1)
             data = snapshot_file.read()
 
-            if version == MsgPackSnapshot.SNAPSHOT_VERSION_BYTE:
-                return MsgPackSnapshot.from_bytes(data)
+            if version == Snapshot.SNAPSHOT_VERSION_BYTE:
+                return Snapshot.from_bytes(data)
             raise RuntimeError(
                 "Unable to load snapshot from"
                 f" {snapshot_location}: unknown version of"

--- a/src/python/libmuscle/test/conftest.py
+++ b/src/python/libmuscle/test/conftest.py
@@ -7,6 +7,7 @@ from ymmsl.v0_2 import Operator, Reference, Settings
 
 from libmuscle.api_guard import APIGuard
 from libmuscle.communicator import Message
+from libmuscle.communicator_state import CommunicatorState
 from libmuscle.mcp.transport_client import ProfileData
 from libmuscle.mmp_client import MMPClient
 from libmuscle.planner.resources import Core, CoreSet, OnNodeResources, Resources
@@ -44,12 +45,15 @@ def profile_data() -> ProfileData:
 
 
 @pytest.fixture
-def timeline_state() -> TimelineState:
-    return TimelineState(
-        iteration=[1],
-        send_participated=[],
-        receive_participated=[["in", None]],
-        subtimeline_states={},
+def communicator_state() -> CommunicatorState:
+    return CommunicatorState(
+        port_message_counts={"in": [1], "out": [4], "muscle_settings_in": [0]},
+        timeline_state=TimelineState(
+            iteration=[1],
+            send_participated=[],
+            receive_participated=[["in", None]],
+            subtimeline_states={},
+        ),
     )
 
 

--- a/src/python/libmuscle/test/test_snapshot.py
+++ b/src/python/libmuscle/test/test_snapshot.py
@@ -2,29 +2,26 @@ import pytest
 from ymmsl.v0_2 import Settings
 
 from libmuscle.communicator import Message
-from libmuscle.snapshot import MsgPackSnapshot, Snapshot, SnapshotMetadata
-from libmuscle.timeline_manager import TimelineState
+from libmuscle.communicator_state import CommunicatorState
+from libmuscle.snapshot import Snapshot, SnapshotMetadata
 
 
 @pytest.fixture
-def snapshot(timeline_state: TimelineState) -> Snapshot:
+def snapshot(communicator_state: CommunicatorState) -> Snapshot:
     triggers = ["test triggers"]
     wallclock_time = 15.3
-    port_message_counts = {"in": [1], "out": [4], "muscle_settings_in": [0]}
     is_final = True
     message = Message(1.2, data="test_data")
-    snapshot = MsgPackSnapshot(
+    snapshot = Snapshot(
         triggers,
         wallclock_time,
-        port_message_counts,
         is_final,
         message,
         Settings({"test": 1}),
-        timeline_state,
+        communicator_state,
     )
     assert snapshot.triggers == triggers
     assert snapshot.wallclock_time == wallclock_time
-    assert snapshot.port_message_counts == port_message_counts
     assert snapshot.is_final_snapshot == is_final
     assert snapshot.message == message
     assert snapshot.settings_overlay.keys() == {"test"}
@@ -38,16 +35,15 @@ def test_snapshot(snapshot: Snapshot) -> None:
     binary_snapshot = snapshot.to_bytes()
     assert isinstance(binary_snapshot, bytes)
 
-    snapshot2 = MsgPackSnapshot.from_bytes(binary_snapshot)
+    snapshot2 = Snapshot.from_bytes(binary_snapshot)
 
     assert snapshot2.triggers == snapshot.triggers
     assert snapshot2.wallclock_time == snapshot.wallclock_time
-    assert snapshot2.port_message_counts == snapshot.port_message_counts
     assert snapshot2.is_final_snapshot == snapshot.is_final_snapshot
     assert snapshot2.message.timestamp == snapshot.message.timestamp
     assert snapshot2.message.next_timestamp == snapshot.message.next_timestamp
     assert snapshot2.message.data == snapshot.message.data
-    assert snapshot2.timeline_state == snapshot.timeline_state
+    assert snapshot2.communicator_state == snapshot.communicator_state
 
 
 def test_snapshot_metadata(snapshot: Snapshot) -> None:
@@ -55,32 +51,34 @@ def test_snapshot_metadata(snapshot: Snapshot) -> None:
 
     assert metadata.triggers == snapshot.triggers
     assert metadata.wallclock_time == snapshot.wallclock_time
-    assert metadata.port_message_counts == snapshot.port_message_counts
+    assert (
+        metadata.port_message_counts == snapshot.communicator_state.port_message_counts
+    )
     assert metadata.is_final_snapshot == snapshot.is_final_snapshot
     assert metadata.timestamp == snapshot.message.timestamp
     assert metadata.next_timestamp == snapshot.message.next_timestamp
     assert metadata.snapshot_filename == "test"
 
 
-def test_message_with_settings(timeline_state: TimelineState) -> None:
+def test_message_with_settings(communicator_state: CommunicatorState) -> None:
     message = Message(1.0, 2.0, "test_data", Settings({"setting": True}))
-    snapshot = MsgPackSnapshot([], 0, {}, False, message, Settings(), timeline_state)
+    snapshot = Snapshot([], 0, False, message, Settings(), communicator_state)
     assert snapshot.message.settings.get("setting") is True
 
     binary_snapshot = snapshot.to_bytes()
     assert isinstance(binary_snapshot, bytes)
 
-    snapshot2 = MsgPackSnapshot.from_bytes(binary_snapshot)
+    snapshot2 = Snapshot.from_bytes(binary_snapshot)
     assert snapshot2.message.settings.get("setting") is True
 
 
-def test_implicit_snapshot(timeline_state: TimelineState) -> None:
+def test_implicit_snapshot(communicator_state: CommunicatorState) -> None:
     message = None
-    snapshot = MsgPackSnapshot([], 0, {}, True, message, Settings(), timeline_state)
+    snapshot = Snapshot([], 0, True, message, Settings(), communicator_state)
     assert snapshot.message is None
 
     binary_snapshot = snapshot.to_bytes()
     assert isinstance(binary_snapshot, bytes)
 
-    snapshot2 = MsgPackSnapshot.from_bytes(binary_snapshot)
+    snapshot2 = Snapshot.from_bytes(binary_snapshot)
     assert snapshot2.message is None

--- a/src/python/libmuscle/test/test_snapshot_manager.py
+++ b/src/python/libmuscle/test/test_snapshot_manager.py
@@ -6,35 +6,29 @@ import pytest
 from ymmsl.v0_2 import Reference, Settings
 
 from libmuscle.communicator import Message
+from libmuscle.communicator_state import CommunicatorState
 from libmuscle.snapshot import SnapshotMetadata
 from libmuscle.snapshot_manager import SnapshotManager
-from libmuscle.timeline_manager import TimelineState
 
 
 def test_no_checkpointing(tmp_path: Path) -> None:
     manager = MagicMock()
-    port_manager = MagicMock()
-    port_manager.get_message_counts.return_value = {}
     communicator = MagicMock()
-    snapshot_manager = SnapshotManager(
-        Reference("test"), manager, port_manager, communicator
-    )
+    snapshot_manager = SnapshotManager(Reference("test"), manager, communicator)
 
     snapshot_manager.prepare_resume(None, tmp_path)
     assert not snapshot_manager.resuming_from_intermediate()
     assert not snapshot_manager.resuming_from_final()
 
 
-def test_save_load_snapshot(tmp_path: Path, timeline_state: TimelineState) -> None:
+def test_save_load_snapshot(
+    tmp_path: Path, communicator_state: CommunicatorState
+) -> None:
     manager = MagicMock()
-    port_manager = MagicMock()
-    port_message_counts = {"in": [1], "out": [2], "muscle_settings_in": [0]}
-    port_manager.get_message_counts.return_value = port_message_counts
 
     instance_id = Reference("test[1]")
     communicator = MagicMock()
-    communicator.get_state.return_value = timeline_state
-    snapshot_manager = SnapshotManager(instance_id, manager, port_manager, communicator)
+    snapshot_manager = SnapshotManager(instance_id, manager, communicator)
 
     snapshot_manager.prepare_resume(None, tmp_path)
     assert not snapshot_manager.resuming_from_intermediate()
@@ -47,9 +41,9 @@ def test_save_load_snapshot(tmp_path: Path, timeline_state: TimelineState) -> No
         13.0,
         None,
         Settings(),
+        communicator_state,
     )
 
-    port_manager.get_message_counts.assert_called_with()
     manager.submit_snapshot_metadata.assert_called()
     (metadata,) = manager.submit_snapshot_metadata.call_args[0]
     assert isinstance(metadata, SnapshotMetadata)
@@ -57,22 +51,19 @@ def test_save_load_snapshot(tmp_path: Path, timeline_state: TimelineState) -> No
     assert metadata.wallclock_time == 13.0
     assert metadata.timestamp == 0.2
     assert metadata.next_timestamp is None
-    assert metadata.port_message_counts == port_message_counts
+    assert metadata.port_message_counts == communicator_state.port_message_counts
     assert not metadata.is_final_snapshot
     snapshot_path = Path(metadata.snapshot_filename)
     assert snapshot_path.parent == tmp_path
     assert snapshot_path.name == "test-1_1.pack"
 
-    snapshot_manager2 = SnapshotManager(
-        instance_id, manager, port_manager, communicator
-    )
+    snapshot_manager2 = SnapshotManager(instance_id, manager, communicator)
 
     snapshot_manager2.prepare_resume(snapshot_path, tmp_path)
-    port_manager.restore_message_counts.assert_called_with(port_message_counts)
+    communicator.restore_state.assert_called_once_with(communicator_state)
 
     assert snapshot_manager2.resuming_from_intermediate()
     assert not snapshot_manager2.resuming_from_final()
-    communicator.restore_state.assert_called_once_with(timeline_state)
     msg = snapshot_manager2.load_snapshot()
     assert msg.timestamp == 0.2
     assert msg.next_timestamp is None
@@ -85,6 +76,7 @@ def test_save_load_snapshot(tmp_path: Path, timeline_state: TimelineState) -> No
         42.2,
         1.2,
         Settings(),
+        communicator_state,
     )
 
     (metadata,) = manager.submit_snapshot_metadata.call_args[0]
@@ -93,40 +85,35 @@ def test_save_load_snapshot(tmp_path: Path, timeline_state: TimelineState) -> No
     assert metadata.wallclock_time == 42.2
     assert metadata.timestamp == 0.6
     assert metadata.next_timestamp is None
-    assert metadata.port_message_counts == port_message_counts
+    assert metadata.port_message_counts == communicator_state.port_message_counts
     assert metadata.is_final_snapshot
     snapshot_path = Path(metadata.snapshot_filename)
     assert snapshot_path.parent == tmp_path
     assert snapshot_path.name == "test-1_3.pack"
 
     communicator.restore_state.reset_mock()
-    snapshot_manager3 = SnapshotManager(
-        instance_id, manager, port_manager, communicator
-    )
+    snapshot_manager3 = SnapshotManager(instance_id, manager, communicator)
     snapshot_manager3.prepare_resume(snapshot_path, tmp_path)
+    communicator.restore_state.assert_called_once_with(communicator_state)
     assert snapshot_manager3.resuming_from_final()
-    communicator.restore_state.assert_not_called()
 
 
 def test_save_load_implicit_snapshot(
-    tmp_path: Path, timeline_state: TimelineState
+    tmp_path: Path, communicator_state: CommunicatorState
 ) -> None:
     manager = MagicMock()
-    port_manager = MagicMock()
-    port_message_counts = {"in": [1], "out": [2], "muscle_settings_in": [0]}
-    port_manager.get_message_counts.return_value = port_message_counts
-
     instance_id = Reference("test[1]")
     communicator = MagicMock()
-    communicator.get_state.return_value = timeline_state
-    snapshot_manager = SnapshotManager(instance_id, manager, port_manager, communicator)
+    snapshot_manager = SnapshotManager(instance_id, manager, communicator)
 
     snapshot_manager.prepare_resume(None, tmp_path)
 
     assert not snapshot_manager.resuming_from_intermediate()
     assert not snapshot_manager.resuming_from_final()
     # save implicit snapshot
-    snapshot_manager.save_snapshot(None, True, ["implicit"], 1.0, 1.5, Settings())
+    snapshot_manager.save_snapshot(
+        None, True, ["implicit"], 1.0, 1.5, Settings(), communicator_state
+    )
 
     manager.submit_snapshot_metadata.assert_called_once()
     (metadata,) = manager.submit_snapshot_metadata.call_args[0]
@@ -134,20 +121,19 @@ def test_save_load_implicit_snapshot(
     snapshot_path = Path(metadata.snapshot_filename)
     manager.submit_snapshot_metadata.reset_mock()
 
-    snapshot_manager2 = SnapshotManager(
-        instance_id, manager, port_manager, communicator
-    )
+    snapshot_manager2 = SnapshotManager(instance_id, manager, communicator)
 
     snapshot_manager2.prepare_resume(snapshot_path, tmp_path)
-    port_manager.restore_message_counts.assert_called_with(port_message_counts)
+    communicator.restore_state.assert_called_with(communicator_state)
     manager.submit_snapshot_metadata.assert_called_once()
     manager.submit_snapshot_metadata.reset_mock()
 
     assert not snapshot_manager2.resuming_from_intermediate()
     assert not snapshot_manager2.resuming_from_final()
 
-    communicator.restore_state.assert_not_called()
-    snapshot_manager2.save_snapshot(None, True, ["implicit"], 12.3, 2.5, Settings())
+    snapshot_manager2.save_snapshot(
+        None, True, ["implicit"], 12.3, 2.5, Settings(), communicator_state
+    )
     manager.submit_snapshot_metadata.assert_called_once()
 
 

--- a/src/python/muscle3/muscle3.py
+++ b/src/python/muscle3/muscle3.py
@@ -230,10 +230,8 @@ def snapshot(snapshot_files: Sequence[Path], data: bool, verbose: bool) -> None:
             ]
         )
         if verbose:
-            properties.update(
-                [
-                    ("Internal: Port message counts", snapshot.port_message_counts),
-                ]
+            properties["Internal: Port message counts"] = (
+                snapshot.communicator_state.port_message_counts,
             )
         for prop_name, prop_value in properties.items():
             click.secho(f"{prop_name}: ", nl=False, bold=True)


### PR DESCRIPTION
- Create CommunicatorState which captures both the `port_message_counts` and `timeline_state`. This will store the message cache (for repeated messages) as well in the future
- Store CommunicatorState before calling pre-receive, instead of trying to correct the state after the pre-receive