### PR TITLE
Implement repeat filters for F_INIT and S ports

### DIFF
--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -50,7 +50,7 @@ def ls_snapshots(run_dir, instance=None):
     )
 
 
-def _python_wrapper(tmpdir, instance_name, muscle_manager, callable):
+def _python_wrapper(tmpdir, instance_name, muscle_manager, callable, *args):
     sys.argv.append(f"--muscle-instance={instance_name}")
     sys.argv.append(f"--muscle-manager={muscle_manager}")
 
@@ -70,7 +70,7 @@ def _python_wrapper(tmpdir, instance_name, muscle_manager, callable):
             root_logger.setLevel(logging.DEBUG)
 
             try:
-                callable()
+                callable(*args)
             except Exception as e:
                 root_logger.exception(e)
                 raise
@@ -88,8 +88,9 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
             Language can be ``"python"``, ``"cpp"``, ``"mpi_cpp"`` or ``"fortran"``.
             Details differ per language.
 
-            For python actors, details is a single callable which is executed
-            in a ``multiprocessing.Process``.
+            For python actors, details is a callable which is executed
+            in a ``multiprocessing.Process``. Additional positional arguments can be
+            supplied as well.
 
             For cpp actors, details is an executable path with optional arguments.
             The executable paths are assumed to be relative to
@@ -129,7 +130,7 @@ def run_manager_with_actors(ymmsl_text, tmpdir, actors, expect_success=True):
                 # start python actor
                 proc = mp.Process(
                     target=_python_wrapper,
-                    args=(tmpdir, instance_name, env["MUSCLE_MANAGER"], actor),
+                    args=(tmpdir, instance_name, env["MUSCLE_MANAGER"], actor, *args),
                     name=instance_name,
                 )
                 proc.start()

--- a/integration_test/test_filters.py
+++ b/integration_test/test_filters.py
@@ -1,0 +1,287 @@
+import pytest
+from ymmsl.v0_2 import Operator
+
+from libmuscle import Instance, Message
+from libmuscle.instance import InstanceFlags
+from libmuscle.manager.run_dir import RunDir
+
+from .conftest import ls_snapshots, run_manager_with_actors, skip_if_python_only
+
+
+def macro() -> None:
+    instance = Instance({Operator.O_I: ["out"]})
+
+    while instance.reuse_instance():
+        for i in range(4):
+            instance.send("out", Message(i, data=["macro", i]))
+
+
+def meso() -> None:
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_I: ["out"]})
+
+    reused = 0
+    while instance.reuse_instance():
+        msg = instance.receive("in")
+        for i in range(reused):
+            t = msg.timestamp + i / 10
+            instance.send("out", Message(t, data=msg.data + ["meso", i]))
+        reused += 1
+
+
+def micro() -> None:
+    instance = Instance({Operator.F_INIT: ["in"], Operator.O_I: ["out"]})
+
+    while instance.reuse_instance():
+        msg = instance.receive("in")
+        for i in range(2):
+            t = msg.timestamp + i / 100
+            instance.send("out", Message(t, data=msg.data + ["micro", i]))
+
+
+EXPECTED_COUNTS = [
+    [1, 0, 0],
+    [1, 0, 1],
+    [2, 0, 0],
+    [2, 0, 1],
+    [2, 1, 0],
+    [2, 1, 1],
+    [3, 0, 0],
+    [3, 0, 1],
+    [3, 1, 0],
+    [3, 1, 1],
+    [3, 2, 0],
+    [3, 2, 1],
+]
+
+
+def pico(filters: str) -> None:
+    print("Running with conduit filter:", filters)
+    instance = Instance({Operator.F_INIT: ["macro", "meso", "micro"]})
+
+    reused = 0
+    while instance.reuse_instance():
+        macro = instance.receive("macro")
+        meso = instance.receive("meso")
+        micro = instance.receive("micro")
+
+        print("Received:", macro.data, meso.data, micro.data)
+        message_counts = micro.data[1::2]
+        assert message_counts == EXPECTED_COUNTS[reused]
+
+        # Test if macro message is padded or repeated, based on conduit filter filters
+        if filters == "pad pad" and any(message_counts[1:]):
+            assert macro.data is None
+        elif filters == "repeat pad" and message_counts[-1]:
+            assert macro.data is None
+        else:
+            assert macro.data == micro.data[:2]
+
+        assert micro.data[:4] == meso.data
+        reused += 1
+
+    assert reused == len(EXPECTED_COUNTS)
+
+
+def repeat_s(filters: str) -> None:
+    instance = Instance(
+        {Operator.F_INIT: ["meso"], Operator.S: ["macro", "repeated_meso", "micro"]}
+    )
+
+    micro_received = 0
+    while instance.reuse_instance():
+        meso = instance.receive("meso")
+        print("Receveid meso:", meso.data)
+
+        for _ in range(2):
+            macro = instance.receive("macro")
+            repeated_meso = instance.receive("repeated_meso")
+            micro = instance.receive("micro")
+
+            print("Received S:", macro.data, repeated_meso.data, micro.data)
+            message_counts = micro.data[1::2]
+            assert message_counts == EXPECTED_COUNTS[micro_received]
+
+            # Test if macro message is padded or repeated
+            if filters == "pad pad" and any(message_counts[1:]):
+                assert macro.data is None
+            elif filters == "repeat pad" and message_counts[-1]:
+                assert macro.data is None
+            else:
+                assert macro.data == micro.data[:2]
+
+            assert repeated_meso.data == meso.data
+            assert micro.data[:4] == meso.data
+            micro_received += 1
+    assert micro_received == len(EXPECTED_COUNTS)
+
+
+config = """
+ymmsl_version: v0.2
+models:
+  repeaters:
+    components:
+      macro:
+        description: macro
+        ports:
+          o_i: out
+        implementation: macro
+      meso:
+        description: meso
+        ports:
+          f_init: in
+          o_i: out
+        implementation: meso
+      micro:
+        description: micro
+        ports:
+          f_init: in
+          o_i: out
+        implementation: micro
+      repeat_s:
+        description: micro with repeaters on S ports
+        ports:
+          f_init: meso
+          timeline micro:
+            s: macro repeated_meso micro
+        implementation: repeat_s
+      pico:
+        description: pico
+        ports:
+          f_init: macro meso micro
+        implementation: pico
+    conduits:
+      macro.out:
+      - meso.in
+      - {filters} pico.macro
+      - {filters} repeat_s.macro
+      meso.out:
+      - micro.in
+      - repeat pico.meso
+      - repeat_s.meso
+      - repeat repeat_s.repeated_meso
+      micro.out:
+      - pico.micro
+      - repeat_s.micro
+"""
+
+
+@pytest.mark.parametrize("filters", ["repeat repeat", "repeat pad", "pad pad"])
+def test_repeater_filters(tmp_path, filters):
+    actors = {
+        "macro": ("python", macro),
+        "meso": ("python", meso),
+        "micro": ("python", micro),
+        "repeat_s": ("python", repeat_s, filters),
+        "pico": ("python", pico, filters),
+    }
+    run_manager_with_actors(config.format(filters=filters), tmp_path, actors)
+
+
+@skip_if_python_only
+@pytest.mark.parametrize("filters", ["repeat repeat", "repeat pad", "pad pad"])
+def test_repeater_filters_cpp(tmp_path, filters):
+    actors = {
+        "macro": ("python", macro),
+        "meso": ("python", meso),
+        "micro": ("python", micro),
+        "repeat_s": ("cpp", "conduit_filters_test", "repeat_s", filters),
+        "pico": ("cpp", "conduit_filters_test", "pico", filters),
+    }
+    run_manager_with_actors(config.format(filters=filters), tmp_path, actors)
+
+
+checkpoint_config = """
+ymmsl_version: v0.2
+models:
+  checkpointing:
+    components:
+      A:
+        description: first component
+        ports:
+          o_f: out
+        implementation: A
+      B:
+        description: second component
+        ports:
+          s: in
+        implementation: B
+    conduits:
+      A.out: repeat B.in
+checkpoints:
+  at_end: true
+  simulation_time:
+  - at: 2
+"""
+
+
+def checkpointing_A():
+    instance = Instance(
+        {Operator.O_F: ["out"]},
+        InstanceFlags.KEEPS_NO_STATE_FOR_NEXT_USE,
+    )
+
+    while instance.reuse_instance():
+        instance.send("out", Message(5, data="xyz"))
+
+
+def checkpointing_B():
+    instance = Instance(
+        {Operator.S: ["in"]},
+        InstanceFlags.USES_CHECKPOINT_API,
+    )
+
+    while instance.reuse_instance():
+        if instance.resuming():
+            t_cur = instance.load_snapshot().timestamp
+        if instance.should_init():
+            t_cur = 0.0
+
+        while t_cur < 5:
+            msg = instance.receive("in")
+            assert msg.data == "xyz"
+            assert msg.timestamp == 5
+            print("Message is alright!")
+
+            t_cur += 1
+            if instance.should_save_snapshot(t_cur):
+                instance.save_snapshot(Message(t_cur))
+
+        if instance.should_save_final_snapshot():
+            instance.save_final_snapshot(Message(t_cur))
+
+
+def test_repeater_filters_checkpoint(tmp_path):
+    actors = {
+        "A": ("python", checkpointing_A),
+        "B": ("python", checkpointing_B),
+    }
+    run_checkpointing_config_with_actors(actors, tmp_path)
+
+
+@skip_if_python_only
+def test_repeater_filters_checkpoint_cpp(tmp_path):
+    actors = {
+        "A": ("cpp", "conduit_filters_test", "checkpointing_A"),
+        "B": ("cpp", "conduit_filters_test", "checkpointing_B"),
+    }
+    run_checkpointing_config_with_actors(actors, tmp_path)
+
+
+def run_checkpointing_config_with_actors(actors, tmp_path):
+    run_dir1 = RunDir(tmp_path / "run1")
+    run_manager_with_actors(checkpoint_config, run_dir1.path, actors)
+
+    assert len(ls_snapshots(run_dir1, "A")) == 1  # at_end
+    assert len(ls_snapshots(run_dir1, "B")) == 2  # t=2, at_end
+    snapshots_ymmsl = ls_snapshots(run_dir1)
+    assert len(snapshots_ymmsl) == 2
+
+    # resume from the snapshot
+    run_dir2 = RunDir(tmp_path / "run2")
+    snapshot_txt = snapshots_ymmsl[0].read_text()
+
+    run_manager_with_actors(
+        checkpoint_config + snapshot_txt.removeprefix("ymmsl_version: v0.2"),
+        run_dir2.path,
+        actors,
+    )

--- a/integration_test/test_parameter_overlays.py
+++ b/integration_test/test_parameter_overlays.py
@@ -127,6 +127,7 @@ def test_settings_overlays(log_file_in_tmpdir):
                 ("test4", True),
                 ("test5", [2.3, 5.6]),
                 ("test6", [[1.0, 2.0], [3.0, 1.0]]),
+                ("muscle_remote_log_level", "DEBUG"),
             ]
         )
     )

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -33,6 +33,45 @@ using ymmsl::Settings;
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 
+namespace {
+
+/** Helper method to construct a Message from an MPPMessage.
+ * 
+ * N.B. since C++ enforces only const access to .settings and .data, we don't need to
+ * make a copy (unlike the Python equivalent).
+ */
+Message make_message(MPPMessage const & mpp_msg) {
+    Message message(
+        mpp_msg.timestamp,
+        mpp_msg.data,
+        mpp_msg.settings_overlay.as<Settings>()
+    );
+    if (mpp_msg.next_timestamp.is_set())
+        message.set_next_timestamp(mpp_msg.next_timestamp.get());
+    return message;
+}
+
+
+/** Helper template method to execute code for each slot of the given port.
+ * 
+ * Expects a function with arguments (Optional<int> slot, Reference port_ref)
+ */
+template<typename F>
+void for_each_slot(Port const & port, F&& f) {
+    Reference port_name(port.name);
+    if (!port.is_vector()) {
+        f({}, port_name);
+    } else {
+        int slot = 0; // Allow pre-receive to receive 1 message that updates port._length
+        do {
+            f(slot, port_name + slot);  
+        } while (++slot < port.get_length());
+    }
+}
+
+}
+
+
 Communicator::Communicator(
         ymmsl::Reference const & kernel,
         std::vector<int> const & index,
@@ -47,6 +86,9 @@ Communicator::Communicator(
     , server_()
     , clients_()
     , receive_timeout_(10.0)  // Notify manager, by default, after 10 seconds waiting in receive_message()
+    , pre_receive_ports_()
+    , repeat_filters_()
+    , message_cache_()
 {}
 
 std::vector<std::string> Communicator::get_locations() const {
@@ -56,13 +98,15 @@ std::vector<std::string> Communicator::get_locations() const {
 void Communicator::set_peer_info(PeerInfo const & peer_info) {
     peer_info_ = peer_info;
     timeline_manager_ = std::make_unique<TimelineManager>(port_manager_);
+    prepare_conduit_filters_();
 }
 
 CommunicatorState Communicator::get_state() const {
     assert(timeline_manager_);
     return {
         port_manager_.get_message_counts(),
-        timeline_manager_->get_state()
+        timeline_manager_->get_state(),
+        message_cache_
     };
 }
 
@@ -70,6 +114,7 @@ void Communicator::restore_state(CommunicatorState const & state) {
     assert(timeline_manager_);
     port_manager_.restore_message_counts(state.port_message_counts);
     timeline_manager_->restore_state(state.timeline_state);
+    message_cache_ = state.message_cache;
 }
 
 void Communicator::send_message(
@@ -132,80 +177,89 @@ void Communicator::send_message(
         port.set_closed(slot);
 }
 
-Communicator::FInitCacheType Communicator::pre_receive_f_init() {
+Communicator::FInitCacheType Communicator::pre_receive() {
     assert(timeline_manager_);
     auto finished_iteration = timeline_manager_->start_reuse_iteration();
-    if (finished_iteration.is_set())
-        broadcast_milestone_(Milestone(finished_iteration.get()), true);
+    auto milestone_iteration = finished_iteration;
 
+    while (true) {
+        if (milestone_iteration.is_set()) {
+            // Should send on O_I only when this is the milestone for the finished
+            // iteration. Other milestones (received on F_INIT ports) should
+            // propagate to O_F as well:
+            Milestone milestone(milestone_iteration.get());
+            broadcast_milestone_(milestone, (milestone_iteration == finished_iteration));
+
+            // Clean up stale messages in the cache
+            for (auto it = message_cache_.begin(); it != message_cache_.end(); ) {
+                if (it->second.iteration == milestone_iteration.get())
+                    it = message_cache_.erase(it);
+                else
+                    ++it;
+            }
+
+            // TODO: send buffered messages for reducer filters
+
+            if (milestone.is_final_milestone())
+                throw PortClosed();
+        }
+
+        std::vector<IterationCount> milestone_iterations;
+        // Pre-receive on all F_INIT ports and repeated S ports, if needed
+        for (Port const & port : pre_receive_ports_) {
+            std::string port_name(port.name);
+            for_each_slot(port, [&](Optional<int> slot, Reference port_ref){
+                if (message_cache_.count(port_ref)) return;
+                log_debug("Pre-receiving on ", port_desc(port_name, slot));
+                auto mpp_message = receive_message_(port_name, slot);
+                message_cache_.emplace(port_ref, mpp_message);
+
+                if (is_milestone(mpp_message.data))
+                    milestone_iterations.emplace_back(Milestone(mpp_message.data).iteration());
+            });
+        }
+
+        if (milestone_iterations.empty())
+            break;  // No milestones received, we have only messages now
+
+        // Handle most deeply nested milestone first:
+        try {
+            milestone_iteration = get_most_nested_iteration(milestone_iterations);
+        } catch (std::runtime_error & err) {
+            throw std::runtime_error(
+                "Internal error: received milestones for incompatible iterations "
+                "during F_INIT: " + std::string(err.what())
+            );
+        }
+    }
+
+    // Update current iteration
+    std::vector<IterationCount> received_iterations;
+    for (auto & item : message_cache_)
+        received_iterations.push_back(item.second.iteration);
+    auto new_iteration = timeline_manager_->check_pre_received_iteration_counts(
+            received_iterations);
+
+    // Sanity check: we should not have any milestones left in the cache at this point
+    for (auto & item : message_cache_) {
+        if (is_milestone(item.second.data))
+            throw std::runtime_error("Internal error: found milestones in message cache.");
+    }
+
+    // Fill F_INIT cache for Instance
     FInitCacheType cache;
-
-    auto pre_receive = [&](std::string & port_name, Optional<int> slot) {
-        Reference port_ref(port_name);
-        if (slot.is_set())
-            port_ref += slot.get();
-        
-        auto msg = receive_message_(port_name, slot);
-        cache.emplace(port_ref, msg);
-    };
-
     for (Port const & port : port_manager_.get_connected_ports(Operator::F_INIT, {})) {
         std::string port_name(port.name);
-        log_debug("Pre-receiving on port ", port_name);
-        if (!port.is_vector())
-            pre_receive(port_name, {});
-        else {
-            pre_receive(port_name, 0);
-            // The above receives the length, if needed, so now we can get the rest.
-            for (int slot = 1; slot < port.get_length(); ++slot)
-                pre_receive(port_name, slot);
-        }
-    }
-
-    // Check if we have received milestones
-    std::vector<Optional<IterationCount>> milestone_iterations;
-    std::vector<std::string> closed_ports;
-    for (auto & item : cache) {
-        Optional<IterationCount> it;
-        if (is_milestone(item.second.data())) {
-            Milestone milestone(item.second.data());
-            it = milestone.iteration();
-            if (milestone.is_final_milestone()) {
-                closed_ports.emplace_back(item.first);
-            }
-        }
-        auto found = std::find(milestone_iterations.begin(), milestone_iterations.end(), it);
-        if (found == milestone_iterations.end())  // Not found
-            milestone_iterations.push_back(it);
-    }
-    // Milestones should be consistent, or something went wrong
-    if (milestone_iterations.size() > 1) {
-        if (closed_ports.size() > 0) {
-            std::ostringstream oss;
-            oss << "Some ports were unexpectedly closed while trying to receive, did ";
-            oss << "the peers crash? Closed ports: ";
-            bool first = true;
-            for (auto & port : closed_ports) {
-                if (!first) oss << ", ";
-                first = false;
-                oss << port;
-            }
-            throw std::runtime_error(oss.str());
-        }
-        throw std::runtime_error(
-            "Internal error: received milestones for different iterations in F_INIT. "
-            "This is not supposed to happen and may be a bug in libmuscle. Please "
-            "report an issue."
-        );
-    }
-    if (!milestone_iterations.empty() && milestone_iterations.at(0).is_set()) {
-        // Propagate milestone
-        Milestone milestone(milestone_iterations.at(0).get());
-        broadcast_milestone_(milestone, false);
-        if (milestone_iterations.at(0).get().empty())  // Final milestone received
-            throw PortClosed();
-        // Pre-receive again to receive the actual messages
-        return pre_receive_f_init();
+        bool pad_message = false;
+        if (repeat_filters_.count(port_name))
+            pad_message = pad_message_(new_iteration, repeat_filters_.at(port_name));
+        for_each_slot(port, [&](Optional<int> slot, Reference port_ref){
+            auto & mpp_message = message_cache_.at(port_ref);
+            auto message = make_message(mpp_message);
+            if (pad_message)
+                message.set_data(Data());
+            cache.emplace(port_ref, message);
+        });
     }
 
     return cache;
@@ -215,27 +269,43 @@ Message Communicator::receive_s_message(
         std::string const & port_name,
         Optional<int> slot)
 {
+    timeline_manager_->check_receive_s(port_name, slot);
+
+    // Handle receive on repeated S port:
+    if (repeat_filters_.count(port_name)) {
+        auto & filters = repeat_filters_.at(port_name);
+        Reference port_ref(port_name);
+        if (slot.is_set()) port_ref += slot.get();
+        auto & message = message_cache_.at(port_ref);
+        auto & cur_iteration = timeline_manager_->record_received_s_message(
+                port_name, slot, message.iteration, filters.size());
+        auto result = make_message(message);
+        if (pad_message_(cur_iteration, filters))
+            result.set_data(Data());
+        return result;
+    }
+
     // Instance should not need to bother about milestones, so we keep receiving
     // messages until we have actual data.
     while (true) {
         auto message = receive_message_(port_name, slot);
-        if (is_milestone(message.data())) {
-            if (Milestone(message.data()).is_final_milestone())
+        if (is_milestone(message.data)) {
+            if (Milestone(message.data).is_final_milestone())
                 throw PortClosed();
             // TODO: handle milestone, if needed
         } else {
-            return message;
+            timeline_manager_->record_received_s_message(
+                    port_name, slot, message.iteration);
+            return make_message(message);
         }
     }
 }
 
 
-Message Communicator::receive_message_(
+MPPMessage Communicator::receive_message_(
         std::string const & port_name,
         Optional<int> slot)
 {
-    timeline_manager_->check_receive(port_name, slot);
-
     Port & port = port_manager_.get_port(port_name);
     std::string port_and_slot = port_desc(port_name, slot);
     log_debug("Waiting for message on ", port_and_slot);
@@ -262,7 +332,6 @@ Message Communicator::receive_message_(
             port.get_num_messages(), msg.size());
 
     auto mpp_message = MPPMessage::from_bytes(msg);
-    Settings overlay_settings(mpp_message.settings_overlay.as<Settings>());
 
     recv_decode_event.stop();
 
@@ -275,26 +344,20 @@ Message Communicator::receive_message_(
             port.set_closed(slot);
     }
 
-    Message message(
-            mpp_message.timestamp, mpp_message.data, overlay_settings);
-
-    if (mpp_message.next_timestamp.is_set())
-        message.set_next_timestamp(mpp_message.next_timestamp.get());
-
     ProfileTimestamp start_recv, end_wait, end_transfer;
     std::tie(start_recv, end_wait, end_transfer) = std::get<1>(msg_and_profile);
     ProfileEvent recv_wait_event(
             ProfileEventType::receive_wait, start_recv,
             end_wait, port, mpp_message.port_length, slot,
-            port.get_num_messages(), msg.size(), message.timestamp());
+            port.get_num_messages(), msg.size(), mpp_message.timestamp);
 
     ProfileEvent recv_xfer_event(
             ProfileEventType::receive_transfer, end_wait,
             end_transfer, port, mpp_message.port_length, slot,
-            port.get_num_messages(), msg.size(), message.timestamp());
+            port.get_num_messages(), msg.size(), mpp_message.timestamp);
 
-    recv_decode_event.message_timestamp = message.timestamp();
-    receive_event.message_timestamp = message.timestamp();
+    recv_decode_event.message_timestamp = mpp_message.timestamp;
+    receive_event.message_timestamp = mpp_message.timestamp;
 
     if (port.is_vector()) {
         receive_event.port_length = port.get_length();
@@ -334,8 +397,6 @@ Message Communicator::receive_message_(
     if (!is_milestone(mpp_message.data)) {
         port.increment_num_messages(slot);
         log_debug("Received message on ", port_and_slot);
-        timeline_manager_->record_received_message(
-                port_name, slot, mpp_message.iteration.get());
     } else {
         Milestone milestone(mpp_message.data);
         if (milestone.is_final_milestone())
@@ -343,7 +404,7 @@ Message Communicator::receive_message_(
         else
             log_debug("Received ", std::string(milestone), " on ", port_and_slot);
     }
-    return message;
+    return mpp_message;
 }
 
 void Communicator::shutdown() {
@@ -482,6 +543,38 @@ void Communicator::close_ports_() {
         return;  // Not connected yet, no ports to close
     close_outgoing_ports_();
     close_incoming_ports_();
+}
+
+void Communicator::prepare_conduit_filters_() {
+    // Repeater filters
+    for (auto op : {Operator::F_INIT, Operator::S}) {
+        for (Port const & port : port_manager_.get_connected_ports(op, {})) {
+            auto filters = peer_info_.get().get_filters_for_receiver(kernel_ + port.name);
+            // Only keep the repeater filters, the sending component handles reducers:
+            filters.erase(
+                std::remove_if(filters.begin(), filters.end(), ::ymmsl::is_reducer),
+                filters.end());
+            if (!filters.empty())
+                repeat_filters_.emplace(port.name, filters);
+            if (op == Operator::F_INIT || !filters.empty())
+                pre_receive_ports_.push_back(port);
+        }
+    }
+
+    // TODO: reducer filters
+}
+
+
+bool Communicator::pad_message_(
+        IterationCount const & cur_iteration,
+        std::vector<::ymmsl::ConduitFilter> const & filters)
+{
+    std::size_t offset = cur_iteration.size() - filters.size();
+    for (std::size_t i = 0; i < filters.size(); ++i) {
+        if (filters[i] == ::ymmsl::ConduitFilter::PAD && cur_iteration[offset + i] > 0)
+            return true;
+    }
+    return false;
 }
 
 } }

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -292,7 +292,6 @@ Message Communicator::receive_s_message(
         if (is_milestone(message.data)) {
             if (Milestone(message.data).is_final_milestone())
                 throw PortClosed();
-            // TODO: handle milestone, if needed
         } else {
             timeline_manager_->record_received_s_message(
                     port_name, slot, message.iteration);

--- a/src/cpp/libmuscle/communicator.cpp
+++ b/src/cpp/libmuscle/communicator.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -36,9 +37,10 @@ namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 namespace {
 
 /** Helper method to construct a Message from an MPPMessage.
- * 
- * N.B. since C++ enforces only const access to .settings and .data, we don't need to
- * make a copy (unlike the Python equivalent).
+ *
+ * N.B. unlike the Python equivalent, no explicit copy is needed: the Message
+ * constructor already copies mpp_msg's settings and data, and mutators like
+ * set_data() reseat Message's own reference rather than modify mpp_msg's data.
  */
 Message make_message(MPPMessage const & mpp_msg) {
     Message message(
@@ -52,12 +54,10 @@ Message make_message(MPPMessage const & mpp_msg) {
 }
 
 
-/** Helper template method to execute code for each slot of the given port.
- * 
- * Expects a function with arguments (Optional<int> slot, Reference port_ref)
- */
-template<typename F>
-void for_each_slot(Port const & port, F&& f) {
+/** Helper method to execute code for each slot of the given port. */
+void for_each_slot(
+        Port const & port,
+        std::function<void(Optional<int> slot, Reference port_ref)> const & f) {
     Reference port_name(port.name);
     if (!port.is_vector()) {
         f({}, port_name);
@@ -237,7 +237,7 @@ Communicator::FInitCacheType Communicator::pre_receive() {
     std::vector<IterationCount> received_iterations;
     for (auto & item : message_cache_)
         received_iterations.push_back(item.second.iteration);
-    auto new_iteration = timeline_manager_->check_pre_received_iteration_counts(
+    auto new_iteration = timeline_manager_->record_pre_received_iteration_counts(
             received_iterations);
 
     // Sanity check: we should not have any milestones left in the cache at this point

--- a/src/cpp/libmuscle/communicator.hpp
+++ b/src/cpp/libmuscle/communicator.hpp
@@ -46,6 +46,7 @@ class Communicator {
     public:
         using PortMessageCounts = std::unordered_map<std::string, std::vector<int>>;
         using FInitCacheType = std::unordered_map<::ymmsl::Reference, Message>;
+        using MPPCacheType = std::unordered_map<::ymmsl::Reference, MPPMessage>;
 
         /** Create a Communicator.
          *
@@ -101,11 +102,11 @@ class Communicator {
                 Message const & message,
                 Optional<int> slot = {});
 
-        /** Receive on all connected F_INIT port (including muscle_settings_in).
+        /** Pre-receive on all connected F_INIT ports and S ports with repeat filters.
          * 
-         * @return The received messages.
+         * @return The received messages on F_INIT ports (including muscle_settings_in).
          */
-        FInitCacheType pre_receive_f_init();
+        FInitCacheType pre_receive();
 
         /** Receive a message and attached settings overlay on an "S" port.
          *
@@ -161,7 +162,7 @@ class Communicator {
 
         /** Implementation for receive_message.
          */
-        Message receive_message_(
+        MPPMessage receive_message_(
                 std::string const & port_name,
                 Optional<int> slot = {}
                 );
@@ -214,6 +215,20 @@ class Communicator {
          */
         void close_ports_();
 
+        /** Check which ports are connected with a conduit filter and initialize the
+         * associated logic.
+         */
+        void prepare_conduit_filters_();
+
+        /** Check if we should pad the message in the current iteration, based on the
+         * configured pad/repeat filters.
+         * 
+         * @return true if the mesage data should be nilled, false otherwise.
+         */
+        bool pad_message_(
+                IterationCount const & cur_iteration,
+                std::vector<::ymmsl::ConduitFilter> const & filters);
+
         ymmsl::Reference kernel_;
         std::vector<int> index_;
         PortManager & port_manager_;
@@ -224,6 +239,10 @@ class Communicator {
         Optional<PeerInfo> peer_info_;
         double receive_timeout_;
         std::unique_ptr<TimelineManager> timeline_manager_;
+
+        PortManager::PortReferences pre_receive_ports_;
+        std::unordered_map<std::string, std::vector<::ymmsl::ConduitFilter>> repeat_filters_;
+        MPPCacheType message_cache_;
 };
 
 } }

--- a/src/cpp/libmuscle/communicator_state.cpp
+++ b/src/cpp/libmuscle/communicator_state.cpp
@@ -13,9 +13,14 @@ Data CommunicatorState::to_data() const {
         pmc[kv.first] = counts;
     }
 
+    Data mc = Data::dict();
+    for (const auto & kv : message_cache)
+        mc[std::string(kv.first)] = kv.second.encoded_as_data();
+
     return Data::dict(
         "port_message_counts", pmc,
-        "timeline_state", timeline_state.to_data());
+        "timeline_state", timeline_state.to_data(),
+        "message_cache", mc);
 }
 
 CommunicatorState CommunicatorState::from_data(DataConstRef const & data) {
@@ -31,6 +36,10 @@ CommunicatorState CommunicatorState::from_data(DataConstRef const & data) {
     }
 
     state.timeline_state = TimelineState::from_data(data["timeline_state"]);
+
+    auto data_mc = data["message_cache"];
+    for (std::size_t i=0; i<data_mc.size(); ++i)
+        state.message_cache.emplace(data_mc.key(i), MPPMessage::from_bytes(data_mc.value(i)));
 
     return state;
 }

--- a/src/cpp/libmuscle/communicator_state.hpp
+++ b/src/cpp/libmuscle/communicator_state.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "libmuscle/data.hpp"
+#include "libmuscle/mpp_message.hpp"
 #include "libmuscle/port_manager.hpp"
 #include "libmuscle/timeline_manager.hpp"
+
+#include "ymmsl/ymmsl.hpp"
 
 namespace libmuscle { namespace _MUSCLE_IMPL_NS {
 
@@ -10,6 +13,7 @@ class CommunicatorState {
     public:
         PortManager::PortMessageCounts port_message_counts;
         TimelineState timeline_state;
+        std::unordered_map<::ymmsl::Reference, MPPMessage> message_cache;
 
         /** Convert CommunicatorState into Data */
         Data to_data() const;

--- a/src/cpp/libmuscle/instance.cpp
+++ b/src/cpp/libmuscle/instance.cpp
@@ -980,7 +980,7 @@ bool Instance::Impl::pre_receive_() {
     ProfileEvent sw_event(ProfileEventType::shutdown_wait, ProfileTimestamp());
 
     try {
-        f_init_cache_ = communicator_->pre_receive_f_init();
+        f_init_cache_ = communicator_->pre_receive();
     } catch (PortClosed &err) {
         profiler_->record_event(std::move(sw_event));
         f_init_cache_.clear();

--- a/src/cpp/libmuscle/mpp_message.cpp
+++ b/src/cpp/libmuscle/mpp_message.cpp
@@ -55,7 +55,7 @@ std::vector<char> MPPMessage::encoded() const {
     return bytes;
 }
 
-DataConstRef MPPMessage::encoded_as_dcr() const {
+Data MPPMessage::encoded_as_data() const {
     DataConstRef msg_dict = as_dict_();
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, msg_dict);

--- a/src/cpp/libmuscle/mpp_message.hpp
+++ b/src/cpp/libmuscle/mpp_message.hpp
@@ -49,7 +49,7 @@ class MPPMessage {
 
         /** Encode the message and return as a byte buffer.
          */
-        DataConstRef encoded_as_dcr() const;
+        Data encoded_as_data() const;
 
         /** Create an MCP Message from an encoded buffer.
          *
@@ -69,7 +69,7 @@ class MPPMessage {
         DataConstRef settings_overlay;
         int message_number;
         DataConstRef data;
-        Optional<IterationCount> iteration;
+        IterationCount iteration;
 
     private:
         static MPPMessage from_dict_(DataConstRef const & dict);

--- a/src/cpp/libmuscle/port.hpp
+++ b/src/cpp/libmuscle/port.hpp
@@ -143,7 +143,9 @@ class Port : public ::ymmsl::Port {
          */
         void set_resumed(Optional<int> slot = {});
 
+#ifndef LIBMUSCLE_MOCK_PORT_MANAGER // Enable public access for tests:
     PRIVATE:
+#endif
         bool is_connected_;
         int length_;
         bool is_resizable_;

--- a/src/cpp/libmuscle/port.hpp
+++ b/src/cpp/libmuscle/port.hpp
@@ -143,9 +143,7 @@ class Port : public ::ymmsl::Port {
          */
         void set_resumed(Optional<int> slot = {});
 
-#ifndef LIBMUSCLE_MOCK_PORT_MANAGER // Enable public access for tests:
     PRIVATE:
-#endif
         bool is_connected_;
         int length_;
         bool is_resizable_;

--- a/src/cpp/libmuscle/snapshot.cpp
+++ b/src/cpp/libmuscle/snapshot.cpp
@@ -86,7 +86,7 @@ std::vector<char> Snapshot::to_bytes() const {
             "triggers", d_triggers,
             "wallclock_time", wallclock_time,
             "is_final_snapshot", is_final_snapshot,
-            "message", mpp_msg.encoded_as_dcr(),
+            "message", mpp_msg.encoded_as_data(),
             "settings_overlay", Data(settings_overlay),
             "communicator_state", communicator_state.to_data());
 

--- a/src/cpp/libmuscle/tests/conduit_filters_test.cpp
+++ b/src/cpp/libmuscle/tests/conduit_filters_test.cpp
@@ -1,0 +1,162 @@
+/* This is a part of the integration test suite, and is run from a Python
+ * test in /integration_test. It is not a unit test.
+ */
+#include <cassert>
+#include <iostream>
+
+#include <libmuscle/libmuscle.hpp>
+#include <ymmsl/ymmsl.hpp>
+
+
+using libmuscle::Data;
+using libmuscle::DataConstRef;
+using libmuscle::Instance;
+using libmuscle::InstanceFlags;
+using libmuscle::Message;
+using ymmsl::Operator;
+
+static std::vector<std::vector<int>> expected_counts{
+    {1, 0, 0},
+    {1, 0, 1},
+    {2, 0, 0},
+    {2, 0, 1},
+    {2, 1, 0},
+    {2, 1, 1},
+    {3, 0, 0},
+    {3, 0, 1},
+    {3, 1, 0},
+    {3, 1, 1},
+    {3, 2, 0},
+    {3, 2, 1}
+};
+
+// See corresponding Python actor in integration_test/test_filters
+void pico(int argc, char * argv[]) {
+    std::string filters = std::string(argv[2]);
+    std::cout << "Running with conduit filter: '" << filters << "'" << std::endl;
+    assert(filters == "pad pad" || filters == "repeat pad" || filters == "repeat repeat");
+
+    Instance instance(argc, argv, {{Operator::F_INIT, {"macro", "meso", "micro"}}});
+
+    int reused = 0;
+    while (instance.reuse_instance()) {
+        auto macro = instance.receive("macro");
+        auto meso = instance.receive("meso");
+        auto micro = instance.receive("micro");
+
+        std::vector<int> message_counts{
+            micro.data()[1].as<int>(),
+            micro.data()[3].as<int>(),
+            micro.data()[5].as<int>()};
+        assert(message_counts == expected_counts[reused]);
+
+        if (filters == "pad pad" && (message_counts[1] || message_counts[2])) {
+            assert(macro.data().is_nil());
+        } else if (filters == "repeat pad" && message_counts[2]) {
+            assert(macro.data().is_nil());
+        } else {
+            assert(macro.data()[0].as<std::string>() == micro.data()[0].as<std::string>());
+            assert(macro.data()[1].as<int>() == micro.data()[1].as<int>());
+        }
+
+        ++reused;
+    }
+    assert(reused == expected_counts.size());
+}
+
+// See corresponding Python actor in integration_test/test_filters
+void repeat_s(int argc, char * argv[]) {
+    std::string filters = std::string(argv[2]);
+    std::cout << "Running with conduit filter: '" << filters << "'" << std::endl;
+
+    
+    Instance instance(argc, argv, {
+        {Operator::F_INIT, {"meso"}},
+        {Operator::S, {"macro", "repeated_meso", "micro"}}
+    });
+
+    int micro_received = 0;
+    while (instance.reuse_instance()) {
+        auto meso = instance.receive("meso");
+
+        for (int i = 0; i < 2; ++i) {
+            auto macro = instance.receive("macro");
+            auto repeated_meso = instance.receive("repeated_meso");
+            auto micro = instance.receive("micro");
+
+            std::vector<int> message_counts{
+                micro.data()[1].as<int>(),
+                micro.data()[3].as<int>(),
+                micro.data()[5].as<int>()};
+            assert(message_counts == expected_counts[micro_received]);
+
+            if (filters == "pad pad" && (message_counts[1] || message_counts[2])) {
+                assert(macro.data().is_nil());
+            } else if (filters == "repeat pad" && message_counts[2]) {
+                assert(macro.data().is_nil());
+            } else {
+                assert(macro.data()[0].as<std::string>() == micro.data()[0].as<std::string>());
+                assert(macro.data()[1].as<int>() == micro.data()[1].as<int>());
+            }
+
+            ++micro_received;
+        }
+    }
+    assert(micro_received == expected_counts.size());
+}
+
+// See corresponding Python actor in integration_test/test_filters
+void checkpointing_A(int argc, char * argv[]) {
+    Instance instance(argc, argv, 
+        {{Operator::O_F, {"out"}}},
+        InstanceFlags::KEEPS_NO_STATE_FOR_NEXT_USE);
+
+    while (instance.reuse_instance())
+        instance.send("out", Message(4, "xyz"));
+}
+
+// See corresponding Python actor in integration_test/test_filters
+void checkpointing_B(int argc, char * argv[]) {
+    Instance instance(argc, argv, 
+        {{Operator::S, {"in"}}},
+        InstanceFlags::USES_CHECKPOINT_API);
+
+    while (instance.reuse_instance()) {
+        double t_cur;
+        if (instance.resuming())
+            t_cur = instance.load_snapshot().timestamp();
+        if (instance.should_init())
+            t_cur = 0.0;
+        
+        while (t_cur < 5) {
+            auto msg = instance.receive("in");
+            assert(msg.data().as<std::string>() == "xyz");
+            assert(msg.timestamp() == 5);
+            std::cout << "Message is alright!";
+
+            t_cur += 1.0;
+            if (instance.should_save_snapshot(t_cur))
+                instance.save_snapshot(Message(t_cur));
+        }
+
+        if (instance.should_save_final_snapshot())
+            instance.save_final_snapshot(Message(t_cur));
+    }
+}
+
+
+int main(int argc, char * argv[]) {
+    if (argc < 3) throw std::runtime_error("Missing filters argument");
+    if (argv[1] == std::string("pico"))
+        pico(argc, argv);
+    else if (argv[1] == std::string("repeat_s"))
+        repeat_s(argc, argv);
+    else if (argv[1] == std::string("checkpointing_A"))
+        checkpointing_A(argc, argv);
+    else if (argv[1] == std::string("checkpointing_B"))
+        checkpointing_B(argc, argv);
+    else
+        throw std::runtime_error("Unknown program: " + std::string(argv[1]));
+    return EXIT_SUCCESS;
+}
+

--- a/src/cpp/libmuscle/tests/conduit_filters_test.cpp
+++ b/src/cpp/libmuscle/tests/conduit_filters_test.cpp
@@ -38,7 +38,7 @@ void pico(int argc, char * argv[]) {
 
     Instance instance(argc, argv, {{Operator::F_INIT, {"macro", "meso", "micro"}}});
 
-    int reused = 0;
+    std::size_t reused = 0;
     while (instance.reuse_instance()) {
         auto macro = instance.receive("macro");
         auto meso = instance.receive("meso");
@@ -75,7 +75,7 @@ void repeat_s(int argc, char * argv[]) {
         {Operator::S, {"macro", "repeated_meso", "micro"}}
     });
 
-    int micro_received = 0;
+    std::size_t micro_received = 0;
     while (instance.reuse_instance()) {
         auto meso = instance.receive("meso");
 
@@ -112,7 +112,7 @@ void checkpointing_A(int argc, char * argv[]) {
         InstanceFlags::KEEPS_NO_STATE_FOR_NEXT_USE);
 
     while (instance.reuse_instance())
-        instance.send("out", Message(4, "xyz"));
+        instance.send("out", Message(5, "xyz"));
 }
 
 // See corresponding Python actor in integration_test/test_filters

--- a/src/cpp/libmuscle/tests/fixtures.hpp
+++ b/src/cpp/libmuscle/tests/fixtures.hpp
@@ -206,8 +206,6 @@ struct CommunicatorStateFixture {
 
             communicator_state_.timeline_state.iteration = IterationCount({1});
             communicator_state_.timeline_state.send_participated = {};
-            communicator_state_.timeline_state.receive_participated = {
-                    PortAndSlot("in", OptionalSlot())};
             communicator_state_.timeline_state.subtimeline_states = {};
         }
 };

--- a/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_communicator.hpp
@@ -97,7 +97,7 @@ class MockCommunicator : public MockClass<MockCommunicator> {
             NAME_MOCK_MEM_FUN(MockCommunicator, get_locations);
             NAME_MOCK_MEM_FUN(MockCommunicator, set_peer_info);
             NAME_MOCK_MEM_FUN(MockCommunicator, send_message);
-            NAME_MOCK_MEM_FUN(MockCommunicator, pre_receive_f_init);
+            NAME_MOCK_MEM_FUN(MockCommunicator, pre_receive);
             NAME_MOCK_MEM_FUN(MockCommunicator, receive_s_message);
             NAME_MOCK_MEM_FUN(MockCommunicator, shutdown);
             NAME_MOCK_MEM_FUN(MockCommunicator, set_receive_timeout);
@@ -136,7 +136,7 @@ class MockCommunicator : public MockClass<MockCommunicator> {
 
         ::mock_communicator::CommunicatorSendMessageMock send_message;
 
-        MockFun<Val<FInitCacheType>> pre_receive_f_init;
+        MockFun<Val<FInitCacheType>> pre_receive;
 
         ::mock_communicator::CommunicatorReceiveMessageMock receive_s_message;
 

--- a/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
@@ -18,8 +18,9 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
         MockTimelineManager(ReturnValue) {
             NAME_MOCK_MEM_FUN(MockTimelineManager, constructor);
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_send_message);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, check_pre_received_iteration_counts);
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive_s);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_s_message);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_s_message_mock);
             NAME_MOCK_MEM_FUN(MockTimelineManager, reset);
             NAME_MOCK_MEM_FUN(MockTimelineManager, start_reuse_iteration);
             NAME_MOCK_MEM_FUN(MockTimelineManager, get_state);
@@ -41,11 +42,22 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
             Val<IterationCount>, Val<std::string const &>,
             Val<Optional<int>>> check_send_message;
 
+        MockFun<
+            Val<IterationCount>,
+            Val<std::vector<IterationCount>>> check_pre_received_iteration_counts;
+
         MockFun<Void, Val<std::string const &>, Val<Optional<int>>> check_receive_s;
 
         MockFun<
-            Void, Val<std::string const &>, Val<Optional<int>>,
-            Val<IterationCount const &>> record_received_s_message;
+            Val<IterationCount const &>, Val<std::string const &>, Val<Optional<int>>,
+            Val<IterationCount const &>, Val<std::size_t>> record_received_s_message_mock;
+        
+        IterationCount const & record_received_s_message(
+                std::string const & port_name, Optional<int> slot,
+                IterationCount const & iteration, std::size_t num_repeat_filters = 0)
+        {
+            return record_received_s_message_mock(port_name, slot, iteration, num_repeat_filters);
+        }
 
         MockFun<Void> reset;
 

--- a/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
@@ -18,8 +18,8 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
         MockTimelineManager(ReturnValue) {
             NAME_MOCK_MEM_FUN(MockTimelineManager, constructor);
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_send_message);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_message);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive_s);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_s_message);
             NAME_MOCK_MEM_FUN(MockTimelineManager, reset);
             NAME_MOCK_MEM_FUN(MockTimelineManager, start_reuse_iteration);
             NAME_MOCK_MEM_FUN(MockTimelineManager, get_state);
@@ -41,11 +41,11 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
             Val<IterationCount>, Val<std::string const &>,
             Val<Optional<int>>> check_send_message;
 
-        MockFun<Void, Val<std::string const &>, Val<Optional<int>>> check_receive;
+        MockFun<Void, Val<std::string const &>, Val<Optional<int>>> check_receive_s;
 
         MockFun<
             Void, Val<std::string const &>, Val<Optional<int>>,
-            Val<IterationCount const &>> record_received_message;
+            Val<IterationCount const &>> record_received_s_message;
 
         MockFun<Void> reset;
 

--- a/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
+++ b/src/cpp/libmuscle/tests/mocks/mock_timeline_manager.hpp
@@ -18,7 +18,7 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
         MockTimelineManager(ReturnValue) {
             NAME_MOCK_MEM_FUN(MockTimelineManager, constructor);
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_send_message);
-            NAME_MOCK_MEM_FUN(MockTimelineManager, check_pre_received_iteration_counts);
+            NAME_MOCK_MEM_FUN(MockTimelineManager, record_pre_received_iteration_counts);
             NAME_MOCK_MEM_FUN(MockTimelineManager, check_receive_s);
             NAME_MOCK_MEM_FUN(MockTimelineManager, record_received_s_message_mock);
             NAME_MOCK_MEM_FUN(MockTimelineManager, reset);
@@ -44,7 +44,7 @@ class MockTimelineManager : public MockClass<MockTimelineManager> {
 
         MockFun<
             Val<IterationCount>,
-            Val<std::vector<IterationCount>>> check_pre_received_iteration_counts;
+            Val<std::vector<IterationCount>>> record_pre_received_iteration_counts;
 
         MockFun<Void, Val<std::string const &>, Val<Optional<int>>> check_receive_s;
 

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -86,25 +86,29 @@ struct libmuscle_communicator
             MockLogger, MockMMPClient, MockMPPClient, MockMPPServer, MockProfiler);
 
     MockProfiler profiler_;
-    MockPortManager port_manager_;
     MockMMPClient manager_;
 
     Communicator communicator_;
 
-    libmuscle_communicator()
+    libmuscle_communicator(bool settings_in_connected = false)
         : communicator_("component", {}, connected_port_manager_, profiler_, manager_)
     {
-        port_manager_.settings_in_connected.return_value = false;
+        connected_port_manager_.settings_in_connected.return_value = settings_in_connected;
         MockTimelineManager::return_value.start_reuse_iteration.return_value = Optional<IterationCount>();
+        MockTimelineManager::return_value.record_received_s_message_mock.return_value = IterationCount();
+        MockTimelineManager::return_value.check_pre_received_iteration_counts.side_effect = [](
+                auto iterations) -> auto { return iterations.at(0); };
     }
 };
 
 
 struct libmuscle_communicator2 : libmuscle_communicator {
     Communicator & connected_communicator_;
+    std::unique_ptr<PeerInfo> peer_info_;
 
-    libmuscle_communicator2()
-        : connected_communicator_(communicator_)
+    libmuscle_communicator2(bool settings_in_connected = false)
+        : libmuscle_communicator(settings_in_connected)
+        , connected_communicator_(communicator_)
     {
         std::vector<Conduit> conduits({
             Conduit("peer.out", "component.in"),
@@ -137,6 +141,11 @@ struct libmuscle_communicator2 : libmuscle_communicator {
         // signatures: mpp_client->receive.called_with(..., nullptr)
         connected_communicator_.set_receive_timeout(-1.0);
     }
+};
+
+struct libmuscle_communicator2_with_settings : libmuscle_communicator2 {
+    libmuscle_communicator2_with_settings()
+            : libmuscle_communicator2(true) {}
 };
 
 
@@ -173,8 +182,7 @@ TEST_F(libmuscle_communicator2, send_message) {
     ASSERT_EQ(overlay["s0"].as<int64_t>(), 0);
     ASSERT_EQ(overlay["s1"].as<std::string>(), "1");
     ASSERT_EQ(encoded_msg.data.as<std::string>(), "test");
-    ASSERT_TRUE(encoded_msg.iteration.is_set());
-    ASSERT_EQ(encoded_msg.iteration.get(), IterationCount({2, 0}));
+    ASSERT_EQ(encoded_msg.iteration, IterationCount({2, 0}));
 }
 
 TEST_F(libmuscle_communicator2, send_message_disconnected) {
@@ -248,10 +256,9 @@ TEST_F(libmuscle_communicator2, pre_receive) {
     ASSERT_EQ(cache.at("in").data(), Data("test"));
 }
 
-TEST_F(libmuscle_communicator2, pre_receive_f_init_with_settings) {
+TEST_F(libmuscle_communicator2_with_settings, pre_receive_f_init_with_settings) {
     MockMPPClient::return_value.receive.return_value = mock_mpp_receive(
         Settings({{"a", true}}), {});
-    connected_port_manager_.settings_in_connected.return_value = true;
 
     auto cache = connected_communicator_.pre_receive();
     ASSERT_EQ(cache.size(), 2);
@@ -270,7 +277,7 @@ TEST_F(libmuscle_communicator2, pre_receive_vector) {
     MockMPPClient::return_value.receive.return_value = mock_mpp_receive(
         Data("test"), {});
 
-    mock_ports_["in"] = std::make_unique<Port>("in", Operator::F_INIT, Timeline(""), true, true, 0, std::vector<int>());
+    mock_ports_["in"]->is_resizable_ = true;
     mock_ports_["in"]->set_length(4);
 
     auto cache = connected_communicator_.pre_receive();
@@ -305,26 +312,25 @@ TEST_F(libmuscle_communicator2, pre_receive_broadcast_milestone) {
     }
 }
 
-TEST_F(libmuscle_communicator2, pre_receive_different_milestones) {
-    connected_port_manager_.settings_in_connected.return_value = true;
+TEST_F(libmuscle_communicator2_with_settings, pre_receive_different_milestones) {
     // One of these is received on "in", the other on "muscle_settings_in"
     std::vector<std::tuple<std::vector<char>, ProfileData>> return_values =  {
         mock_mpp_receive(Milestone(IterationCount({1})), {1}),
-        mock_mpp_receive(Data("test data"), {2, 0}),
+        mock_mpp_receive(Milestone(IterationCount({2})), {2}),
     };
     auto next_message = return_values.begin();
     MockMPPClient::return_value.receive.side_effect = [&](Reference const &, TimeoutHandler *){
         return *next_message++;
     };
 
-    ASSERT_THROW(connected_communicator_.pre_receive(), std::runtime_error);
+    ASSERT_THROW(connected_communicator_.pre_receive(), std::logic_error);
 }
 
-TEST_F(libmuscle_communicator2, pre_receive_some_port_close) {
-    connected_port_manager_.settings_in_connected.return_value = true;
+TEST_F(libmuscle_communicator2_with_settings, pre_receive_some_port_close) {
     // One of these is received on "in", the other on "muscle_settings_in"
     std::vector<std::tuple<std::vector<char>, ProfileData>> return_values =  {
         mock_mpp_receive(Milestone(IterationCount({1})), {1}),
+        mock_mpp_receive(Milestone(IterationCount({})), {}),
         mock_mpp_receive(Milestone(IterationCount({})), {}),
     };
     auto next_message = return_values.begin();
@@ -332,7 +338,7 @@ TEST_F(libmuscle_communicator2, pre_receive_some_port_close) {
         return *next_message++;
     };
 
-    ASSERT_THROW(connected_communicator_.pre_receive(), std::runtime_error);
+    ASSERT_THROW(connected_communicator_.pre_receive(), PortClosed);
 }
 
 TEST_F(libmuscle_communicator2, port_count_validation) {

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -239,11 +239,11 @@ TEST_F(libmuscle_communicator2, receive_root_milestone_vector) {
     ASSERT_FALSE(mock_ports_["in_v"]->is_open(5));
 }
 
-TEST_F(libmuscle_communicator2, pre_receive_f_init) {
+TEST_F(libmuscle_communicator2, pre_receive) {
     MockMPPClient::return_value.receive.return_value = mock_mpp_receive(
         Data("test"), {});
 
-    auto cache = connected_communicator_.pre_receive_f_init();
+    auto cache = connected_communicator_.pre_receive();
     ASSERT_EQ(cache.size(), 1);
     ASSERT_EQ(cache.at("in").data(), Data("test"));
 }
@@ -253,7 +253,7 @@ TEST_F(libmuscle_communicator2, pre_receive_f_init_with_settings) {
         Settings({{"a", true}}), {});
     connected_port_manager_.settings_in_connected.return_value = true;
 
-    auto cache = connected_communicator_.pre_receive_f_init();
+    auto cache = connected_communicator_.pre_receive();
     ASSERT_EQ(cache.size(), 2);
     ASSERT_EQ(cache.at("in").data(), Settings({{"a", true}}));
     ASSERT_EQ(cache.at("muscle_settings_in").data(), Settings({{"a", true}}));
@@ -263,7 +263,7 @@ TEST_F(libmuscle_communicator2, pre_receive_close_port) {
     MockMPPClient::return_value.receive.return_value = mock_mpp_receive(
         Milestone({IterationCount({})}), {});
 
-    ASSERT_THROW(connected_communicator_.pre_receive_f_init(), PortClosed);
+    ASSERT_THROW(connected_communicator_.pre_receive(), PortClosed);
 }
 
 TEST_F(libmuscle_communicator2, pre_receive_vector) {
@@ -273,7 +273,7 @@ TEST_F(libmuscle_communicator2, pre_receive_vector) {
     mock_ports_["in"] = std::make_unique<Port>("in", Operator::F_INIT, Timeline(""), true, true, 0, std::vector<int>());
     mock_ports_["in"]->set_length(4);
 
-    auto cache = connected_communicator_.pre_receive_f_init();
+    auto cache = connected_communicator_.pre_receive();
     ASSERT_EQ(cache.size(), 4);
     for (int slot = 0; slot < 4; ++slot) {
         ASSERT_EQ(cache.count(Reference("in") + slot), 1);
@@ -290,7 +290,7 @@ TEST_F(libmuscle_communicator2, pre_receive_broadcast_milestone) {
         return *next_message++;
     };
 
-    auto cache = connected_communicator_.pre_receive_f_init();
+    auto cache = connected_communicator_.pre_receive();
     ASSERT_EQ(cache.size(), 1);
     ASSERT_EQ(cache.at("in").data(), Data("test data"));
     // Expect a milestone broadcasted to all O_I and O_F ports
@@ -317,7 +317,7 @@ TEST_F(libmuscle_communicator2, pre_receive_different_milestones) {
         return *next_message++;
     };
 
-    ASSERT_THROW(connected_communicator_.pre_receive_f_init(), std::runtime_error);
+    ASSERT_THROW(connected_communicator_.pre_receive(), std::runtime_error);
 }
 
 TEST_F(libmuscle_communicator2, pre_receive_some_port_close) {
@@ -332,7 +332,7 @@ TEST_F(libmuscle_communicator2, pre_receive_some_port_close) {
         return *next_message++;
     };
 
-    ASSERT_THROW(connected_communicator_.pre_receive_f_init(), std::runtime_error);
+    ASSERT_THROW(connected_communicator_.pre_receive(), std::runtime_error);
 }
 
 TEST_F(libmuscle_communicator2, port_count_validation) {

--- a/src/cpp/libmuscle/tests/test_communicator.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator.cpp
@@ -96,7 +96,7 @@ struct libmuscle_communicator
         connected_port_manager_.settings_in_connected.return_value = settings_in_connected;
         MockTimelineManager::return_value.start_reuse_iteration.return_value = Optional<IterationCount>();
         MockTimelineManager::return_value.record_received_s_message_mock.return_value = IterationCount();
-        MockTimelineManager::return_value.check_pre_received_iteration_counts.side_effect = [](
+        MockTimelineManager::return_value.record_pre_received_iteration_counts.side_effect = [](
                 auto iterations) -> auto { return iterations.at(0); };
     }
 };

--- a/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
@@ -187,7 +187,6 @@ TEST_P(libmuscle_repeater_communicator, repeater_filters) {
     ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({0, 0}));
     ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({0}));
     ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
-    communicator_.finish_reuse_iteration();
 
     cache = communicator_.pre_receive();
     ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({0, 1}));
@@ -198,7 +197,6 @@ TEST_P(libmuscle_repeater_communicator, repeater_filters) {
         ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({0}));
         ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
     }
-    communicator_.finish_reuse_iteration();
 
     cache = communicator_.pre_receive();
     ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 0}));
@@ -208,7 +206,6 @@ TEST_P(libmuscle_repeater_communicator, repeater_filters) {
     } else {
         ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
     }
-    communicator_.finish_reuse_iteration();
 
     ASSERT_THROW(communicator_.pre_receive(), PortClosed);
 }
@@ -254,7 +251,6 @@ TEST_P(libmuscle_repeater_communicator, repeater_filters_discard_messages) {
     ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 0, 0}));
     ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 0}));
     ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
-    communicator_.finish_reuse_iteration();
 
     cache = communicator_.pre_receive();
     ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 1, 0}));
@@ -264,7 +260,6 @@ TEST_P(libmuscle_repeater_communicator, repeater_filters_discard_messages) {
     } else {
         ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
     }
-    communicator_.finish_reuse_iteration();
 
     cache = communicator_.pre_receive();
     ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 1, 1}));
@@ -275,7 +270,6 @@ TEST_P(libmuscle_repeater_communicator, repeater_filters_discard_messages) {
         ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 1}));
         ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
     }
-    communicator_.finish_reuse_iteration();
 
     ASSERT_THROW(communicator_.pre_receive(), PortClosed);
 }

--- a/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
@@ -1,0 +1,285 @@
+// Inject mocks
+#define LIBMUSCLE_MOCK_LOGGER <mocks/mock_logger.hpp>
+#define LIBMUSCLE_MOCK_MMP_CLIENT <mocks/mock_mmp_client.hpp>
+#define LIBMUSCLE_MOCK_MPP_CLIENT <mocks/mock_mpp_client.hpp>
+#define LIBMUSCLE_MOCK_MPP_SERVER <mocks/mock_mpp_server.hpp>
+#define LIBMUSCLE_MOCK_PROFILER <mocks/mock_profiler.hpp>
+
+// into the real implementation under test
+#include <ymmsl/ymmsl.hpp>
+
+#include <libmuscle/data.cpp>   // needs to be above milestone.cpp
+#include <libmuscle/communicator.cpp>
+#include <libmuscle/endpoint.cpp>
+#include <libmuscle/mark.cpp>
+#include <libmuscle/mcp/data_pack.cpp>
+#include <libmuscle/mpp_message.cpp>
+#include <libmuscle/mcp/tcp_util.cpp>
+#include <libmuscle/mcp/transport_client.cpp>
+#include <libmuscle/message.cpp>
+#include <libmuscle/milestone.cpp>
+#include <libmuscle/peer_info.cpp>
+#include <libmuscle/port.cpp>
+#include <libmuscle/profiling.cpp>
+#include <libmuscle/receive_timeout_handler.cpp>
+#include <libmuscle/timeline_manager.cpp>
+#include <libmuscle/timestamp.cpp>
+#include <libmuscle/util.cpp>
+
+// Test code dependencies
+#include <memory>
+#include <stdexcept>
+#include <gtest/gtest.h>
+#include <libmuscle/communicator.hpp>
+#include <libmuscle/namespace.hpp>
+#include <mocks/mock_mmp_client.hpp>
+#include <mocks/mock_mpp_client.hpp>
+#include <mocks/mock_mpp_server.hpp>
+#include <mocks/mock_logger.hpp>
+#include <mocks/mock_profiler.hpp>
+
+
+int main(int argc, char *argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+
+using libmuscle::_MUSCLE_IMPL_NS::encode_iteration;
+using libmuscle::_MUSCLE_IMPL_NS::Communicator;
+using libmuscle::_MUSCLE_IMPL_NS::DataConstRef;
+using libmuscle::_MUSCLE_IMPL_NS::IterationCount;
+using libmuscle::_MUSCLE_IMPL_NS::MPPMessage;
+using libmuscle::_MUSCLE_IMPL_NS::MockLogger;
+using libmuscle::_MUSCLE_IMPL_NS::MockProfiler;
+using libmuscle::_MUSCLE_IMPL_NS::MockMMPClient;
+using libmuscle::_MUSCLE_IMPL_NS::MockMPPClient;
+using libmuscle::_MUSCLE_IMPL_NS::MockMPPServer;
+using libmuscle::_MUSCLE_IMPL_NS::PeerInfo;
+using libmuscle::_MUSCLE_IMPL_NS::PortClosed;
+using libmuscle::_MUSCLE_IMPL_NS::PortManager;
+using libmuscle::_MUSCLE_IMPL_NS::mcp::ProfileData;
+using libmuscle::_MUSCLE_IMPL_NS::mcp::TimeoutHandler;
+
+using ymmsl::Conduit;
+using ymmsl::ConduitFilter;
+using ymmsl::Operator;
+using ymmsl::Port;
+
+struct libmuscle_repeater_communicator
+    : ::testing::TestWithParam<std::string>
+{
+    RESET_MOCKS(MockLogger, MockMMPClient, MockMPPClient, MockMPPServer, MockProfiler);
+    
+    MockProfiler profiler_;
+    MockMMPClient manager_;
+
+    PortManager port_manager_;
+    Communicator communicator_;
+
+    libmuscle_repeater_communicator()
+        : port_manager_({}, {})
+        , communicator_("component", {}, port_manager_, profiler_, manager_)
+    {
+        std::string repeat_filter = GetParam();
+        PeerInfo peer_info(
+            "component",
+            {},
+            {
+                Conduit("parent1.out", "component.unfiltered"),
+                Conduit("parent2.out", "component.repeated", repeat_filter),
+                Conduit("parent2.out", "component.twicerepeated", repeat_filter + " " + repeat_filter)
+            },
+            {{"parent1", {}}, {"parent2", {}}, {"parent3", {}}},
+            {{"parent1", {}}, {"parent2", {}}, {"parent3", {}}},
+            {
+                Port("unfiltered", Operator::F_INIT),
+                Port("repeated", Operator::F_INIT),
+                Port("twicerepeated", Operator::F_INIT)
+            }
+        );
+        port_manager_.connect_ports(peer_info);
+        communicator_.set_peer_info(peer_info);
+    }
+
+    void TearDown() override {
+        communicator_.shutdown();
+    }
+};
+
+class IterationOrMilestone {
+    public:
+        IterationCount iteration;
+        bool is_milestone;
+};
+
+IterationOrMilestone M(IterationCount iteration) {
+    return {iteration, true};
+}
+
+IterationOrMilestone I(IterationCount iteration) {
+    return {iteration, false};
+}
+
+
+
+/** Helper method to mock MPPClient.receiev ,so it gives data with correct message
+ * numbers and iteration counts.
+ */
+void mock_receive_messages(
+    std::unordered_map<Reference, std::vector<IterationOrMilestone>> const & data)
+{
+    std::unordered_map<Reference, int> idx_per_port;
+    std::unordered_map<Reference, int> num_per_port;
+
+    for (auto & item : data) {
+        idx_per_port.emplace(item.first, 0);
+        num_per_port.emplace(item.first, 0);
+    }
+
+    // Capture a copy of the data, the local variables go out-of-scope at the end of
+    // this method:
+    MockMPPClient::return_value.receive.side_effect = [data, idx_per_port, num_per_port](
+            Reference ref, TimeoutHandler *handler
+        ) mutable -> std::tuple<std::vector<char>, ProfileData>
+    {
+        int & idx = idx_per_port.at(ref);
+        int & num = num_per_port.at(ref);
+        auto iteration_or_milestone = data.at(ref).at(idx);
+        auto & iteration = iteration_or_milestone.iteration;
+
+        DataConstRef dcr = iteration_or_milestone.is_milestone ? 
+            DataConstRef(Milestone(iteration)) : DataConstRef(encode_iteration(iteration));
+
+        MPPMessage msg("snd", "recv", {}, 0.0, {}, Settings(), num, dcr, iteration);
+        auto encoded = msg.encoded();
+
+        ++idx;
+        if (!iteration_or_milestone.is_milestone) ++num;
+        return {encoded, ProfileData()};
+    };
+}
+
+
+TEST_P(libmuscle_repeater_communicator, repeater_filters) {
+    mock_receive_messages({
+        {"component.twicerepeated", {
+            I({}), M({})
+        }},
+        {"component.repeated", {
+            I({0}), I({1}), I({2}), M({})
+        }},
+        {"component.unfiltered", {
+            I({0, 0}),
+            I({0, 1}),
+            M({0}),
+            // parent is allowed to send 0 messages on its O_I port in an iteration
+            M({1}),
+            I({2, 0}),
+            M({2}),
+            M({})
+        }}
+    });
+
+    bool is_padded = GetParam() == "pad";
+
+    auto cache = communicator_.pre_receive();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({0, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({0}));
+    ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({0, 1}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("repeated").data().is_nil());
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({0}));
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    ASSERT_THROW(communicator_.pre_receive(), PortClosed);
+}
+
+TEST_P(libmuscle_repeater_communicator, repeater_filters_discard_messages) {
+    mock_receive_messages({
+        {"component.twicerepeated", {
+            I({0}), I({1}), I({2}), M({})
+        }},
+        {"component.repeated", {
+            // Grandparent doesn't send on O_I in its first iteration
+            M({0}),
+            I({1, 0}),
+            I({1, 1}),
+            I({1, 2}),
+            M({1}),
+            I({2, 0}),
+            I({2, 1}),
+            M({2}),
+            M({})
+        }},
+        {"component.unfiltered", {
+            M({0}),
+            // parent doesn't send messages on O_I in the first couple of iterations
+            // component will need to discard the corresponding messages from the grandparent
+            M({1, 0}),
+            M({1, 1}),
+            M({1, 2}),
+            M({1}),
+            I({2, 0, 0}),
+            M({2, 0}),
+            I({2, 1, 0}),
+            I({2, 1, 1}),
+            M({2, 1}),
+            M({2}),
+            M({})
+        }}
+    });
+
+    bool is_padded = GetParam() == "pad";
+
+    auto cache = communicator_.pre_receive();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 0, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 1, 0}));
+    ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 1}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    cache = communicator_.pre_receive();
+    ASSERT_EQ(decode_iteration(cache.at("unfiltered").data()).get(), IterationCount({2, 1, 1}));
+    if (is_padded) {
+        ASSERT_TRUE(cache.at("repeated").data().is_nil());
+        ASSERT_TRUE(cache.at("twicerepeated").data().is_nil());
+    } else {
+        ASSERT_EQ(decode_iteration(cache.at("repeated").data()).get(), IterationCount({2, 1}));
+        ASSERT_EQ(decode_iteration(cache.at("twicerepeated").data()).get(), IterationCount({2}));
+    }
+    communicator_.finish_reuse_iteration();
+
+    ASSERT_THROW(communicator_.pre_receive(), PortClosed);
+}
+
+
+INSTANTIATE_TEST_SUITE_P(
+    repeated, libmuscle_repeater_communicator, ::testing::Values("repeat", "pad"));

--- a/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
+++ b/src/cpp/libmuscle/tests/test_communicator_conduit_filters.cpp
@@ -123,7 +123,7 @@ IterationOrMilestone I(IterationCount iteration) {
 
 
 
-/** Helper method to mock MPPClient.receiev ,so it gives data with correct message
+/** Helper method to mock MPPClient.receive ,so it gives data with correct message
  * numbers and iteration counts.
  */
 void mock_receive_messages(

--- a/src/cpp/libmuscle/tests/test_instance.cpp
+++ b/src/cpp/libmuscle/tests/test_instance.cpp
@@ -186,7 +186,7 @@ struct libmuscle_instance : ConnectedPortManagerHelper {
         , snapshot_manager_(*instance_.impl_()->snapshot_manager_)
         , trigger_manager_(*instance_.impl_()->trigger_manager_)
     {
-        communicator_.pre_receive_f_init.return_value = MockCommunicator::FInitCacheType();
+        communicator_.pre_receive.return_value = MockCommunicator::FInitCacheType();
     }
 };
 
@@ -214,7 +214,7 @@ struct libmuscle_instance_dont_apply_overlay : ConnectedPortManagerHelper {
         , snapshot_manager_(*instance_dont_apply_overlay_.impl_()->snapshot_manager_)
         , trigger_manager_(*instance_dont_apply_overlay_.impl_()->trigger_manager_)
     {
-        communicator_.pre_receive_f_init.return_value = MockCommunicator::FInitCacheType();
+        communicator_.pre_receive.return_value = MockCommunicator::FInitCacheType();
     }
 };
 
@@ -418,7 +418,7 @@ TEST_F(libmuscle_instance, reuse_set_overlay) {
     Message mock_msg(
             0.0, {}, Settings({{"s1", 1}, {"s2", 2}}), Settings({{"s0", 0}}));
     MockCommunicator::FInitCacheType cache = {{"muscle_settings_in", mock_msg}};
-    communicator_.pre_receive_f_init.return_value = cache;
+    communicator_.pre_receive.return_value = cache;
 
     instance_.reuse_instance();
 
@@ -429,11 +429,11 @@ TEST_F(libmuscle_instance, reuse_set_overlay) {
 
 TEST_F(libmuscle_instance, reuse_closed_port) {
     ASSERT_TRUE(instance_.reuse_instance());  // First iteration: should always reuse
-    communicator_.pre_receive_f_init.side_effect = [](
+    communicator_.pre_receive.side_effect = [](
         ) -> MockCommunicator::FInitCacheType {
             throw PortClosed();
         };
-    ASSERT_THROW(communicator_.pre_receive_f_init(), PortClosed);
+    ASSERT_THROW(communicator_.pre_receive(), PortClosed);
     ASSERT_FALSE(instance_.reuse_instance());
 }
 
@@ -448,7 +448,7 @@ TEST_F(libmuscle_instance, reuse_always_prereceives) {
     port_manager_.has_f_init_connections.return_value = false;
 
     instance_.reuse_instance();
-    ASSERT_TRUE(communicator_.pre_receive_f_init.called_once());
+    ASSERT_TRUE(communicator_.pre_receive.called_once());
 }
 
 TEST_F(libmuscle_instance, send_message) {
@@ -502,7 +502,7 @@ TEST_F(libmuscle_instance, receive_slot_on_scalar_port) {
 TEST_F(libmuscle_instance, receive_f_init) {
     Message mock_msg(0.0, Settings());
     MockCommunicator::FInitCacheType cache = {{"in", mock_msg}};
-    communicator_.pre_receive_f_init.return_value = cache;
+    communicator_.pre_receive.return_value = cache;
 
     instance_.reuse_instance();
 
@@ -536,7 +536,7 @@ TEST_F(libmuscle_instance, receive_inconsistent_settings) {
     MockCommunicator::FInitCacheType cache = {
         {"muscle_settings_in", Message(0.0, Settings({{"s1", 1}}), Settings())},
         {"in", Message(0.0, DataConstRef(), Settings({{"s0", 0}}))}};
-    communicator_.pre_receive_f_init.return_value = cache;
+    communicator_.pre_receive.return_value = cache;
     port_manager_.settings_in_connected.return_value = true;
 
     ASSERT_THROW(instance_.reuse_instance(), std::logic_error);
@@ -546,7 +546,7 @@ TEST_F(libmuscle_instance_dont_apply_overlay, receive_with_settings) {
     Message mock_msg(0.0);
     mock_msg.settings_ = Settings({{"s0", 0}, {"s1", 1}});
     MockCommunicator::FInitCacheType cache = {{"in", mock_msg}};
-    communicator_.pre_receive_f_init.return_value = cache;
+    communicator_.pre_receive.return_value = cache;
 
     instance_dont_apply_overlay_.reuse_instance();
     auto msg = instance_dont_apply_overlay_.receive("in");

--- a/src/cpp/libmuscle/tests/test_mpp_message.cpp
+++ b/src/cpp/libmuscle/tests/test_mpp_message.cpp
@@ -106,5 +106,5 @@ TEST(test_mcp_message, iteration_roundtrip) {
             );
 
     auto m_out = MPPMessage::from_bytes(m.encoded());
-    ASSERT_EQ(m_out.iteration.get(), IterationCount({0, 2}));
+    ASSERT_EQ(m_out.iteration, IterationCount({0, 2}));
 }

--- a/src/cpp/libmuscle/tests/test_snapshot.cpp
+++ b/src/cpp/libmuscle/tests/test_snapshot.cpp
@@ -71,8 +71,6 @@ TEST_F(libmuscle_snapshot, test_snapshot) {
               snapshot2.communicator_state.timeline_state.iteration.get());
     ASSERT_EQ(snapshot_.communicator_state.timeline_state.send_participated,
               snapshot2.communicator_state.timeline_state.send_participated);
-    ASSERT_EQ(snapshot_.communicator_state.timeline_state.receive_participated,
-              snapshot2.communicator_state.timeline_state.receive_participated);
     ASSERT_EQ(snapshot_.communicator_state.timeline_state.subtimeline_states.size(),
               snapshot2.communicator_state.timeline_state.subtimeline_states.size());
 }

--- a/src/cpp/libmuscle/tests/test_snapshot_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_snapshot_manager.cpp
@@ -129,7 +129,6 @@ TEST_F(libmuscle_snapshot_manager, test_save_load_snapshot) {
     ASSERT_EQ(restored_state.timeline_state.iteration.is_set(), communicator_state_.timeline_state.iteration.is_set());
     ASSERT_EQ(restored_state.timeline_state.iteration.get(), communicator_state_.timeline_state.iteration.get());
     ASSERT_EQ(restored_state.timeline_state.send_participated, communicator_state_.timeline_state.send_participated);
-    ASSERT_EQ(restored_state.timeline_state.receive_participated, communicator_state_.timeline_state.receive_participated);
     ASSERT_EQ(
             restored_state.timeline_state.subtimeline_states.size(),
             communicator_state_.timeline_state.subtimeline_states.size());

--- a/src/cpp/libmuscle/tests/test_timeline_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_timeline_manager.cpp
@@ -20,6 +20,8 @@ int main(int argc, char *argv[]) {
 }
 
 
+using libmuscle::_MUSCLE_IMPL_NS::get_most_nested_iteration;
+using libmuscle::_MUSCLE_IMPL_NS::is_subiteration;
 using libmuscle::_MUSCLE_IMPL_NS::AlreadyParticipated;
 using libmuscle::_MUSCLE_IMPL_NS::ExpectedActions;
 using libmuscle::_MUSCLE_IMPL_NS::IterationCount;
@@ -155,38 +157,47 @@ struct libmuscle_vector_timeline_manager : libmuscle_timeline_manager {
                 PortsDescription{{Operator::O_F, {"out_v[]"}}}, {}, {{"out_v", {3}}});
         tm_ = std::make_unique<TimelineManager>(*port_manager_);
         tm_->start_reuse_iteration();
+        EXPECT_EQ(tm_->check_pre_received_iteration_counts({}), IterationCount());
     }
 };
 
 
+// Test support methods
+
+TEST(libmuscle_timeline, is_subiteration) {
+    ASSERT_TRUE(is_subiteration({}, {}));
+    ASSERT_TRUE(is_subiteration({1, 2}, {1, 2}));
+    ASSERT_TRUE(is_subiteration({1, 2}, {1}));
+    ASSERT_TRUE(is_subiteration({1, 2}, {}));
+    ASSERT_FALSE(is_subiteration({1, 2}, {1, 2, 3}));
+    ASSERT_FALSE(is_subiteration({1, 2}, {1, 1}));
+    ASSERT_FALSE(is_subiteration({}, {1, 1}));
+}
+
+TEST(libmuscle_timeline, get_most_nested_iteration) {
+    ASSERT_EQ(
+        get_most_nested_iteration({{1, 2, 3}, {1}, {1, 2, 3, 4}}),
+        IterationCount({1, 2, 3, 4}));
+    ASSERT_THROW(get_most_nested_iteration({}), std::logic_error);
+    ASSERT_THROW(get_most_nested_iteration({{1}, {2}}), std::logic_error);
+}
+
 // -- Main timeline: F_INIT / O_F --
-
-TEST_F(libmuscle_full_timeline_manager, f_init_receive_allowed_once) {
-    check_received(*tm_, "in_f", {}, {});
-    ASSERT_THROW(tm_->check_receive_s("in_f"), AlreadyParticipated);
-}
-
-TEST_F(libmuscle_full_timeline_manager, settings_in_receive_allowed_once) {
-    check_received(*tm_, "muscle_settings_in", {}, {});
-    ASSERT_THROW(tm_->check_receive_s("muscle_settings_in"), AlreadyParticipated);
-}
 
 TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_adopts_iteration) {
     IterationCount first = {3};
-    check_received(*tm_, "in_f", {}, first);
-    check_received(*tm_, "muscle_settings_in", {}, first);
+    tm_->check_pre_received_iteration_counts({first, first});
 
     ASSERT_EQ(tm_->check_send_message("out_f"), first);
 }
 
 TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_raises_on_mismatch) {
-    check_received(*tm_, "in_f", {}, {3});
-    ASSERT_THROW(
-            tm_->record_received_s_message("muscle_settings_in", {}, {4}), MessageOutOfSync);
+    ASSERT_THROW(tm_->check_pre_received_iteration_counts({{3}, {4}}), std::logic_error);
 }
 
 TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_connections) {
     create(PortsDescription{{Operator::O_F, {"out_f"}}});
+    tm_->check_pre_received_iteration_counts({});
 
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount());
@@ -194,8 +205,7 @@ TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_conne
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_f_blocked_while_subtimeline_incomplete) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     tm_->check_send_message("out_a1");  // starts :A1, but doesn't complete it
 
@@ -203,8 +213,7 @@ TEST_F(libmuscle_full_timeline_manager, o_f_blocked_while_subtimeline_incomplete
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_f_send_records_iteration_and_participation) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount({3}));
@@ -215,16 +224,14 @@ TEST_F(libmuscle_full_timeline_manager, o_f_send_records_iteration_and_participa
 // -- Sub-timeline O_I/S leadership races --
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_first_send_starts_subtimeline_at_zero) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     IterationCount iteration = tm_->check_send_message("out_a1");
     ASSERT_EQ(iteration, IterationCount({3, 0}));
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_second_send_blocked_until_all_s_received) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
@@ -234,8 +241,7 @@ TEST_F(libmuscle_full_timeline_manager, o_i_leads_second_send_blocked_until_all_
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_advances_once_all_s_received) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     IterationCount first = tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, first);
@@ -247,8 +253,7 @@ TEST_F(libmuscle_full_timeline_manager, o_i_leads_advances_once_all_s_received) 
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_first_receive_starts_subtimeline) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     check_received(*tm_, "in_a1", {}, {7});
     // second receive on the same port before O_I sends anything is blocked
@@ -256,8 +261,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_first_receive_starts_subtimeline
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     check_received(*tm_, "in_a1", {}, {7});
     // in_a1_2 hasn't received yet, so S hasn't fully led :A1 yet
@@ -266,8 +270,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_iteration) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     check_received(*tm_, "in_a1", {}, {7});
     check_received(*tm_, "in_a1_2", {}, {7});
@@ -283,8 +286,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_itera
 }
 
 TEST_F(libmuscle_full_timeline_manager, many_o_i_one_s_mirror_scenario) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
 
     // :A2 has two O_I ports (out_a2, out_a2_2) and one S port (in_a2)
     tm_->check_send_message("out_a2");
@@ -301,31 +303,27 @@ TEST_F(libmuscle_full_timeline_manager, many_o_i_one_s_mirror_scenario) {
 // -- Reuse loop completion / reset --
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_raises_when_incomplete) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
     // out_f never sent
 
     ASSERT_THROW(tm_->start_reuse_iteration(), ReuseLoopIncomplete);
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_resets_when_complete) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_f");
 
     tm_->start_reuse_iteration();
 
     // fully reset: the same sequence works again from scratch
-    check_received(*tm_, "in_f", {}, {4});
-    check_received(*tm_, "muscle_settings_in", {}, {4});
+    tm_->check_pre_received_iteration_counts({{4}, {4}});
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount({4}));
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeline_unused) {
     // a sub-timeline never touched this iteration doesn't block completion
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_f");
 
     ASSERT_NO_THROW(tm_->start_reuse_iteration());
@@ -335,8 +333,7 @@ TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeli
 // -- Snapshot state round-trip --
 
 TEST_F(libmuscle_full_timeline_manager, get_state_and_restore_state_round_trip) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
     // in_a1_2 not yet received, so :A1 is incomplete, and out_f not yet sent
@@ -350,14 +347,12 @@ TEST_F(libmuscle_full_timeline_manager, get_state_and_restore_state_round_trip) 
     ASSERT_EQ(state.iteration.is_set(), restored_state.iteration.is_set());
     ASSERT_EQ(state.iteration.get(), restored_state.iteration.get());
     ASSERT_EQ(state.send_participated, restored_state.send_participated);
-    ASSERT_EQ(state.receive_participated, restored_state.receive_participated);
     ASSERT_EQ(
             state.subtimeline_states.size(), restored_state.subtimeline_states.size());
 }
 
 TEST_F(libmuscle_full_timeline_manager, state_data_round_trip_through_msgpack_shape) {
-    check_received(*tm_, "in_f", {}, {3});
-    check_received(*tm_, "muscle_settings_in", {}, {3});
+    tm_->check_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
 
@@ -368,7 +363,6 @@ TEST_F(libmuscle_full_timeline_manager, state_data_round_trip_through_msgpack_sh
     ASSERT_EQ(state.iteration.is_set(), round_tripped.iteration.is_set());
     ASSERT_EQ(state.iteration.get(), round_tripped.iteration.get());
     ASSERT_EQ(state.send_participated, round_tripped.send_participated);
-    ASSERT_EQ(state.receive_participated, round_tripped.receive_participated);
     ASSERT_EQ(
             state.subtimeline_states.size(), round_tripped.subtimeline_states.size());
 }

--- a/src/cpp/libmuscle/tests/test_timeline_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_timeline_manager.cpp
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
 
 
 using libmuscle::_MUSCLE_IMPL_NS::get_most_nested_iteration;
-using libmuscle::_MUSCLE_IMPL_NS::is_subiteration;
+using libmuscle::_MUSCLE_IMPL_NS::is_subiteration_or_equal;
 using libmuscle::_MUSCLE_IMPL_NS::AlreadyParticipated;
 using libmuscle::_MUSCLE_IMPL_NS::ExpectedActions;
 using libmuscle::_MUSCLE_IMPL_NS::IterationCount;
@@ -164,14 +164,14 @@ struct libmuscle_vector_timeline_manager : libmuscle_timeline_manager {
 
 // Test support methods
 
-TEST(libmuscle_timeline, is_subiteration) {
-    ASSERT_TRUE(is_subiteration({}, {}));
-    ASSERT_TRUE(is_subiteration({1, 2}, {1, 2}));
-    ASSERT_TRUE(is_subiteration({1, 2}, {1}));
-    ASSERT_TRUE(is_subiteration({1, 2}, {}));
-    ASSERT_FALSE(is_subiteration({1, 2}, {1, 2, 3}));
-    ASSERT_FALSE(is_subiteration({1, 2}, {1, 1}));
-    ASSERT_FALSE(is_subiteration({}, {1, 1}));
+TEST(libmuscle_timeline, is_subiteration_or_equal) {
+    ASSERT_TRUE(is_subiteration_or_equal({}, {}));
+    ASSERT_TRUE(is_subiteration_or_equal({1, 2}, {1, 2}));
+    ASSERT_TRUE(is_subiteration_or_equal({1, 2}, {1}));
+    ASSERT_TRUE(is_subiteration_or_equal({1, 2}, {}));
+    ASSERT_FALSE(is_subiteration_or_equal({1, 2}, {1, 2, 3}));
+    ASSERT_FALSE(is_subiteration_or_equal({1, 2}, {1, 1}));
+    ASSERT_FALSE(is_subiteration_or_equal({}, {1, 1}));
 }
 
 TEST(libmuscle_timeline, get_most_nested_iteration) {

--- a/src/cpp/libmuscle/tests/test_timeline_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_timeline_manager.cpp
@@ -99,12 +99,12 @@ std::unique_ptr<PortManager> make_port_manager(
     return port_manager;
 }
 
-/* check_receive + record_received_message, as Communicator::receive_message does. */
+/* check_receive_s + record_received_message, as Communicator::receive_message does. */
 void check_received(
         TimelineManager & tm, std::string const & port_name, Optional<int> slot,
         IterationCount const & iteration) {
-    tm.check_receive(port_name, slot);
-    tm.record_received_message(port_name, slot, iteration);
+    tm.check_receive_s(port_name, slot);
+    tm.record_received_s_message(port_name, slot, iteration);
 }
 
 }   // anonymous namespace
@@ -163,12 +163,12 @@ struct libmuscle_vector_timeline_manager : libmuscle_timeline_manager {
 
 TEST_F(libmuscle_full_timeline_manager, f_init_receive_allowed_once) {
     check_received(*tm_, "in_f", {}, {});
-    ASSERT_THROW(tm_->check_receive("in_f"), AlreadyParticipated);
+    ASSERT_THROW(tm_->check_receive_s("in_f"), AlreadyParticipated);
 }
 
 TEST_F(libmuscle_full_timeline_manager, settings_in_receive_allowed_once) {
     check_received(*tm_, "muscle_settings_in", {}, {});
-    ASSERT_THROW(tm_->check_receive("muscle_settings_in"), AlreadyParticipated);
+    ASSERT_THROW(tm_->check_receive_s("muscle_settings_in"), AlreadyParticipated);
 }
 
 TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_adopts_iteration) {
@@ -182,7 +182,7 @@ TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_adopts_it
 TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_raises_on_mismatch) {
     check_received(*tm_, "in_f", {}, {3});
     ASSERT_THROW(
-            tm_->record_received_message("muscle_settings_in", {}, {4}), MessageOutOfSync);
+            tm_->record_received_s_message("muscle_settings_in", {}, {4}), MessageOutOfSync);
 }
 
 TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_connections) {
@@ -252,7 +252,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_first_receive_starts_subtimeline
 
     check_received(*tm_, "in_a1", {}, {7});
     // second receive on the same port before O_I sends anything is blocked
-    ASSERT_THROW(tm_->check_receive("in_a1"), PortBlocked);
+    ASSERT_THROW(tm_->check_receive_s("in_a1"), PortBlocked);
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received) {
@@ -275,8 +275,8 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_itera
     tm_->check_send_message("out_a1");
 
     // an equal-or-earlier iteration on the already-participated S port is out of sync
-    tm_->check_receive("in_a1");
-    ASSERT_THROW(tm_->record_received_message("in_a1", {}, {7}), MessageOutOfSync);
+    tm_->check_receive_s("in_a1");
+    ASSERT_THROW(tm_->record_received_s_message("in_a1", {}, {7}), MessageOutOfSync);
 
     // a strictly later one advances the sub-iteration
     check_received(*tm_, "in_a1", {}, {8});

--- a/src/cpp/libmuscle/tests/test_timeline_manager.cpp
+++ b/src/cpp/libmuscle/tests/test_timeline_manager.cpp
@@ -157,7 +157,7 @@ struct libmuscle_vector_timeline_manager : libmuscle_timeline_manager {
                 PortsDescription{{Operator::O_F, {"out_v[]"}}}, {}, {{"out_v", {3}}});
         tm_ = std::make_unique<TimelineManager>(*port_manager_);
         tm_->start_reuse_iteration();
-        EXPECT_EQ(tm_->check_pre_received_iteration_counts({}), IterationCount());
+        EXPECT_EQ(tm_->record_pre_received_iteration_counts({}), IterationCount());
     }
 };
 
@@ -186,18 +186,18 @@ TEST(libmuscle_timeline, get_most_nested_iteration) {
 
 TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_adopts_iteration) {
     IterationCount first = {3};
-    tm_->check_pre_received_iteration_counts({first, first});
+    tm_->record_pre_received_iteration_counts({first, first});
 
     ASSERT_EQ(tm_->check_send_message("out_f"), first);
 }
 
 TEST_F(libmuscle_full_timeline_manager, record_received_message_f_init_raises_on_mismatch) {
-    ASSERT_THROW(tm_->check_pre_received_iteration_counts({{3}, {4}}), std::logic_error);
+    ASSERT_THROW(tm_->record_pre_received_iteration_counts({{3}, {4}}), std::logic_error);
 }
 
 TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_connections) {
     create(PortsDescription{{Operator::O_F, {"out_f"}}});
-    tm_->check_pre_received_iteration_counts({});
+    tm_->record_pre_received_iteration_counts({});
 
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount());
@@ -205,7 +205,7 @@ TEST_F(libmuscle_timeline_manager, o_f_can_send_immediately_when_no_f_init_conne
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_f_blocked_while_subtimeline_incomplete) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     tm_->check_send_message("out_a1");  // starts :A1, but doesn't complete it
 
@@ -213,7 +213,7 @@ TEST_F(libmuscle_full_timeline_manager, o_f_blocked_while_subtimeline_incomplete
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_f_send_records_iteration_and_participation) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount({3}));
@@ -224,14 +224,14 @@ TEST_F(libmuscle_full_timeline_manager, o_f_send_records_iteration_and_participa
 // -- Sub-timeline O_I/S leadership races --
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_first_send_starts_subtimeline_at_zero) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     IterationCount iteration = tm_->check_send_message("out_a1");
     ASSERT_EQ(iteration, IterationCount({3, 0}));
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_second_send_blocked_until_all_s_received) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
@@ -241,7 +241,7 @@ TEST_F(libmuscle_full_timeline_manager, o_i_leads_second_send_blocked_until_all_
 }
 
 TEST_F(libmuscle_full_timeline_manager, o_i_leads_advances_once_all_s_received) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     IterationCount first = tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, first);
@@ -253,7 +253,7 @@ TEST_F(libmuscle_full_timeline_manager, o_i_leads_advances_once_all_s_received) 
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_first_receive_starts_subtimeline) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     check_received(*tm_, "in_a1", {}, {7});
     // second receive on the same port before O_I sends anything is blocked
@@ -261,7 +261,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_first_receive_starts_subtimeline
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     check_received(*tm_, "in_a1", {}, {7});
     // in_a1_2 hasn't received yet, so S hasn't fully led :A1 yet
@@ -270,7 +270,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_o_i_blocked_until_all_s_received
 }
 
 TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_iteration) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     check_received(*tm_, "in_a1", {}, {7});
     check_received(*tm_, "in_a1_2", {}, {7});
@@ -286,7 +286,7 @@ TEST_F(libmuscle_full_timeline_manager, s_leads_advances_on_strictly_later_itera
 }
 
 TEST_F(libmuscle_full_timeline_manager, many_o_i_one_s_mirror_scenario) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
 
     // :A2 has two O_I ports (out_a2, out_a2_2) and one S port (in_a2)
     tm_->check_send_message("out_a2");
@@ -303,27 +303,27 @@ TEST_F(libmuscle_full_timeline_manager, many_o_i_one_s_mirror_scenario) {
 // -- Reuse loop completion / reset --
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_raises_when_incomplete) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
     // out_f never sent
 
     ASSERT_THROW(tm_->start_reuse_iteration(), ReuseLoopIncomplete);
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_resets_when_complete) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_f");
 
     tm_->start_reuse_iteration();
 
     // fully reset: the same sequence works again from scratch
-    tm_->check_pre_received_iteration_counts({{4}, {4}});
+    tm_->record_pre_received_iteration_counts({{4}, {4}});
     IterationCount iteration = tm_->check_send_message("out_f");
     ASSERT_EQ(iteration, IterationCount({4}));
 }
 
 TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeline_unused) {
     // a sub-timeline never touched this iteration doesn't block completion
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_f");
 
     ASSERT_NO_THROW(tm_->start_reuse_iteration());
@@ -333,7 +333,7 @@ TEST_F(libmuscle_full_timeline_manager, finish_reuse_iteration_ok_when_subtimeli
 // -- Snapshot state round-trip --
 
 TEST_F(libmuscle_full_timeline_manager, get_state_and_restore_state_round_trip) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
     // in_a1_2 not yet received, so :A1 is incomplete, and out_f not yet sent
@@ -352,7 +352,7 @@ TEST_F(libmuscle_full_timeline_manager, get_state_and_restore_state_round_trip) 
 }
 
 TEST_F(libmuscle_full_timeline_manager, state_data_round_trip_through_msgpack_shape) {
-    tm_->check_pre_received_iteration_counts({{3}, {3}});
+    tm_->record_pre_received_iteration_counts({{3}, {3}});
     tm_->check_send_message("out_a1");
     check_received(*tm_, "in_a1", {}, {3, 0});
 

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -60,7 +60,7 @@ Optional<IterationCount> decode_iteration(DataConstRef const & data) {
     return result;
 }
 
-bool is_subiteration(IterationCount const & it1, IterationCount const & it2) {
+bool is_subiteration_or_equal(IterationCount const & it1, IterationCount const & it2) {
     if (it1.size() < it2.size())
         return false;
     for (std::size_t i = 0; i < it2.size(); ++i) {
@@ -90,7 +90,7 @@ IterationCount const & get_most_nested_iteration(std::vector<IterationCount> con
                 return lhs.get() < rhs.get();   // lexicographical vector comparison
             });
     for (std::size_t i = 0; i < iterations.size() - 1; ++i) {
-        if (!is_subiteration(sorted[i + 1], sorted[i]))
+        if (!is_subiteration_or_equal(sorted[i + 1], sorted[i]))
             throw std::logic_error(
                 to_string(sorted[i+1]) + " is not a subiteration of "
                 + to_string(sorted[i]));

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -502,7 +502,7 @@ void TimelineManager::check_receive_s(std::string const & port_name, Optional<in
 
 IterationCount const & TimelineManager::record_received_s_message(
         std::string const & port_name, Optional<int> slot,
-        IterationCount const & iteration, int num_repeat_filters) {
+        IterationCount const & iteration, std::size_t num_repeat_filters) {
     Port const & port = port_manager_.get_port(port_name);
     assert(port.oper == Operator::S);
     return submanagers_.at(port.timeline).record_received_message(

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -1,5 +1,6 @@
 #include <libmuscle/timeline_manager.hpp>
 
+#include <cassert>
 #include <sstream>
 #include <algorithm>
 #include "timeline_manager.hpp"
@@ -59,6 +60,44 @@ Optional<IterationCount> decode_iteration(DataConstRef const & data) {
     return result;
 }
 
+bool is_subiteration(IterationCount const & it1, IterationCount const & it2) {
+    if (it1.size() < it2.size())
+        return false;
+    for (std::size_t i = 0; i < it2.size(); ++i) {
+        if (it1[i] != it2[i])
+            return false;
+    }
+    return true;
+}
+
+std::string to_string(IterationCount const & iteration) {
+    std::ostringstream oss;
+    oss << "[";
+    for (std::size_t i = 0; i < iteration.size(); ++i) {
+        if (i > 0) oss << ", ";
+        oss << iteration[i];
+    }
+    oss << "]";
+    return oss.str();
+}
+
+IterationCount const & get_most_nested_iteration(std::vector<IterationCount> const & iterations) {
+    if (iterations.empty())
+        throw std::logic_error("iterations is an empty list");
+    std::vector<std::reference_wrapper<IterationCount const>> sorted(iterations.begin(), iterations.end());
+    std::sort(sorted.begin(), sorted.end(),
+            [](auto && lhs, auto && rhs) {
+                return lhs.get() < rhs.get();   // lexicographical vector comparison
+            });
+    for (std::size_t i = 0; i < iterations.size() - 1; ++i) {
+        if (!is_subiteration(sorted[i + 1], sorted[i]))
+            throw std::logic_error(
+                to_string(sorted[i+1]) + " is not a subiteration of "
+                + to_string(sorted[i]));
+    }
+    return sorted.back();
+}
+
 
 Data SubTimelineState::to_data() const {
     Data first_op;
@@ -91,7 +130,6 @@ Data TimelineState::to_data() const {
     return Data::dict(
             "iteration", encode_iteration(iteration),
             "send_participated", encode_participated(send_participated),
-            "receive_participated", encode_participated(receive_participated),
             "subtimeline_states", subtimelines);
 }
 
@@ -99,7 +137,6 @@ TimelineState TimelineState::from_data(DataConstRef const & data) {
     TimelineState state;
     state.iteration = decode_iteration(data["iteration"]);
     state.send_participated = decode_participated(data["send_participated"]);
-    state.receive_participated = decode_participated(data["receive_participated"]);
 
     auto subtimelines = data["subtimeline_states"];
     for (std::size_t i = 0; i < subtimelines.size(); ++i)
@@ -333,25 +370,39 @@ void SubTimelineManager::check_receive(Port const & port, Optional<int> slot) {
     }
 }
 
-void SubTimelineManager::record_received_message(
-        Port const & port, Optional<int> slot, IterationCount const & iteration) {
+IterationCount const & SubTimelineManager::record_received_message(
+        Port const & port, Optional<int> slot, IterationCount const & iteration,
+        IterationCount const & component_iteration, int num_repeat_filters) {
     std::string port_name = std::string(port.name);
 
     if (!iteration_.is_set()) {
-        iteration_ = iteration;
+        if (num_repeat_filters > 0) {
+            // Handle cases with multiple levels of repeat filters, for example:
+            // - cached message iteration count: [2], with 2 repeat filters
+            // - component iteration count: [2, 1]
+            // Our iteration count needs to become [2, 1, 0]
+            iteration_ = component_iteration;
+            iteration_.get().push_back(0);
+        } else {
+            iteration_ = iteration;
+        }
         first_operator_ = Operator::S;
     } else if (!receive_.has_participated(port_name, slot)) {
-        if (iteration != iteration_.get())
+        if (num_repeat_filters == 0 && iteration != iteration_.get())
             throw MessageOutOfSync(port, slot);
     } else {
-        if (iteration <= iteration_.get())
+        if (num_repeat_filters > 0)
+            ++iteration_.get().back();
+        else if (iteration <= iteration_.get())
             throw MessageOutOfSync(port, slot);
-        iteration_ = iteration;
+        else
+            iteration_ = iteration;
         send_.reset();
         receive_.reset();
     }
 
     receive_.participate(port_name, slot);
+    return iteration_.get();
 }
 
 void SubTimelineManager::reset() {
@@ -408,6 +459,23 @@ IterationCount TimelineManager::check_send_message(
     return submanagers_.at(port.timeline).check_send_message(port, slot, iteration_.get());
 }
 
+IterationCount TimelineManager::check_pre_received_iteration_counts(
+        std::vector<IterationCount> const & iterations)
+{
+    IterationCount new_iteration;
+    if (iterations.empty()) {
+        assert(!port_manager_.has_f_init_connections());
+    } else {
+        new_iteration = get_most_nested_iteration(iterations);
+    }
+    if (iteration_.is_set() && new_iteration <= iteration_.get())
+        throw std::runtime_error(
+            "Internal error: received F_INIT iteration count " + to_string(new_iteration)
+            + " is not newer than the previous iteration " + to_string(iteration_.get()));
+    iteration_ = new_iteration;
+    return new_iteration;
+}
+
 IterationCount TimelineManager::check_send_o_f_(Port const & port, Optional<int> slot) {
     std::string port_name = std::string(port.name);
 
@@ -426,37 +494,23 @@ IterationCount TimelineManager::check_send_o_f_(Port const & port, Optional<int>
     return iteration_.get();
 }
 
-void TimelineManager::check_receive(std::string const & port_name, Optional<int> slot) {
+void TimelineManager::check_receive_s(std::string const & port_name, Optional<int> slot) {
     Port const & port = port_manager_.get_port(port_name);
-
-    if (port.oper == Operator::F_INIT) {
-        if (receive_.has_participated(port_name, slot))
-            throw AlreadyParticipated(port, slot);
-    } else if (port.oper == Operator::S)
-        submanagers_.at(port.timeline).check_receive(port, slot);
+    assert(port.oper == Operator::S);
+    submanagers_.at(port.timeline).check_receive(port, slot);
 }
 
-void TimelineManager::record_received_message(
-        std::string const & port_name, Optional<int> slot, IterationCount const & iteration) {
+IterationCount const & TimelineManager::record_received_s_message(
+        std::string const & port_name, Optional<int> slot,
+        IterationCount const & iteration, int num_repeat_filters) {
     Port const & port = port_manager_.get_port(port_name);
-
-    if (port.oper == Operator::F_INIT) {
-        if (!iteration_.is_set())
-            iteration_ = iteration;
-        else if (iteration != iteration_.get())
-            throw MessageOutOfSync(port, slot);
-        receive_.participate(port_name, slot);
-        return;
-    }
-
-    submanagers_.at(port.timeline).record_received_message(port, slot, iteration);
+    assert(port.oper == Operator::S);
+    return submanagers_.at(port.timeline).record_received_message(
+            port, slot, iteration, iteration_.get(), num_repeat_filters);
 }
 
 void TimelineManager::reset() {
-    iteration_ = port_manager_.has_f_init_connections() ?
-            Optional<IterationCount>() : Optional<IterationCount>(IterationCount());
     send_.reset();
-    receive_.reset();
     for (auto & item : submanagers_)
         item.second.reset();
 }
@@ -472,15 +526,14 @@ Optional<IterationCount> TimelineManager::start_reuse_iteration() {
     }
 
     if (!iteration.is_set() || (
-            receive_.all_participated()
-            && send_.all_participated()
+            send_.all_participated()
             && subtimelines_complete )) {
         reset();
         return iteration;
     }
 
     ExpectedActions expected;
-    expected_actions(&send_, &receive_, expected);
+    expected_actions(&send_, nullptr, expected);
     for (auto const & item : submanagers_) {
         if (!item.second.is_complete())
             item.second.missing_actions(expected);
@@ -493,7 +546,6 @@ TimelineState TimelineManager::get_state() const {
     TimelineState state;
     state.iteration = iteration_;
     state.send_participated = send_.participated;
-    state.receive_participated = receive_.participated;
     for (auto const & item : submanagers_)
         state.subtimeline_states.emplace(
                 static_cast<std::string>(item.first), item.second.get_state());
@@ -503,7 +555,6 @@ TimelineState TimelineManager::get_state() const {
 void TimelineManager::restore_state(TimelineState const & state) {
     iteration_ = state.iteration;
     send_.participated = state.send_participated;
-    receive_.participated = state.receive_participated;
     for (auto & item : submanagers_) {
         auto it = state.subtimeline_states.find(static_cast<std::string>(item.first));
         if (it != state.subtimeline_states.end())

--- a/src/cpp/libmuscle/timeline_manager.cpp
+++ b/src/cpp/libmuscle/timeline_manager.cpp
@@ -372,7 +372,7 @@ void SubTimelineManager::check_receive(Port const & port, Optional<int> slot) {
 
 IterationCount const & SubTimelineManager::record_received_message(
         Port const & port, Optional<int> slot, IterationCount const & iteration,
-        IterationCount const & component_iteration, int num_repeat_filters) {
+        IterationCount const & instance_iteration, int num_repeat_filters) {
     std::string port_name = std::string(port.name);
 
     if (!iteration_.is_set()) {
@@ -381,7 +381,7 @@ IterationCount const & SubTimelineManager::record_received_message(
             // - cached message iteration count: [2], with 2 repeat filters
             // - component iteration count: [2, 1]
             // Our iteration count needs to become [2, 1, 0]
-            iteration_ = component_iteration;
+            iteration_ = instance_iteration;
             iteration_.get().push_back(0);
         } else {
             iteration_ = iteration;
@@ -459,7 +459,7 @@ IterationCount TimelineManager::check_send_message(
     return submanagers_.at(port.timeline).check_send_message(port, slot, iteration_.get());
 }
 
-IterationCount TimelineManager::check_pre_received_iteration_counts(
+IterationCount TimelineManager::record_pre_received_iteration_counts(
         std::vector<IterationCount> const & iterations)
 {
     IterationCount new_iteration;

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -36,6 +36,20 @@ using IterationCount = std::vector<int>;
 Data encode_iteration(Optional<IterationCount> const & iteration);
 Optional<IterationCount> decode_iteration(DataConstRef const & data);
 
+/** Check if it1 is a subiteration of it2, or if both counts are equal.
+ * 
+ * @example
+ *      `[1, 2, 3]` is a subiteration of `[1, 2]`, `[1]` and `[]`, but not of `[0]`.
+ */
+bool is_subiteration(IterationCount const & it1, IterationCount const & it2);
+
+/** Return the most nested iteration in the list, i.e. the one with the most items.
+ * 
+ * @throw std::logic_error if iterations is an empty list or if the iterations are
+ *      incompatible with one another.
+ */
+IterationCount const & get_most_nested_iteration(std::vector<IterationCount> const & iterations);
+
 /** A single expected next action: send or receive on the given port, and if
  * the port is a vector port, the slots that are still expected ([] for a
  * scalar port). */
@@ -60,13 +74,11 @@ struct SubTimelineState {
  *
  * Returned by TimelineManager::get_state() for saving in a snapshot, and
  * passed back into TimelineManager::restore_state() to resume from one.
- * iteration is unset if the main timeline has not started yet (or has been
- * reset).
+ * iteration is unset if the main timeline has not started yet.
  */
 struct TimelineState {
     Optional<IterationCount> iteration;
     std::vector<PortAndSlot> send_participated;
-    std::vector<PortAndSlot> receive_participated;
     std::unordered_map<std::string, SubTimelineState> subtimeline_states;
 
     Data to_data() const;
@@ -210,12 +222,15 @@ class SubTimelineManager {
         /** Record that a message has been received on the given S port.
          *
          * @param port The S port a message was received on.
-         * @param slot The slot the message was received on, if this is a
-         *      vector port.
+         * @param slot The slot the message was received on, if this is a vector port.
          * @param iteration The iteration the received message was sent with.
+         * @param component_iteration The current iteration of the component.
+         * @param num_repeat_filters Number of repeater filters applied to this message.
+         * @return Current iteration count of the subtimeline.
          */
-        void record_received_message(
-                Port const & port, Optional<int> slot, IterationCount const & iteration);
+        IterationCount const & record_received_message(
+                Port const & port, Optional<int> slot, IterationCount const & iteration,
+                IterationCount const & component_iteration, int num_repeat_filters);
 
         /** Reset this sub-timeline once the main timeline's reuse loop
          * iteration completes. */
@@ -293,30 +308,34 @@ class TimelineManager {
         IterationCount check_send_message(
                 std::string const & port_name, Optional<int> slot = {});
 
-        /** Check that receiving on the given port is currently allowed.
+        /** Check if the iteration counts of pre-received messages are consistent.
+         * 
+         * @return The iteration count for the upcoming reuse loop.
+         * @throw std::logic_error if the iteration counts are inconsistent.
+         */
+        IterationCount check_pre_received_iteration_counts(
+                std::vector<IterationCount> const & iterations);
+
+        /** Check that receiving on the given S port is currently allowed.
          *
-         * An F_INIT port may receive once after the reuse loop starts and
-         * before any other ports are used. Whether an S port may receive is
-         * delegated to the corresponding SubTimelineManager.
-         *
-         * @param port_name Name of the F_INIT or S port about to receive.
+         * @param port_name Name of the S port about to receive.
          * @param slot The slot being received on, if this is a vector port.
          */
-        void check_receive(std::string const & port_name, Optional<int> slot = {});
+        void check_receive_s(std::string const & port_name, Optional<int> slot = {});
 
-        /** Record that a message has been received on the given port.
+        /** Record that a message has been received on the given S port.
          *
-         * check_receive already established that this receive is allowed.
+         * check_receive_s already established that this receive is allowed.
          *
-         * @param port_name Name of the F_INIT or S port a message was
-         *      received on.
-         * @param slot The slot the message was received on, if this is a
-         *      vector port.
+         * @param port_name Name of the S port a message was received on.
+         * @param slot The slot the message was received on, if this is a vector port.
          * @param iteration The iteration the received message was sent with.
+         * @param num_repeat_filters Number of repeat filters applied to this S port.
+         * @return New iteration count for the subtimeline of the S port.
          */
-        void record_received_message(
+        IterationCount const & record_received_s_message(
                 std::string const & port_name, Optional<int> slot,
-                IterationCount const & iteration);
+                IterationCount const & iteration, int num_repeat_filters = 0);
 
         /** Reset the main timeline and its sub-timelines.
          *

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -335,7 +335,7 @@ class TimelineManager {
          */
         IterationCount const & record_received_s_message(
                 std::string const & port_name, Optional<int> slot,
-                IterationCount const & iteration, int num_repeat_filters = 0);
+                IterationCount const & iteration, std::size_t num_repeat_filters = 0);
 
         /** Reset the main timeline and its sub-timelines.
          *

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -41,7 +41,7 @@ Optional<IterationCount> decode_iteration(DataConstRef const & data);
  * @example
  *      `[1, 2, 3]` is a subiteration of `[1, 2]`, `[1]` and `[]`, but not of `[0]`.
  */
-bool is_subiteration(IterationCount const & it1, IterationCount const & it2);
+bool is_subiteration_or_equal(IterationCount const & it1, IterationCount const & it2);
 
 /** Return the most nested iteration in the list, i.e. the one with the most items.
  * 

--- a/src/cpp/libmuscle/timeline_manager.hpp
+++ b/src/cpp/libmuscle/timeline_manager.hpp
@@ -224,13 +224,13 @@ class SubTimelineManager {
          * @param port The S port a message was received on.
          * @param slot The slot the message was received on, if this is a vector port.
          * @param iteration The iteration the received message was sent with.
-         * @param component_iteration The current iteration of the component.
+         * @param instance_iteration The current iteration of the component.
          * @param num_repeat_filters Number of repeater filters applied to this message.
          * @return Current iteration count of the subtimeline.
          */
         IterationCount const & record_received_message(
                 Port const & port, Optional<int> slot, IterationCount const & iteration,
-                IterationCount const & component_iteration, int num_repeat_filters);
+                IterationCount const & instance_iteration, int num_repeat_filters);
 
         /** Reset this sub-timeline once the main timeline's reuse loop
          * iteration completes. */
@@ -313,7 +313,7 @@ class TimelineManager {
          * @return The iteration count for the upcoming reuse loop.
          * @throw std::logic_error if the iteration counts are inconsistent.
          */
-        IterationCount check_pre_received_iteration_counts(
+        IterationCount record_pre_received_iteration_counts(
                 std::vector<IterationCount> const & iterations);
 
         /** Check that receiving on the given S port is currently allowed.

--- a/src/cpp/ymmsl/ymmsl.hpp
+++ b/src/cpp/ymmsl/ymmsl.hpp
@@ -13,6 +13,10 @@ namespace ymmsl {
     using impl::allows_receiving;
     using impl::operator_name;
     using impl::operator_for_name;
+    using impl::is_reducer;
+    using impl::is_repeater;
+    using impl::conduit_filter_name;
+    using impl::conduit_filter_for_name;
     using impl::Conduit;
     using impl::ConduitFilter;
     using impl::Identifier;

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -1,7 +1,9 @@
 import logging
+from collections.abc import Iterator
+from copy import deepcopy
 from typing import Any, Optional, cast
 
-from ymmsl.v0_2 import Operator, Reference, Settings
+from ymmsl.v0_2 import ConduitFilter, Operator, Reference, Settings
 
 from libmuscle.communicator_state import CommunicatorState
 from libmuscle.endpoint import Endpoint
@@ -16,14 +18,20 @@ from libmuscle.port_manager import PortManager
 from libmuscle.profiler import Profiler
 from libmuscle.profiling import ProfileEvent, ProfileEventType, ProfileTimestamp
 from libmuscle.receive_timeout_handler import Deadlock, ReceiveTimeoutHandler
-from libmuscle.timeline_manager import IterationCount, TimelineManager
+from libmuscle.timeline_manager import (
+    IterationCount,
+    PortAndSlot,
+    TimelineManager,
+    get_most_nested_iteration,
+)
 from libmuscle.util import port_desc
 
 _logger = logging.getLogger(__name__)
 
 
 MessageObject = Any
-FInitCacheType = dict[tuple[str, Optional[int]], "Message"]
+FInitCacheType = dict[PortAndSlot, "Message"]
+MPPCacheType = dict[PortAndSlot, MPPMessage]
 
 
 class PortClosed(Exception):
@@ -74,6 +82,29 @@ class Message:
         self.settings = settings
 
 
+def _make_message(mpp_msg: MPPMessage, copy: bool = False) -> Message:
+    """Create a Message object from the provided MPPMessage.
+    Args:
+        mpp_msg: The MPPMessage object to create the Message from.
+        copy: Whether to deepcopy the data and settings.
+    """
+    return Message(
+        mpp_msg.timestamp,
+        mpp_msg.next_timestamp,
+        deepcopy(mpp_msg.data) if copy else mpp_msg.data,
+        deepcopy(mpp_msg.settings_overlay) if copy else mpp_msg.settings_overlay,
+    )
+
+
+def _yield_slots(port: Port) -> Iterator[Optional[int]]:
+    """Iterator over the slots in the port."""
+    if not port.is_vector():
+        yield None
+    else:
+        yield 0  # Allow pre-receive to receive 1 message that updates port._length
+        yield from range(1, port.get_length())
+
+
 class Communicator:
     """Communication engine for MUSCLE3.
 
@@ -117,6 +148,13 @@ class Communicator:
         # indexed by remote instance id
         self._clients: dict[Reference, MPPClient] = {}
 
+        self._pre_receive_ports: list[Port] = []
+        """List of ports that we should pre-receive on."""
+        self._repeat_filters: dict[str, list[ConduitFilter]] = {}
+        """List of repeat filters for each port_name with repeat filters applied."""
+        self._message_cache: MPPCacheType = {}
+        """Message cache for pre-received messages."""
+
     def get_locations(self) -> list[str]:
         """Returns a list of locations that we can be reached at.
 
@@ -141,6 +179,7 @@ class Communicator:
         """
         self._peer_info = peer_info
         self._timeline_manager = TimelineManager(self._port_manager)
+        self._prepare_conduit_filters()
 
     def set_receive_timeout(self, receive_timeout: float) -> None:
         """Update the timeout after which the manager is notified that we are waiting
@@ -159,6 +198,7 @@ class Communicator:
         return CommunicatorState(
             self._port_manager.get_message_counts(),
             self._timeline_manager.get_state(),
+            self._message_cache,
         )
 
     def restore_state(self, state: CommunicatorState) -> None:
@@ -169,6 +209,7 @@ class Communicator:
         """
         self._port_manager.restore_message_counts(state.port_message_counts)
         self._timeline_manager.restore_state(state.timeline_state)
+        self._message_cache = state.message_cache
 
     def send_message(
         self,
@@ -248,61 +289,84 @@ class Communicator:
         elif message.data.is_final_milestone():
             port.set_closed(slot)
 
-    def pre_receive_f_init(self) -> FInitCacheType:
-        """Receive on all connected F_INIT port (including muscle_settings_in).
+    def pre_receive(self) -> FInitCacheType:
+        """Pre-receive on all connected F_INIT ports and S ports with repeat filters.
 
         Returns:
-            f_init_cache: The received messages.
+            The received messages on F_INIT ports (including muscle_settings_in).
         """
         finished_iteration = self._timeline_manager.start_reuse_iteration()
-        if finished_iteration is not None:
-            self._broadcast_milestone(Milestone(finished_iteration), True)
+        milestone_iteration = finished_iteration
 
+        while True:
+            if milestone_iteration is not None:
+                # Should send on O_I only when this is the milestone for the finished
+                # iteration. Other milestones (received on F_INIT ports) should
+                # propagate to O_F as well:
+                milestone = Milestone(milestone_iteration)
+                self._broadcast_milestone(
+                    milestone, only_o_i=(milestone_iteration == finished_iteration)
+                )
+
+                # Clean up stale messages in the cache
+                self._message_cache = {
+                    key: message
+                    for key, message in self._message_cache.items()
+                    if message.iteration != milestone_iteration
+                }
+
+                # TODO: send buffered message for reducer filters
+
+                if milestone.is_final_milestone():
+                    raise PortClosed()
+
+            milestone_iterations: list[IterationCount] = []
+            # Pre-receive on all F_INIT ports and repeated S ports, if needed
+            for port in self._pre_receive_ports:
+                port_name = str(port.name)
+                for slot in _yield_slots(port):
+                    if (port_name, slot) in self._message_cache:
+                        continue
+                    _logger.debug("Pre-receiving on %s", port_desc(port_name, slot))
+                    mpp_message = self._receive_message(port_name, slot)
+                    self._message_cache[(port_name, slot)] = mpp_message
+
+                    if isinstance(mpp_message.data, Milestone):
+                        milestone_iterations.append(mpp_message.data.iteration)
+
+            if not milestone_iterations:
+                break  # No milestones received, we have only messages now
+
+            # Handle most deeply nested milestone first:
+            try:
+                milestone_iteration = get_most_nested_iteration(milestone_iterations)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "Internal error: received milestones for incompatible iterations "
+                    f"during F_INIT: {milestone_iterations}"
+                ) from exc
+
+        # Update current iteration
+        new_iteration = self._timeline_manager.check_pre_received_iteration_counts(
+            [msg.iteration for msg in self._message_cache.values()]
+        )
+
+        # Sanity check: we should not have any milestones in the cache at this point
+        if any(isinstance(msg.data, Milestone) for msg in self._message_cache.values()):
+            raise RuntimeError("Internal error: found milestones in message cache.")
+
+        # Fill F_INIT cache for Instance
         cache: FInitCacheType = {}
-
-        def pre_receive(port_name: str, slot: Optional[int]) -> None:
-            cache[(port_name, slot)] = self._receive_message(port_name, slot)
-
         for port in self._port_manager.get_connected_ports(Operator.F_INIT):
             port_name = str(port.name)
-            _logger.debug("Pre-receiving on port %s", port_name)
-            if not port.is_vector():
-                pre_receive(port_name, None)
-            else:
-                pre_receive(port_name, 0)
-                # The above receives the length, if needed, so now we can get the rest.
-                for slot in range(1, port.get_length()):
-                    pre_receive(port_name, slot)
-
-        # Check if we have received milestones
-        milestone_iterations: list[Optional[IterationCount]] = []
-        closed_ports: set[str] = set()
-        for (port_name, _), message in cache.items():
-            it = message.data.iteration if isinstance(message.data, Milestone) else None
-            if it not in milestone_iterations:
-                milestone_iterations.append(it)
-            if it == []:
-                closed_ports.add(port_name)
-        # Milestones should be consistent, or something went wrong
-        if len(milestone_iterations) > 1:
-            if closed_ports:
-                raise RuntimeError(
-                    "Some ports were unexpectedly closed while trying to receive, did "
-                    "the peers crash? Closed ports: " + ", ".join(sorted(closed_ports))
-                )
-            raise RuntimeError(
-                "Internal error: received milestones for different iterations in "
-                f"F_INIT: {milestone_iterations}. This is not supposed to happen and "
-                "may be a bug in libmuscle. Please report an issue."
-            )
-        if milestone_iterations and milestone_iterations[0] is not None:
-            # Propagate milestone
-            milestone = Milestone(milestone_iterations[0])
-            self._broadcast_milestone(milestone, False)
-            if milestone.is_final_milestone():
-                raise PortClosed()
-            # Pre-receive again to receive the actual messages
-            return self.pre_receive_f_init()
+            filters = self._repeat_filters.get(port_name, [])
+            pad_message = self._pad_message(new_iteration, filters)
+            for slot in _yield_slots(port):
+                mpp_message = self._message_cache[(port_name, slot)]
+                message = _make_message(mpp_message)
+                if pad_message:
+                    message.data = None
+                cache[(port_name, slot)] = message
 
         return cache
 
@@ -326,6 +390,20 @@ class Communicator:
             RuntimeError: If the network connection had an error, or the
                     message number was incorrect.
         """
+        self._timeline_manager.check_receive_s(port_name, slot)
+
+        # Handle receive on repeated S port:
+        if port_name in self._repeat_filters:
+            filters = self._repeat_filters[port_name]
+            message = self._message_cache[(port_name, slot)]
+            cur_iteration = self._timeline_manager.record_received_s_message(
+                port_name, slot, message.iteration, len(filters)
+            )
+            result = _make_message(message, copy=True)
+            if self._pad_message(cur_iteration, filters):
+                result.data = None
+            return result
+
         # Instance should not need to bother about milestones, so we keep receiving
         # messages until we have actual data:
         while True:
@@ -335,12 +413,13 @@ class Communicator:
                     raise PortClosed()
                 # TODO: handle milestone, if needed
             else:
-                return message
+                self._timeline_manager.record_received_s_message(
+                    port_name, slot, message.iteration
+                )
+                return _make_message(message)
 
-    def _receive_message(self, port_name: str, slot: Optional[int]) -> Message:
+    def _receive_message(self, port_name: str, slot: Optional[int]) -> MPPMessage:
         """Implementation for receive_message."""
-        self._timeline_manager.check_receive(port_name, slot)
-
         port = self._port_manager.get_port(port_name)
         port_and_slot = port_desc(port_name, slot)
         _logger.debug("Waiting for message on %s", port_and_slot)
@@ -408,13 +487,6 @@ class Communicator:
             if milestone.is_final_milestone():
                 port.set_closed(slot)
 
-        message = Message(
-            mpp_message.timestamp,
-            mpp_message.next_timestamp,
-            mpp_message.data,
-            mpp_message.settings_overlay,
-        )
-
         recv_wait_event = ProfileEvent(
             ProfileEventType.RECEIVE_WAIT,
             profile[0],
@@ -424,7 +496,7 @@ class Communicator:
             slot,
             port.get_num_messages(),
             len(memoryview(mpp_message_bytes)),
-            message.timestamp,
+            mpp_message.timestamp,
         )
 
         recv_xfer_event = ProfileEvent(
@@ -436,11 +508,11 @@ class Communicator:
             slot,
             port.get_num_messages(),
             len(memoryview(mpp_message_bytes)),
-            message.timestamp,
+            mpp_message.timestamp,
         )
 
-        recv_decode_event.message_timestamp = message.timestamp
-        receive_event.message_timestamp = message.timestamp
+        recv_decode_event.message_timestamp = mpp_message.timestamp
+        receive_event.message_timestamp = mpp_message.timestamp
 
         if port.is_vector():
             receive_event.port_length = port.get_length()
@@ -481,15 +553,12 @@ class Communicator:
         if milestone is None:
             port.increment_num_messages(slot)
             _logger.debug(f"Received message on {port_and_slot}")
-            self._timeline_manager.record_received_message(
-                port_name, slot, mpp_message.iteration
-            )
         elif milestone.is_final_milestone():
             _logger.debug(f"Port {port_and_slot} is now closed")
         else:
             _logger.debug("Received %s on %s", milestone, port_and_slot)
 
-        return message
+        return mpp_message
 
     def shutdown(self) -> None:
         """Shuts down the Communicator, closing connections."""
@@ -612,3 +681,36 @@ class Communicator:
             return  # Not connected yet, no ports to close
         self._close_outgoing_ports()
         self._close_incoming_ports()
+
+    def _prepare_conduit_filters(self) -> None:
+        """Check which ports are connected with a conduit filter and initialize the
+        associated logic.
+        """
+        # Repeater filters
+        for operator in (Operator.F_INIT, Operator.S):
+            for port in self._port_manager.get_connected_ports(operator):
+                filters = self._peer_info.get_filters_for_receiver(
+                    self._kernel + port.name
+                )
+                # Only keep the repeater filters, the sending component handles reducers
+                filters = [filter for filter in filters if filter.is_repeater()]
+                if filters:
+                    self._repeat_filters[str(port.name)] = filters
+                if operator is Operator.F_INIT or filters:
+                    self._pre_receive_ports.append(port)
+
+        # TODO: reducer filters
+
+    def _pad_message(
+        self, cur_iteration: IterationCount, filters: list[ConduitFilter]
+    ) -> bool:
+        """Check if we should pad the message in the current iteration, based on the
+        configured pad/repeat filters.
+
+        Returns:
+            True if the message data should be nilled, False otherwise.
+        """
+        return any(
+            filter is ConduitFilter.PAD and cur_iteration[-len(filters) + i] > 0
+            for i, filter in enumerate(filters)
+        )

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -411,7 +411,6 @@ class Communicator:
             if isinstance(message.data, Milestone):
                 if message.data.is_final_milestone():
                     raise PortClosed()
-                # TODO: handle milestone, if needed
             else:
                 self._timeline_manager.record_received_s_message(
                     port_name, slot, message.iteration

--- a/src/python/libmuscle/communicator.py
+++ b/src/python/libmuscle/communicator.py
@@ -347,7 +347,7 @@ class Communicator:
                 ) from exc
 
         # Update current iteration
-        new_iteration = self._timeline_manager.check_pre_received_iteration_counts(
+        new_iteration = self._timeline_manager.record_pre_received_iteration_counts(
             [msg.iteration for msg in self._message_cache.values()]
         )
 

--- a/src/python/libmuscle/communicator_state.py
+++ b/src/python/libmuscle/communicator_state.py
@@ -1,19 +1,24 @@
 from dataclasses import asdict, dataclass
 
-from libmuscle.timeline_manager import TimelineState
+from libmuscle.mpp_message import MPPMessage
+from libmuscle.timeline_manager import PortAndSlot, TimelineState
 
 
 @dataclass
 class CommunicatorState:
     port_message_counts: dict[str, list[int]]
     timeline_state: TimelineState
-    # TODO: message cache
+    message_cache: dict[PortAndSlot, MPPMessage]
 
     def asdict(self) -> dict:
         """Convert CommunicatorState into a MsgPack-serializable dictionary."""
         return {
             "port_message_counts": self.port_message_counts,
             "timeline_state": asdict(self.timeline_state),
+            "message_cache": [
+                [port_name, slot, msg.encoded()]
+                for (port_name, slot), msg in self.message_cache.items()
+            ],
         }
 
     @classmethod
@@ -22,4 +27,8 @@ class CommunicatorState:
         return cls(
             data["port_message_counts"],
             TimelineState(**data["timeline_state"]),
+            {
+                (port_name, slot): MPPMessage.from_bytes(encoded)
+                for port_name, slot, encoded in data["message_cache"]
+            },
         )

--- a/src/python/libmuscle/instance.py
+++ b/src/python/libmuscle/instance.py
@@ -1110,7 +1110,7 @@ class Instance:
         sw_event = ProfileEvent(ProfileEventType.SHUTDOWN_WAIT, ProfileTimestamp())
 
         try:
-            self._f_init_cache = self._communicator.pre_receive_f_init()
+            self._f_init_cache = self._communicator.pre_receive()
         except PortClosed:
             self._profiler.record_event(sw_event)
             self._f_init_cache.clear()

--- a/src/python/libmuscle/test/conftest.py
+++ b/src/python/libmuscle/test/conftest.py
@@ -51,9 +51,9 @@ def communicator_state() -> CommunicatorState:
         timeline_state=TimelineState(
             iteration=[1],
             send_participated=[],
-            receive_participated=[["in", None]],
             subtimeline_states={},
         ),
+        message_cache={},
     )
 
 
@@ -112,7 +112,15 @@ def mock_ports():
 
 
 @pytest.fixture
-def connected_port_manager(port_manager, declared_ports, mock_ports):
+def settings_in_connected(request):
+    # Allow indirectly parametrizing settings_in_connected
+    return getattr(request, "param", False)
+
+
+@pytest.fixture
+def connected_port_manager(
+    port_manager, declared_ports, mock_ports, settings_in_connected
+):
 
     def get_port(name):
         if name == "muscle_settings_in":
@@ -128,8 +136,9 @@ def connected_port_manager(port_manager, declared_ports, mock_ports):
 
     port_manager._ports = mock_ports
     port_manager._muscle_settings_in = Port(
-        "muscle_settings_in", Operator.F_INIT, None, False, True, 0, []
+        "muscle_settings_in", Operator.F_INIT, None, False, settings_in_connected, 0, []
     )
+    port_manager.settings_in_connected.return_value = settings_in_connected
     port_manager.get_port = get_port
     port_manager.get_connected_ports = get_connected_ports
     port_manager.list_ports.return_value = declared_ports

--- a/src/python/libmuscle/test/test_communicator.py
+++ b/src/python/libmuscle/test/test_communicator.py
@@ -29,9 +29,7 @@ def mpp_server(MPPServer):
 @pytest.fixture
 def port_manager():
     with patch("libmuscle.communicator.PortManager") as PortManager:
-        port_manager = PortManager.return_value
-        port_manager.settings_in_connected.return_value = False
-        yield port_manager
+        yield PortManager.return_value
 
 
 @pytest.fixture(autouse=True)
@@ -231,21 +229,19 @@ def test_receive_root_milestone_vector(
     assert port_manager.get_port("in_v").is_open(5) is False
 
 
-def test_pre_receive_f_init(connected_communicator, mpp_client):
+def test_pre_receive(connected_communicator, mpp_client):
     mpp_client.receive.return_value = mock_mpp_receive(data="test")
 
-    cache = connected_communicator.pre_receive_f_init()
+    cache = connected_communicator.pre_receive()
     assert len(cache) == 1
     assert cache[("in", None)].data == "test"
 
 
-def test_pre_receive_f_init_with_settings(
-    connected_communicator, connected_port_manager, mpp_client
-):
+@pytest.mark.parametrize("settings_in_connected", [True], indirect=True)
+def test_pre_receive_with_settings(connected_communicator, mpp_client):
     mpp_client.receive.return_value = mock_mpp_receive(data=Settings({"a": True}))
-    connected_port_manager.settings_in_connected.return_value = True
 
-    cache = connected_communicator.pre_receive_f_init()
+    cache = connected_communicator.pre_receive()
     assert cache.keys() == {("in", None), ("muscle_settings_in", None)}
     for msg in cache.values():
         assert msg.data == Settings({"a": True})
@@ -255,7 +251,7 @@ def test_pre_receive_close_port(connected_communicator, mpp_client):
     mpp_client.receive.return_value = mock_mpp_receive(data=Milestone([]))
 
     with pytest.raises(PortClosed):
-        connected_communicator.pre_receive_f_init()
+        connected_communicator.pre_receive()
 
 
 def test_pre_receive_vector(connected_communicator, mock_ports, mpp_client):
@@ -263,7 +259,7 @@ def test_pre_receive_vector(connected_communicator, mock_ports, mpp_client):
     mock_ports["in"]._is_resizable = True
     mock_ports["in"].set_length(4)
 
-    cache = connected_communicator.pre_receive_f_init()
+    cache = connected_communicator.pre_receive()
     assert cache.keys() == {("in", slot) for slot in range(4)}
 
 
@@ -275,7 +271,7 @@ def test_pre_receive_broadcast_milestone(
         (mock_mpp_receive(data="test data", iteration=[2, 0])),
     ]
 
-    cache = connected_communicator.pre_receive_f_init()
+    cache = connected_communicator.pre_receive()
     assert cache.keys() == {("in", None)}
     assert cache[("in", None)].data == "test data"
     # Expect a milestone broadcasted to all O_I and O_F ports
@@ -288,32 +284,29 @@ def test_pre_receive_broadcast_milestone(
         assert msg.data.iteration == [1]
 
 
-def test_pre_receive_different_milestones(
-    connected_communicator, connected_port_manager, mpp_client
-):
-    connected_port_manager.settings_in_connected.return_value = True
+@pytest.mark.parametrize("settings_in_connected", [True], indirect=True)
+def test_pre_receive_different_milestones(connected_communicator, mpp_client):
     # One of these is received on "in", the other on "muscle_settings_in":
     mpp_client.receive.side_effect = [
         (mock_mpp_receive(data=Milestone([1]), iteration=[1])),
         (mock_mpp_receive(data=Milestone([2]), iteration=[2])),
     ]
 
-    with pytest.raises(RuntimeError, match="different iterations"):
-        connected_communicator.pre_receive_f_init()
+    with pytest.raises(RuntimeError, match="incompatible iterations"):
+        connected_communicator.pre_receive()
 
 
-def test_pre_receive_some_port_closed(
-    connected_communicator, connected_port_manager, mpp_client
-):
-    connected_port_manager.settings_in_connected.return_value = True
+@pytest.mark.parametrize("settings_in_connected", [True], indirect=True)
+def test_pre_receive_some_port_closed(connected_communicator, mpp_client):
     # One of these is received on "in", the other on "muscle_settings_in":
     mpp_client.receive.side_effect = [
         (mock_mpp_receive(data=Milestone([1]), iteration=[1])),
         (mock_mpp_receive(data=Milestone([]), iteration=[])),
+        (mock_mpp_receive(data=Milestone([]), iteration=[])),
     ]
 
-    with pytest.raises(RuntimeError, match="unexpectedly closed"):
-        connected_communicator.pre_receive_f_init()
+    with pytest.raises(PortClosed):
+        connected_communicator.pre_receive()
 
 
 def test_port_count_validation(
@@ -484,7 +477,7 @@ def test_send_milestone_at_reuse(
     mpp_client.receive.return_value = mock_mpp_receive(data=None, iteration=[1, 3])
     timeline_manager().start_reuse_iteration.return_value = [1, 2]
 
-    connected_communicator.pre_receive_f_init()
+    connected_communicator.pre_receive()
 
     timeline_manager().start_reuse_iteration.assert_called_once()
     # Expect a milestone broadcasted to all O_I ports

--- a/src/python/libmuscle/test/test_communicator_conduit_filters.py
+++ b/src/python/libmuscle/test/test_communicator_conduit_filters.py
@@ -1,0 +1,253 @@
+from typing import Union
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ymmsl.v0_2 import Conduit, ConduitFilter, Operator, Port, Settings
+from ymmsl.v0_2 import Identifier as Id
+from ymmsl.v0_2 import Reference as Ref
+
+from libmuscle.communicator import Communicator, PortClosed
+from libmuscle.mpp_message import Milestone, MPPMessage
+from libmuscle.peer_info import PeerInfo
+from libmuscle.port_manager import PortManager
+from libmuscle.timeline_manager import IterationCount
+
+
+@pytest.fixture
+def mpp_client():
+    with patch("libmuscle.communicator.MPPClient") as MPPClient:
+        yield MPPClient.return_value
+
+
+@pytest.fixture(params=["repeat", "pad"])
+def repeat_filter(request):
+    return request.param
+
+
+@pytest.fixture()
+def repeater_communicator(repeat_filter, mpp_client):
+    port_manager = PortManager([], None)
+    communicator = Communicator(
+        Ref("component"), [], port_manager, MagicMock(), MagicMock()
+    )
+    peer_info = PeerInfo(
+        Ref("component"),
+        [],
+        [
+            Conduit("parent1.out", "component.unfiltered"),
+            Conduit("parent2.out", "component.repeated", repeat_filter),
+            Conduit(
+                "parent3.out",
+                "component.twicerepeated",
+                repeat_filter + " " + repeat_filter,
+            ),
+            Conduit("parent1.out2", "component.repeated_s", repeat_filter),
+        ],
+        {Ref("parent1"): [], Ref("parent2"): [], Ref("parent3"): []},
+        {Ref("parent1"): [], Ref("parent2"): [], Ref("parent3"): []},
+        [
+            Port(Id("unfiltered"), Operator.F_INIT),
+            Port(Id("repeated"), Operator.F_INIT),
+            Port(Id("twicerepeated"), Operator.F_INIT),
+            Port(Id("repeated_s"), Operator.S),
+        ],
+    )
+    port_manager.connect_ports(peer_info)
+    communicator.set_peer_info(peer_info)
+    assert communicator._repeat_filters == {
+        "repeated": [ConduitFilter(repeat_filter)],
+        "twicerepeated": [ConduitFilter(repeat_filter)] * 2,
+        "repeated_s": [ConduitFilter(repeat_filter)],
+    }
+    yield communicator
+    communicator.shutdown()
+
+
+def mock_receive_messages(
+    mpp_client, data: dict[str, list[Union[IterationCount, Milestone]]]
+):
+    """Helper method to mock MPPClient.receive, so it gives data with correct message
+    numbers and iteration counts.
+
+    Args:
+        data: A list of IterationCount or Milestone for each port (component.port_name).
+            This will end up filling both the MPPMessage.iteration and MPPMessage.data
+            fields. MPPMessage.message_number is derived from the number of
+            non-Milestone messages sent so far.
+    """
+
+    def message_maker(data: list[Union[IterationCount, Milestone]]):
+        num = 0
+        for item in data:
+            iteration = item.iteration if isinstance(item, Milestone) else item
+            yield (
+                MPPMessage(
+                    Ref("snd"),
+                    Ref("rcv"),
+                    None,
+                    0.0,
+                    None,
+                    Settings(),
+                    num,
+                    item,
+                    iteration,
+                ).encoded(),
+                MagicMock(),
+            )
+            if not isinstance(item, Milestone):
+                num += 1
+
+    def side_effect(peer, _):
+        return next(iterators[peer])
+
+    iterators = {Ref(key): message_maker(value) for key, value in data.items()}
+    mpp_client.receive.side_effect = side_effect
+
+
+def test_repeater_filters(repeater_communicator, mpp_client, repeat_filter):
+    twicerepeated_messages = [[], Milestone([])]
+    repeated_messages = [[0], [1], [2], Milestone([])]
+    unfiltered_messages = [
+        [0, 0],
+        [0, 1],
+        Milestone([0]),
+        # parent is allowed to send 0 messages on its O_I port in an iteration
+        Milestone([1]),
+        [2, 0],
+        Milestone([2]),
+        Milestone([]),
+    ]
+    mock_receive_messages(
+        mpp_client,
+        {
+            "component.twicerepeated": twicerepeated_messages,
+            "component.repeated": repeated_messages,
+            "component.unfiltered": unfiltered_messages,
+            "component.repeated_s": unfiltered_messages,
+        },
+    )
+
+    is_padded = repeat_filter == "pad"
+
+    cache = repeater_communicator.pre_receive()
+    assert cache[("unfiltered", None)].data == [0, 0]
+    assert cache[("repeated", None)].data == [0]
+    assert cache[("twicerepeated", None)].data == []
+
+    cache = repeater_communicator.pre_receive()
+    assert cache[("unfiltered", None)].data == [0, 1]
+    assert cache[("repeated", None)].data == (None if is_padded else [0])
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [])
+
+    cache = repeater_communicator.pre_receive()
+    assert cache[("unfiltered", None)].data == [2, 0]
+    assert cache[("repeated", None)].data == [2]
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [])
+
+    with pytest.raises(PortClosed):
+        repeater_communicator.pre_receive()
+
+
+def test_repeater_filters_discard_messages(
+    repeater_communicator, mpp_client, repeat_filter
+):
+    twicerepeated_messages = [[0], [1], [2], Milestone([])]
+    repeated_messages = [
+        # Grandparent doesn't send on O_I in its first iteration:
+        Milestone([0]),
+        [1, 0],
+        [1, 1],
+        [1, 2],
+        Milestone([1]),
+        [2, 0],
+        [2, 1],
+        Milestone([2]),
+        Milestone([]),
+    ]
+    unfiltered_messages = [
+        Milestone([0]),
+        # parent doesn't send messages on O_I in the first couple of iterations
+        # component will need to discard the corresponding messages in repeated_messages
+        Milestone([1, 0]),
+        Milestone([1, 1]),
+        Milestone([1, 2]),
+        Milestone([1]),
+        [2, 0, 0],
+        Milestone([2, 0]),
+        [2, 1, 0],
+        [2, 1, 1],
+        Milestone([2, 1]),
+        Milestone([2]),
+        Milestone([]),
+    ]
+    mock_receive_messages(
+        mpp_client,
+        {
+            "component.twicerepeated": twicerepeated_messages,
+            "component.repeated": repeated_messages,
+            "component.unfiltered": unfiltered_messages,
+            "component.repeated_s": unfiltered_messages,
+        },
+    )
+
+    is_padded = repeat_filter == "pad"
+
+    cache = repeater_communicator.pre_receive()
+    assert cache[("unfiltered", None)].data == [2, 0, 0]
+    assert cache[("repeated", None)].data == [2, 0]
+    assert cache[("twicerepeated", None)].data == [2]
+    for i in range(3):
+        msg = repeater_communicator.receive_s_message("repeated_s")
+        assert msg.data == (None if i and is_padded else [2, 0, 0])
+
+    cache = repeater_communicator.pre_receive()
+    assert cache[("unfiltered", None)].data == [2, 1, 0]
+    assert cache[("repeated", None)].data == [2, 1]
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [2])
+
+    cache = repeater_communicator.pre_receive()
+    assert cache[("unfiltered", None)].data == [2, 1, 1]
+    assert cache[("repeated", None)].data == (None if is_padded else [2, 1])
+    assert cache[("twicerepeated", None)].data == (None if is_padded else [2])
+    for i in range(3):
+        msg = repeater_communicator.receive_s_message("repeated_s")
+        assert msg.data == (None if i and is_padded else [2, 1, 1])
+
+    with pytest.raises(PortClosed):
+        repeater_communicator.pre_receive()
+
+
+def test_repeater_filters_no_finit(mpp_client, repeat_filter):
+    # Prepare messages before communicator.set_peer_info is called:
+    mock_receive_messages(mpp_client, {"component.s_in": [[], Milestone([])]})
+
+    # Prepare a communicator with only a repeated S port and no F_INIT ports:
+    port_manager = PortManager([], None)
+    communicator = Communicator(
+        Ref("component"), [], port_manager, MagicMock(), MagicMock()
+    )
+    peer_info = PeerInfo(
+        Ref("component"),
+        [],
+        [Conduit("previous.out", "component.s_in", repeat_filter)],
+        {Ref("previous"): []},
+        {Ref("previous"): []},
+        [Port(Id("s_in"), Operator.S)],
+    )
+    port_manager.connect_ports(peer_info)
+    communicator.set_peer_info(peer_info)
+    assert communicator._repeat_filters == {
+        "s_in": [ConduitFilter(repeat_filter)],
+    }
+
+    assert communicator.pre_receive() == {}
+    # We can now receive on s_in as often as we'd like
+    for i in range(8):
+        msg = communicator.receive_s_message("s_in")
+        if i == 0 or repeat_filter == "repeat":
+            assert msg.data == []
+        else:
+            assert msg.data is None
+
+    # Cleanup
+    communicator.shutdown()

--- a/src/python/libmuscle/test/test_instance.py
+++ b/src/python/libmuscle/test/test_instance.py
@@ -63,7 +63,7 @@ def port_manager():
 def communicator():
     with patch("libmuscle.instance.Communicator") as Communicator:
         communicator = Communicator.return_value
-        communicator.pre_receive_f_init.return_value = {}
+        communicator.pre_receive.return_value = {}
         yield communicator
 
 
@@ -431,9 +431,7 @@ def test_reuse_set_overlay(
     mock_msg = MagicMock()
     mock_msg.data = Settings({"s1": 1, "s2": 2})
     mock_msg.settings = Settings({"s0": 0})
-    communicator.pre_receive_f_init.return_value = {
-        ("muscle_settings_in", None): mock_msg
-    }
+    communicator.pre_receive.return_value = {("muscle_settings_in", None): mock_msg}
 
     instance.reuse_instance()
     assert settings_manager.overlay["s0"] == 0
@@ -443,20 +441,20 @@ def test_reuse_set_overlay(
 
 def test_reuse_closed_port(instance, communicator):
     assert instance.reuse_instance() is True  # First iteration: should always reuse
-    communicator.pre_receive_f_init.side_effect = PortClosed()
+    communicator.pre_receive.side_effect = PortClosed()
     assert instance.reuse_instance() is False
 
 
 def test_reuse_no_closed_port(instance, communicator):
-    communicator.pre_receive_f_init.return_value = {("in", None): Message(1)}
+    communicator.pre_receive.return_value = {("in", None): Message(1)}
     for _ in range(20):
         assert instance.reuse_instance() is True
-    communicator.pre_receive_f_init.side_effect = PortClosed()
+    communicator.pre_receive.side_effect = PortClosed()
     assert instance.reuse_instance() is False
 
 
 def test_reuse_no_f_init_ports(instance, connected_port_manager, communicator):
-    connected_port_manager.has_f_init_connections.return_value = False
+    communicator.pre_receive.side_effect = [{}, PortClosed()]
 
     assert instance.reuse_instance() is True
     assert instance.reuse_instance() is False
@@ -466,7 +464,7 @@ def test_reuse_always_pre_receives(instance, connected_port_manager, communicato
     connected_port_manager.has_f_init_connections.return_value = False
 
     instance.reuse_instance()
-    communicator.pre_receive_f_init.assert_called_once()
+    communicator.pre_receive.assert_called_once()
 
 
 def test_send_message(instance, settings_manager, communicator):
@@ -525,7 +523,7 @@ def test_receive_slot_on_scalar_port(instance):
 def test_receive_f_init(instance, port_manager, communicator):
     mock_msg = MagicMock()
     mock_msg.data = Settings()
-    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}
+    communicator.pre_receive.return_value = {("in", None): mock_msg}
 
     instance.reuse_instance()
 
@@ -567,7 +565,7 @@ def test_receive_inconsistent_settings(
         ),
         ("in", None): MagicMock(settings=Settings({"s0": 0})),
     }
-    communicator.pre_receive_f_init.return_value = msgs
+    communicator.pre_receive.return_value = msgs
     port_manager.settings_in_connected.return_value = True
 
     with pytest.raises(RuntimeError):
@@ -580,7 +578,7 @@ def test_receive_with_settings(
 
     mock_msg = MagicMock()
     mock_msg.settings = Settings({"s0": 0, "s1": 1})
-    communicator.pre_receive_f_init.return_value = {("in", None): mock_msg}
+    communicator.pre_receive.return_value = {("in", None): mock_msg}
 
     instance_dont_apply_overlay.reuse_instance()
     msg = instance_dont_apply_overlay.receive("in")

--- a/src/python/libmuscle/test/test_timeline_manager.py
+++ b/src/python/libmuscle/test/test_timeline_manager.py
@@ -16,7 +16,7 @@ from libmuscle.timeline_manager import (
     ReuseLoopIncomplete,
     TimelineManager,
     get_most_nested_iteration,
-    is_subiteration,
+    is_subiteration_or_equal,
 )
 
 
@@ -108,12 +108,12 @@ def check_received(
 
 
 def test_is_subiteration():
-    assert is_subiteration([], [])
-    assert is_subiteration([1, 2], [1, 2])
-    assert is_subiteration([1, 2], [1])
-    assert is_subiteration([1, 2], [])
-    assert not is_subiteration([1, 2], [1, 2, 3])
-    assert not is_subiteration([1, 2], [1, 1])
+    assert is_subiteration_or_equal([], [])
+    assert is_subiteration_or_equal([1, 2], [1, 2])
+    assert is_subiteration_or_equal([1, 2], [1])
+    assert is_subiteration_or_equal([1, 2], [])
+    assert not is_subiteration_or_equal([1, 2], [1, 2, 3])
+    assert not is_subiteration_or_equal([1, 2], [1, 1])
 
 
 def test_get_most_nested_iteration():

--- a/src/python/libmuscle/test/test_timeline_manager.py
+++ b/src/python/libmuscle/test/test_timeline_manager.py
@@ -15,6 +15,8 @@ from libmuscle.timeline_manager import (
     PortBlocked,
     ReuseLoopIncomplete,
     TimelineManager,
+    get_most_nested_iteration,
+    is_subiteration,
 )
 
 
@@ -82,6 +84,7 @@ def vector_timeline_manager() -> TimelineManager:
 
     tm = TimelineManager(pm)
     assert tm.start_reuse_iteration() is None
+    assert tm.check_pre_received_iteration_counts([]) == []
     return tm
 
 
@@ -100,33 +103,25 @@ def check_received(
     slot: Optional[int],
     iteration: IterationCount,
 ) -> None:
-    timeline_manager.check_receive(port, slot)
-    timeline_manager.record_received_message(port, slot, iteration)
+    timeline_manager.check_receive_s(port, slot)
+    timeline_manager.record_received_s_message(port, slot, iteration)
 
 
-def test_finish_reuse_iteration_blocked_when_muscle_settings_in_not_received(
-    timeline_manager: TimelineManager,
-) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    timeline_manager.check_send_message("out_f")
-    # muscle_settings_in is never received this iteration
-
-    with pytest.raises(ReuseLoopIncomplete) as exc_info:
-        timeline_manager.start_reuse_iteration()
-
-    assert exc_info.value.expected == expected(
-        timeline_manager, ("receive", "muscle_settings_in", [])
-    )
+def test_is_subiteration():
+    assert is_subiteration([], [])
+    assert is_subiteration([1, 2], [1, 2])
+    assert is_subiteration([1, 2], [1])
+    assert is_subiteration([1, 2], [])
+    assert not is_subiteration([1, 2], [1, 2, 3])
+    assert not is_subiteration([1, 2], [1, 1])
 
 
-@pytest.mark.parametrize("include_settings", [False], indirect=True)
-def test_finish_reuse_iteration_ignores_muscle_settings_in_when_disconnected(
-    timeline_manager: TimelineManager,
-) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    timeline_manager.check_send_message("out_f")
-
-    timeline_manager.start_reuse_iteration()
+def test_get_most_nested_iteration():
+    assert get_most_nested_iteration([[1, 2, 3], [1], [1, 2, 3, 4]]) == [1, 2, 3, 4]
+    with pytest.raises(ValueError, match="empty list"):
+        get_most_nested_iteration([])
+    with pytest.raises(ValueError, match="not a subiteration"):
+        get_most_nested_iteration([[1], [2]])
 
 
 @pytest.mark.parametrize("has_f_init", [False], indirect=True)
@@ -134,6 +129,7 @@ def test_finish_reuse_iteration_ignores_muscle_settings_in_when_disconnected(
 def test_o_f_can_send_immediately_when_no_f_init_connections(
     timeline_manager: TimelineManager,
 ) -> None:
+    timeline_manager.check_pre_received_iteration_counts([])  # no F_INIT messages
     assert timeline_manager.check_send_message("out_f") == []
 
 
@@ -141,8 +137,7 @@ def test_check_send_message_o_f_blocked_when_subtimeline_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so the :A1 sub-timeline is incomplete
 
@@ -158,8 +153,7 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     # skipping the subtimelines is allowed
     timeline_manager.check_send_message("out_f")
 
@@ -174,8 +168,7 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
 def test_check_send_message_o_f_marks_participated_and_returns_iteration(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
 
     assert not timeline_manager._send.has_participated("out_f", None)
     iteration = timeline_manager.check_send_message("out_f")
@@ -187,8 +180,7 @@ def test_check_send_message_o_f_marks_participated_and_returns_iteration(
 def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
 
     iteration = timeline_manager.check_send_message("out_a1")
 
@@ -202,8 +194,7 @@ def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
 def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a1", None, [0])
     # "in_a1_2" never received, so S hasn't fully led :A1 yet
 
@@ -218,13 +209,12 @@ def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
 def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a1", None, [0])
 
-    timeline_manager.check_receive("in_a1_2")
+    timeline_manager.check_receive_s("in_a1_2")
     with pytest.raises(MessageOutOfSync) as exc_info:
-        timeline_manager.record_received_message("in_a1_2", None, [7])
+        timeline_manager.record_received_s_message("in_a1_2", None, [7])
     assert exc_info.value.port == timeline_manager._port_manager.get_port("in_a1_2")
     assert exc_info.value.slot is None
 
@@ -251,14 +241,13 @@ def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
 def test_check_send_message_o_i_when_o_i_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
 
     first_iteration = timeline_manager.check_send_message("out_a1")
-    timeline_manager.check_receive("in_a1")
-    timeline_manager.record_received_message("in_a1", None, first_iteration)
-    timeline_manager.check_receive("in_a1_2")
-    timeline_manager.record_received_message("in_a1_2", None, first_iteration)
+    timeline_manager.check_receive_s("in_a1")
+    timeline_manager.record_received_s_message("in_a1", None, first_iteration)
+    timeline_manager.check_receive_s("in_a1_2")
+    timeline_manager.record_received_s_message("in_a1_2", None, first_iteration)
 
     second_iteration = timeline_manager.check_send_message("out_a1")
 
@@ -273,8 +262,7 @@ def test_check_send_message_o_i_when_o_i_leads_and_complete(
 def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so the sub-iteration is incomplete
 
@@ -286,58 +274,33 @@ def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
     )
 
 
-def test_check_receive_f_init_allowed_when_not_yet_participated(
-    timeline_manager: TimelineManager,
-) -> None:
-    timeline_manager.check_receive("in_f")
-    assert not timeline_manager._receive.has_participated("in_f", None)
+def test_check_pre_receive_increments(timeline_manager: TimelineManager) -> None:
+    assert timeline_manager.check_pre_received_iteration_counts(
+        [[1, 2, 3], [1, 2], [1], [], [1, 2, 3], [1, 2]]
+    ) == [1, 2, 3]
 
-    timeline_manager.record_received_message("in_f", None, [3])
-    assert timeline_manager._iteration == [3]
-    assert timeline_manager._receive.has_participated("in_f", None)
+    with pytest.raises(RuntimeError, match="not newer"):
+        # Iteration count should increase
+        timeline_manager.check_pre_received_iteration_counts([[1, 2, 3]])
 
-    check_received(timeline_manager, "muscle_settings_in", None, [3])
-
-    assert timeline_manager._iteration == [3]
-    assert timeline_manager._receive.has_participated("muscle_settings_in", None)
+    assert timeline_manager.check_pre_received_iteration_counts(
+        [[1, 2, 4], [1, 2], [1], [], [1, 2, 4], [1, 2]]
+    ) == [1, 2, 4]
 
 
-def test_check_receive_f_init_raises_already_participated_when_received_twice(
-    timeline_manager: TimelineManager,
-) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-
-    with pytest.raises(AlreadyParticipated) as exc_info:
-        timeline_manager.check_receive("in_f")
-
-    assert exc_info.value.port == timeline_manager._port_manager.get_port("in_f")
-    assert exc_info.value.slot is None
-    assert exc_info.value.action == "receive"
-
-
-def test_record_received_message_f_init_raises_when_iteration_differs(
+def test_check_pre_receive_iterations_when_iteration_differs(
     timeline_manager: TimelineManager,
 ) -> None:
     """Once the main timeline has started, an F_INIT message for a different
     iteration is rejected."""
-    check_received(timeline_manager, "in_f", None, [3])
-    timeline_manager.check_receive("muscle_settings_in")
-
-    with pytest.raises(MessageOutOfSync) as exc_info:
-        timeline_manager.record_received_message("muscle_settings_in", None, [4])
-
-    assert exc_info.value.port == timeline_manager._port_manager.get_port(
-        "muscle_settings_in"
-    )
-    assert exc_info.value.slot is None
+    with pytest.raises(ValueError, match="not a subiteration"):
+        timeline_manager.check_pre_received_iteration_counts([[3], [4]])
 
 
 def test_check_receive_message_s_starts_subtimeline_with_s_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
-
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a2", None, [0])
 
     stm = timeline_manager._submanagers[Timeline(":A2")]
@@ -349,13 +312,12 @@ def test_check_receive_message_s_starts_subtimeline_with_s_leading(
 def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a2")
     # "out_a2_2" never sent, so O_I hasn't fully led :A2 yet
 
     with pytest.raises(PortBlocked) as exc_info:
-        timeline_manager.check_receive("in_a2")
+        timeline_manager.check_receive_s("in_a2")
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("send", "out_a2_2", [])
@@ -365,8 +327,7 @@ def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
 def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a2")
     timeline_manager.check_send_message("out_a2_2")
 
@@ -380,7 +341,7 @@ def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
     # A second receive on in_a2 cannot advance the sub-iteration itself: with O_I
     # leading, only a new O_I send is allowed to do that.
     with pytest.raises(PortBlocked) as exc_info:
-        timeline_manager.check_receive("in_a2")
+        timeline_manager.check_receive_s("in_a2")
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("send", "out_a2", []), ("send", "out_a2_2", [])
@@ -390,9 +351,7 @@ def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
 def test_check_receive_message_s_when_s_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
-
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a2", None, [1])
 
     stm = timeline_manager._submanagers[Timeline(":A2")]
@@ -401,9 +360,9 @@ def test_check_receive_message_s_when_s_leads_and_complete(
     timeline_manager.check_send_message("out_a2")
     timeline_manager.check_send_message("out_a2_2")
 
-    timeline_manager.check_receive("in_a2")
+    timeline_manager.check_receive_s("in_a2")
     with pytest.raises(MessageOutOfSync) as exc_info:
-        timeline_manager.record_received_message("in_a2", None, first_iteration)
+        timeline_manager.record_received_s_message("in_a2", None, first_iteration)
     assert exc_info.value.port == timeline_manager._port_manager.get_port("in_a2")
     assert exc_info.value.slot is None
 
@@ -420,13 +379,12 @@ def test_check_receive_message_s_when_s_leads_and_complete(
 def test_check_receive_message_s_blocked_when_s_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [])
-    check_received(timeline_manager, "muscle_settings_in", None, [])
+    timeline_manager.check_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a2", None, [1])
     # neither "out_a2" nor "out_a2_2" received, so the sub-iteration is incomplete
 
     with pytest.raises(PortBlocked) as exc_info:
-        timeline_manager.check_receive("in_a2")
+        timeline_manager.check_receive_s("in_a2")
 
     assert exc_info.value.expected == expected(
         timeline_manager, ("send", "out_a2", []), ("send", "out_a2_2", [])
@@ -438,8 +396,7 @@ def test_finish_reuse_iteration_resets_when_complete(
 ) -> None:
     # Drive one full reuse loop iteration, using :A1's sub-timeline, to
     # completion.
-    check_received(timeline_manager, "in_f", None, [3])
-    check_received(timeline_manager, "muscle_settings_in", None, [3])
+    timeline_manager.check_pre_received_iteration_counts([[3], [3]])
     timeline_manager.check_send_message("out_a1")
     check_received(timeline_manager, "in_a1", None, [3, 0])
     check_received(timeline_manager, "in_a1_2", None, [3, 0])
@@ -449,10 +406,13 @@ def test_finish_reuse_iteration_resets_when_complete(
 
     timeline_manager.start_reuse_iteration()
 
-    # A fresh, just-connected TimelineManager has never participated in
-    # anything, so comparing against its state confirms everything was reset.
-    fresh = TimelineManager(timeline_manager._port_manager)
-    assert timeline_manager.get_state() == fresh.get_state()
+    # Inspect timeline state to check that everything is reset:
+    state = timeline_manager.get_state()
+    assert state.send_participated == []
+    assert all(
+        not any(subtl_state.values())  # All values should be None or empty lists
+        for subtl_state in state.subtimeline_states.values()
+    )
 
 
 def test_finish_reuse_iteration_raises_when_incomplete(
@@ -460,8 +420,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 ) -> None:
     # Start a reuse loop iteration but leave it incomplete: :A1's
     # sub-timeline is started but never finishes, and O_F never sends.
-    check_received(timeline_manager, "in_f", None, [4])
-    check_received(timeline_manager, "muscle_settings_in", None, [4])
+    timeline_manager.check_pre_received_iteration_counts([[4], [4]])
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so :A1 is incomplete, and
     # "out_f" is never sent either
@@ -480,8 +439,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 def test_get_state_and_restore_state_round_trip(
     timeline_manager: TimelineManager,
 ) -> None:
-    check_received(timeline_manager, "in_f", None, [3])
-    check_received(timeline_manager, "muscle_settings_in", None, [3])
+    timeline_manager.check_pre_received_iteration_counts([[3], [3]])
     timeline_manager.check_send_message("out_a1")
     check_received(timeline_manager, "in_a1", None, [3, 0])
     # "in_a1_2" not yet received, so :A1 is incomplete, and "out_f" not yet sent

--- a/src/python/libmuscle/test/test_timeline_manager.py
+++ b/src/python/libmuscle/test/test_timeline_manager.py
@@ -84,7 +84,7 @@ def vector_timeline_manager() -> TimelineManager:
 
     tm = TimelineManager(pm)
     assert tm.start_reuse_iteration() is None
-    assert tm.check_pre_received_iteration_counts([]) == []
+    assert tm.record_pre_received_iteration_counts([]) == []
     return tm
 
 
@@ -129,7 +129,7 @@ def test_get_most_nested_iteration():
 def test_o_f_can_send_immediately_when_no_f_init_connections(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([])  # no F_INIT messages
+    timeline_manager.record_pre_received_iteration_counts([])  # no F_INIT messages
     assert timeline_manager.check_send_message("out_f") == []
 
 
@@ -137,7 +137,7 @@ def test_check_send_message_o_f_blocked_when_subtimeline_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so the :A1 sub-timeline is incomplete
 
@@ -153,7 +153,7 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
     timeline_manager: TimelineManager,
 ) -> None:
     # receive on the F_INIT ports
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     # skipping the subtimelines is allowed
     timeline_manager.check_send_message("out_f")
 
@@ -168,7 +168,7 @@ def test_check_send_message_o_f_raises_already_participated_when_sent_twice(
 def test_check_send_message_o_f_marks_participated_and_returns_iteration(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
 
     assert not timeline_manager._send.has_participated("out_f", None)
     iteration = timeline_manager.check_send_message("out_f")
@@ -180,7 +180,7 @@ def test_check_send_message_o_f_marks_participated_and_returns_iteration(
 def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
 
     iteration = timeline_manager.check_send_message("out_a1")
 
@@ -194,7 +194,7 @@ def test_check_send_message_o_i_starts_subtimeline_with_o_i_leading(
 def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a1", None, [0])
     # "in_a1_2" never received, so S hasn't fully led :A1 yet
 
@@ -209,7 +209,7 @@ def test_check_send_message_o_i_blocked_when_s_leads_and_not_all_s_received(
 def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a1", None, [0])
 
     timeline_manager.check_receive_s("in_a1_2")
@@ -241,7 +241,7 @@ def test_check_send_message_o_i_allowed_once_all_led_s_ports_received(
 def test_check_send_message_o_i_when_o_i_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
 
     first_iteration = timeline_manager.check_send_message("out_a1")
     timeline_manager.check_receive_s("in_a1")
@@ -262,7 +262,7 @@ def test_check_send_message_o_i_when_o_i_leads_and_complete(
 def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so the sub-iteration is incomplete
 
@@ -275,15 +275,15 @@ def test_check_send_message_o_i_blocked_when_o_i_leads_and_incomplete(
 
 
 def test_check_pre_receive_increments(timeline_manager: TimelineManager) -> None:
-    assert timeline_manager.check_pre_received_iteration_counts(
+    assert timeline_manager.record_pre_received_iteration_counts(
         [[1, 2, 3], [1, 2], [1], [], [1, 2, 3], [1, 2]]
     ) == [1, 2, 3]
 
     with pytest.raises(RuntimeError, match="not newer"):
         # Iteration count should increase
-        timeline_manager.check_pre_received_iteration_counts([[1, 2, 3]])
+        timeline_manager.record_pre_received_iteration_counts([[1, 2, 3]])
 
-    assert timeline_manager.check_pre_received_iteration_counts(
+    assert timeline_manager.record_pre_received_iteration_counts(
         [[1, 2, 4], [1, 2], [1], [], [1, 2, 4], [1, 2]]
     ) == [1, 2, 4]
 
@@ -294,13 +294,13 @@ def test_check_pre_receive_iterations_when_iteration_differs(
     """Once the main timeline has started, an F_INIT message for a different
     iteration is rejected."""
     with pytest.raises(ValueError, match="not a subiteration"):
-        timeline_manager.check_pre_received_iteration_counts([[3], [4]])
+        timeline_manager.record_pre_received_iteration_counts([[3], [4]])
 
 
 def test_check_receive_message_s_starts_subtimeline_with_s_leading(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a2", None, [0])
 
     stm = timeline_manager._submanagers[Timeline(":A2")]
@@ -312,7 +312,7 @@ def test_check_receive_message_s_starts_subtimeline_with_s_leading(
 def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a2")
     # "out_a2_2" never sent, so O_I hasn't fully led :A2 yet
 
@@ -327,7 +327,7 @@ def test_check_receive_message_s_blocked_when_o_i_leads_and_not_all_o_i_sent(
 def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     timeline_manager.check_send_message("out_a2")
     timeline_manager.check_send_message("out_a2_2")
 
@@ -351,7 +351,7 @@ def test_check_receive_message_s_allowed_once_all_led_o_i_ports_sent(
 def test_check_receive_message_s_when_s_leads_and_complete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a2", None, [1])
 
     stm = timeline_manager._submanagers[Timeline(":A2")]
@@ -379,7 +379,7 @@ def test_check_receive_message_s_when_s_leads_and_complete(
 def test_check_receive_message_s_blocked_when_s_leads_and_incomplete(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[], []])
+    timeline_manager.record_pre_received_iteration_counts([[], []])
     check_received(timeline_manager, "in_a2", None, [1])
     # neither "out_a2" nor "out_a2_2" received, so the sub-iteration is incomplete
 
@@ -396,7 +396,7 @@ def test_finish_reuse_iteration_resets_when_complete(
 ) -> None:
     # Drive one full reuse loop iteration, using :A1's sub-timeline, to
     # completion.
-    timeline_manager.check_pre_received_iteration_counts([[3], [3]])
+    timeline_manager.record_pre_received_iteration_counts([[3], [3]])
     timeline_manager.check_send_message("out_a1")
     check_received(timeline_manager, "in_a1", None, [3, 0])
     check_received(timeline_manager, "in_a1_2", None, [3, 0])
@@ -420,7 +420,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 ) -> None:
     # Start a reuse loop iteration but leave it incomplete: :A1's
     # sub-timeline is started but never finishes, and O_F never sends.
-    timeline_manager.check_pre_received_iteration_counts([[4], [4]])
+    timeline_manager.record_pre_received_iteration_counts([[4], [4]])
     timeline_manager.check_send_message("out_a1")
     # neither "in_a1" nor "in_a1_2" received, so :A1 is incomplete, and
     # "out_f" is never sent either
@@ -439,7 +439,7 @@ def test_finish_reuse_iteration_raises_when_incomplete(
 def test_get_state_and_restore_state_round_trip(
     timeline_manager: TimelineManager,
 ) -> None:
-    timeline_manager.check_pre_received_iteration_counts([[3], [3]])
+    timeline_manager.record_pre_received_iteration_counts([[3], [3]])
     timeline_manager.check_send_message("out_a1")
     check_received(timeline_manager, "in_a1", None, [3, 0])
     # "in_a1_2" not yet received, so :A1 is incomplete, and "out_f" not yet sent

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -13,6 +13,39 @@ IterationCount: TypeAlias = list[int]  # nested iteration counts of a message
 ExpectedActions: TypeAlias = list[tuple[str, Port, list[int]]]
 
 
+def is_subiteration(it1: IterationCount, it2: IterationCount) -> bool:
+    """Check if it1 is a subiteration of it2, or if both counts are equal.
+
+    Example:
+        `[1, 2, 3]` is a subiteration of `[1, 2]`, `[1]` and `[]`, but not of `[0]`.
+    """
+    return it1[: len(it2)] == it2
+
+
+def get_most_nested_iteration(iterations: list[IterationCount]) -> IterationCount:
+    """Return the most nested iteration in the list, i.e. the one with the most items.
+
+    Raises:
+        ValueError if iterations is an empty list or if the iterations are incompatible
+        with one another.
+
+    Example:
+        >>> get_most_nested_iteration([[1, 2, 3], [1], [1, 2, 3, 4]])
+        [1, 2, 3, 4]
+        >>> get_most_nested_iteration([[1], [2], [1, 2, 3, 4]])
+        ValueError("[1, 2, 3, 4] is not a subiteration of [2]")
+    """
+    if not iterations:
+        raise ValueError("iterations is an empty list")
+    iterations.sort()
+    for i in range(len(iterations) - 1):
+        if not is_subiteration(iterations[i + 1], iterations[i]):
+            raise ValueError(
+                f"{iterations[i + 1]} is not a subiteration of {iterations[i]}"
+            )
+    return iterations[-1]
+
+
 class SubTimelineState(TypedDict):
     """A single sub-timeline's state, as returned by
     SubTimelineManager.get_state() for saving in a snapshot."""
@@ -30,12 +63,11 @@ class TimelineState:
 
     Returned by TimelineManager.get_state() for saving in a snapshot, and
     passed back into TimelineManager.restore_state() to resume from one.
-    iteration is None if the main timeline has not started yet (or has been reset).
+    iteration is None if the main timeline has not started yet.
     """
 
     iteration: Optional[IterationCount]
     send_participated: list[PortAndSlot]
-    receive_participated: list[PortAndSlot]
     subtimeline_states: dict[str, SubTimelineState]
 
 
@@ -232,18 +264,13 @@ class TimelineManager:
             port_manager: The (already connected) port manager for this instance.
         """
         self._port_manager = port_manager
-
-        self._receive = TimelinePorts(port_manager.get_connected_ports(Operator.F_INIT))
         self._send = TimelinePorts(port_manager.get_connected_ports(Operator.O_F))
-
         subtimelines = port_manager.list_subtimelines()
         self._submanagers = {
             tl: SubTimelineManager(tl, self._port_manager) for tl in subtimelines
         }
-
-        # A component with no connected F_INIT ports has no F_INIT message to
-        # learn its iteration from, so its main timeline starts at [].
         self._iteration: Optional[IterationCount] = None
+        """Current component iteration count. Is None before the first reuse loop."""
 
     def check_send_message(
         self, port_name: str, slot: Optional[int] = None
@@ -271,6 +298,30 @@ class TimelineManager:
         return self._submanagers[port.timeline].check_send_message(
             port, slot, self._iteration
         )
+
+    def check_pre_received_iteration_counts(
+        self, iterations: list[IterationCount]
+    ) -> IterationCount:
+        """Check if the iteration counts of pre-received messages are consistent.
+
+        Returns:
+            The iteration count for the upcoming reuse loop.
+
+        Raises:
+            ValueError if the iteration counts are inconsistent.
+        """
+        if not iterations:
+            assert not self._port_manager.has_f_init_connections()
+            new_iteration = []
+        else:
+            new_iteration = get_most_nested_iteration(iterations)
+        if self._iteration is not None and new_iteration <= self._iteration:
+            raise RuntimeError(
+                f"Internal error: received F_INIT iteration count {new_iteration} "
+                f"is not newer than the previous iteration {self._iteration}."
+            )
+        self._iteration = new_iteration
+        return self._iteration
 
     def _check_send_o_f(self, port: Port, slot: Optional[int]) -> IterationCount:
         """Check the O_F-specific send conditions, update state, and return
@@ -305,62 +356,43 @@ class TimelineManager:
 
         return self._iteration
 
-    def check_receive(self, port_name: str, slot: Optional[int] = None) -> None:
-        """Check that receiving on the given port is currently allowed.
-
-        An F_INIT port may receive once after the reuse loop starts and before any other
-        ports are used.
-
-        Whether an S port may receive is delegated to the corresponding
-        SubTimelineManager.
+    def check_receive_s(self, port_name: str, slot: Optional[int] = None) -> None:
+        """Check that receiving on the given S port is currently allowed.
 
         Args:
-            port_name: Name of the F_INIT or S port about to receive.
+            port_name: Name of the S port about to receive.
             slot: The slot being received on, if this is a vector port.
         """
         port = self._port_manager.get_port(port_name)
+        assert port.operator is Operator.S
+        self._submanagers[port.timeline].check_receive(port, slot)
 
-        if port.operator is Operator.F_INIT:
-            if self._receive.has_participated(port_name, slot):
-                raise AlreadyParticipated(port, slot)
-        elif port.operator is Operator.S:
-            self._submanagers[port.timeline].check_receive(port, slot)
-
-    def record_received_message(
+    def record_received_s_message(
         self,
         port_name: str,
         slot: Optional[int],
         iteration: IterationCount,
-    ) -> None:
-        """Record that a message has been received on the given port.
+        num_repeat_filters: int = 0,
+    ) -> IterationCount:
+        """Record that a message has been received on the given S port.
 
-        check_receive already established that this receive is allowed.
-
-        For an F_INIT port, if the main timeline has not started yet, its
-        iteration is adopted from the message, otherwise the message must carry
-        the same iteration the main timeline is already on.
-
-        For an S port, recording the message is delegated directly to the
-        corresponding SubTimelineManager.
+        check_receive_s already established that this receive is allowed.
 
         Args:
-            port_name: Name of the F_INIT or S port a message was received
-                on.
-            slot: The slot the message was received on, if this is a vector
-                port.
+            port_name: Name of the S port a message was received on.
+            slot: The slot the message was received on, if this is a vector port.
             iteration: The iteration the received message was sent with.
+            num_repeat_filters: Number of repeat filters applied to this S port.
+
+        Returns:
+            New iteration count for the subtimeline of the S port.
         """
         port = self._port_manager.get_port(port_name)
-
-        if port.operator is Operator.F_INIT:
-            if self._iteration is None:
-                self._iteration = iteration
-            elif iteration != self._iteration:
-                raise MessageOutOfSync(port, slot)
-            self._receive.participate(port_name, slot)
-            return
-
-        self._submanagers[port.timeline].record_received_message(port, slot, iteration)
+        assert port.operator is Operator.S
+        assert self._iteration is not None
+        return self._submanagers[port.timeline].record_received_message(
+            port, slot, iteration, self._iteration, num_repeat_filters
+        )
 
     def reset(self) -> None:
         """Reset the main timeline and it's sub-timelines.
@@ -369,9 +401,7 @@ class TimelineManager:
         F_INIT ports to wait for) and participation state, and resets every sub-timeline
         in turn.
         """
-        self._iteration = None if self._port_manager.has_f_init_connections() else []
         self._send.reset()
-        self._receive.reset()
         for stm in self._submanagers.values():
             stm.reset()
 
@@ -388,14 +418,13 @@ class TimelineManager:
         """
         iteration = self._iteration
         if iteration is None or (
-            self._receive.all_participated()
-            and self._send.all_participated()
+            self._send.all_participated()
             and all(stm.is_complete() for stm in self._submanagers.values())
         ):
             self.reset()
             return iteration
 
-        expected = _expected_actions(self._send, self._receive)
+        expected = _expected_actions(self._send)
         for stm in self._submanagers.values():
             if not stm.is_complete():
                 expected += _expected_actions(stm._send, stm._receive)
@@ -410,7 +439,6 @@ class TimelineManager:
         return TimelineState(
             iteration=self._iteration,
             send_participated=sorted(self._send.participated),
-            receive_participated=sorted(self._receive.participated),
             subtimeline_states={
                 str(tl): stm.get_state() for tl, stm in self._submanagers.items()
             },
@@ -427,7 +455,6 @@ class TimelineManager:
         """
         self._iteration = state.iteration
         self._send.participated = {(p, s) for p, s in state.send_participated}
-        self._receive.participated = {(p, s) for p, s in state.receive_participated}
         for tl, stm in self._submanagers.items():
             sub_state = state.subtimeline_states.get(str(tl))
             if sub_state is not None:
@@ -551,8 +578,13 @@ class SubTimelineManager:
                 raise PortBlocked(port, slot, expected)
 
     def record_received_message(
-        self, port: Port, slot: Optional[int], iteration: IterationCount
-    ) -> None:
+        self,
+        port: Port,
+        slot: Optional[int],
+        iteration: IterationCount,
+        component_iteration: IterationCount,
+        num_repeat_filters: int,
+    ) -> IterationCount:
         """Record that a message has been received on the given S port.
 
         If this sub-timeline has not started yet, its iteration is adopted from the
@@ -570,6 +602,11 @@ class SubTimelineManager:
             port: The S port a message was received on.
             slot: The slot the message was received on, if this is a vector port.
             iteration: The iteration the received message was sent with.
+            component_iteration: The current iteration of the component.
+            num_repeat_filters: Number of repeater filters applied to this message.
+
+        Returns:
+            Current iteration count of the subtimeline.
 
         Raises:
             MessageOutOfSync: If this port and slot has not yet received for
@@ -582,19 +619,29 @@ class SubTimelineManager:
         port_name = str(port.name)
 
         if self._iteration is None:
+            if num_repeat_filters > 0:
+                # Handle cases with multiple levels of repeat filters, for example:
+                # - cached message iteration count: [2], with 2 repeat filters
+                # - component iteration count: [2, 1]
+                # Our iteration count needs to become [2, 1, 0]
+                iteration = component_iteration + [0]
             self._iteration = iteration
             self._first_operator = Operator.S
         elif not self._receive.has_participated(port_name, slot):
-            if iteration != self._iteration:
+            if num_repeat_filters == 0 and iteration != self._iteration:
                 raise MessageOutOfSync(port, slot)
         else:
-            if iteration <= self._iteration:
+            if num_repeat_filters:
+                self._iteration[-1] += 1
+            elif iteration <= self._iteration:
                 raise MessageOutOfSync(port, slot)
-            self._iteration = iteration
+            else:
+                self._iteration = iteration
             self._send.reset()
             self._receive.reset()
 
         self._receive.participate(port_name, slot)
+        return self._iteration
 
     def reset(self) -> None:
         """Reset this sub-timeline once the main timeline's reuse loop iteration

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -13,7 +13,7 @@ IterationCount: TypeAlias = list[int]  # nested iteration counts of a message
 ExpectedActions: TypeAlias = list[tuple[str, Port, list[int]]]
 
 
-def is_subiteration(it1: IterationCount, it2: IterationCount) -> bool:
+def is_subiteration_or_equal(it1: IterationCount, it2: IterationCount) -> bool:
     """Check if it1 is a subiteration of it2, or if both counts are equal.
 
     Example:
@@ -39,7 +39,7 @@ def get_most_nested_iteration(iterations: list[IterationCount]) -> IterationCoun
         raise ValueError("iterations is an empty list")
     iterations.sort()
     for i in range(len(iterations) - 1):
-        if not is_subiteration(iterations[i + 1], iterations[i]):
+        if not is_subiteration_or_equal(iterations[i + 1], iterations[i]):
             raise ValueError(
                 f"{iterations[i + 1]} is not a subiteration of {iterations[i]}"
             )

--- a/src/python/libmuscle/timeline_manager.py
+++ b/src/python/libmuscle/timeline_manager.py
@@ -299,7 +299,7 @@ class TimelineManager:
             port, slot, self._iteration
         )
 
-    def check_pre_received_iteration_counts(
+    def record_pre_received_iteration_counts(
         self, iterations: list[IterationCount]
     ) -> IterationCount:
         """Check if the iteration counts of pre-received messages are consistent.
@@ -582,7 +582,7 @@ class SubTimelineManager:
         port: Port,
         slot: Optional[int],
         iteration: IterationCount,
-        component_iteration: IterationCount,
+        instance_iteration: IterationCount,
         num_repeat_filters: int,
     ) -> IterationCount:
         """Record that a message has been received on the given S port.
@@ -602,7 +602,7 @@ class SubTimelineManager:
             port: The S port a message was received on.
             slot: The slot the message was received on, if this is a vector port.
             iteration: The iteration the received message was sent with.
-            component_iteration: The current iteration of the component.
+            instance_iteration: The current iteration of the component.
             num_repeat_filters: Number of repeater filters applied to this message.
 
         Returns:
@@ -624,7 +624,7 @@ class SubTimelineManager:
                 # - cached message iteration count: [2], with 2 repeat filters
                 # - component iteration count: [2, 1]
                 # Our iteration count needs to become [2, 1, 0]
-                iteration = component_iteration + [0]
+                iteration = instance_iteration + [0]
             self._iteration = iteration
             self._first_operator = Operator.S
         elif not self._receive.has_participated(port_name, slot):


### PR DESCRIPTION
Replaces #402 

This PR implements repeat/pad filters for F_INIT and S ports.

**Brief overview of changes:**
- Update communicator:
  - In addition to F_INIT messages, we also pre-receive S messages with repeat/pad filters applied.
  - All pre-received MPPMessages are stored in a new `message_cache`.
  - The message cache is saved and restored with the checkpointing mechanism.
- Update timeline manager
  - The timeline manager no longer verifies F_INIT receives. Communicator.pre_receive takes care of that now and calls TimelineManager.check_f_init_iteration_counts to verify the iteration counts on the messages (and update the current iteration of the component).
  - Additional logic to handle iteration counts for repeated S messages.
- Additional tests
  - Unit tests for the communicator are in a new file `test_communicator_conduit_filters.py`/`.cpp`: these tests use fewer mocked components (only MPPClient, MMPClient and Profiler) and test how the Communicator responds to mocked message streams.
  - Integration tests (`integration_test/test_filter.py`) for conduit filters, checking pad/repeat and testing the checkpointing mechanism.